### PR TITLE
Correct typo in new org name

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout manifest repo
         uses: actions/checkout@v4
         with:
-          repository: cognizant-ai-labs/manifest
+          repository: cognizant-ai-lab/manifest
           token: ${{ secrets.READ_WRITE_PAT_FOR_DEPLOYMENT }}
           ref: main 
 


### PR DESCRIPTION
This PR fixes a sure-to-be-common typo cognizant-ai-labs instead of the correct cognizant-ai-lab.