### PR TITLE
Add action to build and push docker image

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,97 @@
+# This action script will take a merge to main and build
+# the neuro-san-studio docker image and push it to our ECR.
+# It will then update the manifest file with the new tag
+# which then will get picked up by our Argo CD system and 
+# deploy it to the dev environment.
+# In the case of a github Release event, the similar flow
+# occurs, but in this case, the staging environment is updated.
+# This script does not automatically push anything to production;
+# that case is handled manually.
+# Note, this script only updates the neuro-san-studio image, while
+# the deploy also uses a custom ui image; that process is still 
+# manual as the custom ui build is a manual process and not 
+# run frequently.
+
+name: Build and Push Docker Image to ECR and promote to manifest repo
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]  # Triggers when a GitHub Release is published
+  workflow_dispatch:  # Allow manual runs if needed
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.set-vars.outputs.image_tag }}
+      target_environment: ${{ steps.set-vars.outputs.target_environment }}
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Set up variables
+        id: set-vars
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "image_tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            echo "target_environment=staging" >> $GITHUB_OUTPUT
+          else
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+            echo "image_tag=${SHORT_SHA}" >> $GITHUB_OUTPUT
+            echo "target_environment=dev" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./deploy/Dockerfile
+          push: true
+          tags: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ steps.set-vars.outputs.image_tag }}
+
+  promote-to-manifest:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  ## to allow committing changes
+    steps:
+      - name: Checkout manifest repo
+        uses: actions/checkout@v4
+        with:
+          repository: cognizant-ai-labs/manifest
+          token: ${{ secrets.READ_WRITE_PAT_FOR_DEPLOYMENT }}
+          ref: main 
+
+      - name: Update image tag in values.yaml
+        run: |
+          echo "image_tag is ${{ needs.build-and-push.outputs.image_tag }}"
+          echo "target_enviroment is ${{ needs.build-and-push.outputs.target_environment }}"
+
+          python neuro-san/utility_scripts/deploy_to_cluster.py \
+          --file-path "neuro-san/values-${{ needs.build-and-push.outputs.target_environment }}.yaml" \
+          --neuro-san-studio-tag "${{ needs.build-and-push.outputs.image_tag }}"
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add "neuro-san/values-${{ needs.build-and-push.outputs.target_environment }}.yaml"
+          git commit -m "Update image tag to ${{ github.sha }}"
+          git push


### PR DESCRIPTION


This PR brings our common workflow from neuro-ai to the neuro-san-demos repo. Specifically, that is:

A merge to main will trigger a docker image build and that image is pushed to our ECR. Then that image is deployed to the dev environment.

Similarly, a github Release of neuro-san-demos will trigger an image build and then deploy that image to the staging environment.

The production deployment case is still handled manually.

Also note, this PR updates the deployed version of the neuro-san-demos image, it does not update the deployed ui version. The ui version is from a custom ui build that is still handled manually.
