### PR TITLE
Disambiguate the inquiry if needed. Enhance the messaging between agents

### DIFF
--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -14,4 +14,5 @@
     # Eventually we might have a dictionary value with server specifications for each.
     "hello_world.hocon": true,
     "smart_home.hocon": true,
+    "smart_home_onf.hocon": true,
 }

--- a/registries/smart_home_onf.hocon
+++ b/registries/smart_home_onf.hocon
@@ -1,0 +1,132 @@
+{
+    "llm_config": {
+        "model_name": "gpt-4o",
+        "verbose": true
+    },
+    "commondefs": {
+        "replacement_strings": {
+            "instructions_prefix": """
+You are part of a smart home network of assistants.
+Only answer inquiries that are directly within your area of expertise.
+Do not try to help for other matters.
+Do not mention what you can NOT do. Only mention what you can do.
+            """,
+            "aaosa_instructions": """
+When you receive an inquiry, you will:
+1. If you are clearly not the right agent for this type of inquiry, reply you're not relevant.
+2. If there is a chance you're relevant, call your down-chain agents to determine if they can answer all or part of the inquiry.
+   Do not assume what the down-chain agents can do. Always call them. You'll be surprised.
+3. Deterime which down-chain agents have the strongest claims to the inquiry. If the inquiry is ambiguous, ask for clarification.
+4. Call the relevant down-chain agents and:
+   - ask them for follow-up information if needed,
+   - or ask them to fulfill their part of the inquiry.
+5. Once all relevant down-chain agents have responded, compile their responses and return the final response.
+You may, in turn, be called by other agents in the system and have to act as a down-chain agent to them.
+            """
+        },
+        "replacement_values": {
+            "aaosa_call": {
+                "description": "Depending on the mode, returns a natural language string in response.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "inquiry": {
+                            "type": "string",
+                            "description": "The inquiry"
+                        },
+                        "mode": {
+                            "type": "string",
+                            "description": """
+'Determine' to ask the agent if the inquiry belongs to it, in its entirety or in part.
+'Fulfill' to ask the agent to fulfill the inquiry, if it can.
+'Follow up' to ask the agent to respond to a follow up.
+                            """
+                        },
+                    },
+                    "required": [
+                        "inquiry",
+                        "mode"
+                    ]
+                }
+            },
+            "aaosa_command": """
+If mode is 'Determine', return a json block with the following fields:
+{
+    "Name": <your name>,
+    "Inquiry": <the inquiry>,
+    "Mode": <Determine | Fulfill>,
+    "Relevant": <Yes | No>
+    "Strength": <number between 1 and 10 representing how certain you are in your claim>,
+    "Claim:" <All | Partial>,
+    "Requirements" <None | list of requirements>
+}
+If mode is 'Fulfill' or "Follow up", respond to the inquiry and return a json block with the following fields:
+{
+    "Name": <your name>,
+    "Inquiry": <the inquiry>,
+    "Mode": Fulfill,
+    "Response" <your response>
+}
+            """
+        },
+    }
+    "tools": [
+        {
+            "name": "SmartHouseAssistant",
+
+            # Note that there are no parameters defined for this guy's "function" key.
+            # This is the primary way to identify this tool as a front-man,
+            # distinguishing it from the rest of the tools.
+
+            "function": {
+
+                # When there are no function parameters to the front-man,
+                # its description acts as an initial prompt. 
+
+                "description": """
+An assistant that answer inquiries from the user.
+                """
+            },
+            "instructions": """
+{instructions_prefix}
+Your name is SmartHouseAssistant. Answer inquiries related to the smart home.
+{aaosa_instructions}
+            """,
+            "tools": ["TV", "Lights", "Book"]
+        },
+        {
+            "name": "TV",
+            "function": "aaosa_call",
+            "instructions": """
+{instructions_prefix}
+Your name is TV.
+You can turn the TV on and off.
+{aaosa_instructions}
+            """,
+            "command": "aaosa_command",
+            "tools": []
+        },
+        {
+            "name": "Lights",
+            "function": "aaosa_call",
+            "instructions": """
+{instructions_prefix}
+Your name is Lights.
+You can turn the lights on and off.
+{aaosa_instructions}
+            """,
+            "command": "aaosa_command"
+        },
+        {
+            "name": "Book",
+            "function": "aaosa_call",
+            "instructions": """
+{instructions_prefix}
+Your name is Book.
+You can't do anything. You're a book.
+{aaosa_instructions}
+            """,
+            "command": "aaosa_command"
+        },
+    ]
+}


### PR DESCRIPTION
Another set of AAOSA instructions to disambiguate user queries and improve communication between the agents.
Created a `smart_home_onf` hocon to distinguish it from `smart_home` and compare.
I'll play with it a bit more