### PR TITLE
Update agent network designer prompt.

### DIFF
--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -62,7 +62,7 @@ relevant workflows and responsible nodes. Call your network_generator tool for t
                     "properties": {
                         "agent_network_name": {
                             "type": "string",
-                            "description": "name of project, business or company or other description."
+                            "description": "name of project, business or company or other description, write it in snake case, e.g. foo_bar."
                         },
                     },
                     "required": ["agent_network_name"]


### PR DESCRIPTION
Update agent network designer prompt.

Prior to this change, hocon filenames were generated with PascalCase.  This change generates them with snake_case, which is essential for new networks to show up in the Multi-Agent Accelerator UI.