### PR TITLE
Add toolbox section in user_guide

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -391,7 +391,7 @@ To use tools from toolbox in your agent network, simply call them with field `to
             }
         ```
 
-        For more example please see [https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox_info.hocon](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox_info.hocon)
+        For more examples, please see [https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox_info.hocon](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox_info.hocon)
 
 3. Point to the config file by setting the environment variable `AGENT_TOOLBOX_INFO_FILE` to your custom config:
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -342,7 +342,7 @@ To use tools from toolbox in your agent network, simply call them with field `to
         - Additional dependencies (outside of `langchain_community`) must be installed separately.
         
         Example:
-        ```json
+        ```hocon
             "bing_search": {
                 # Fully qualified class path of the tool to be instantiated.
                 "class": "langchain_community.tools.bing_search.BingSearchResults",
@@ -405,7 +405,7 @@ To use tools from toolbox in your agent network, simply call them with field `to
 
 - Tools' arguments can be overidden in the agent network config file using the `args` key.
 Example:
-```json
+```hocon
 {
     "name": "web_searcher",
     "toolbox": "bing_search",


### PR DESCRIPTION
- Add toolbox section in user_guide with the following topics:
  - Default tools in toolbox
  - Usage in agent network config
  - Adding tools in toolbox

- Add a topic about using `args` keys in `Advanced` section