### PR TITLE
Make nsflow optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ python -m run --demo-mode
 ### Option 3: Using `nsflow` as a developer-oriented web client
 If you want to use neuro-san with a FastAPI-based developer-oriented client, follow these steps:
 
+- Install nsflow. Make sure to replace `x.x.x` with the actual version you want to install.
+```bash
+pip install wheels_private/nsflow-x.x.x-py3-none-any.whl
+```
+
 - Start the Backend & Frontend, from project root
 ```bash
 python -m nsflow.run

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -20,7 +20,7 @@
 #
 
 export SERVICE_TAG=${SERVICE_TAG:-neuro-san-demos}
-export SERVICE_VERSION=${SERVICE_VERSION:-0.0.6}
+export SERVICE_VERSION=${SERVICE_VERSION:-0.0.7}
 
 function check_directory() {
     working_dir=$(pwd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ wheels_private/leaf_common-1.2.20-py3-none-any.whl
 wheels_private/leaf_server_common-0.1.17-py3-none-any.whl
 wheels_private/neuro_san-0.5.10-py3-none-any.whl
 wheels_private/neuro_san_web_client-0.1.4-py3-none-any.whl
-wheels_private/nsflow-0.5.5-py3-none-any.whl
 
 # For the airline_policy demo, to extract text from documents
 pypdf2>=3.0.1


### PR DESCRIPTION
Make nsflow optional
Especially because deploy/build.sh is used for the server side only, not for the client side.