### PR TITLE
Fix links to toolbox_info.hocon in neuro-san repo

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -624,7 +624,7 @@ To use any tool from the Toolbox, simply reference it in the toolbox field of yo
 
 #### Toolbox Configuration
 Toolbox tools are defined in a centralized configuration file.
-This [file](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox_info.hocon) includes definitions for both LangChain tools and shared coded tools. If the tool is defined in the toolbox config, you don’t need to redefine it in the agent network — just reference it by name.
+This [file](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox/toolbox_info.hocon) includes definitions for both LangChain tools and shared coded tools. If the tool is defined in the toolbox config, you don’t need to redefine it in the agent network — just reference it by name.
 
 **LangChain Example**
 ```json

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -394,7 +394,7 @@ To use tools from toolbox in your agent network, simply call them with field `to
             }
         ```
 
-        For more examples, please see [https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox_info.hocon](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox_info.hocon)
+        For more examples, please see [https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox/toolbox_info.hocon](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/toolbox/toolbox_info.hocon)
 
 3. Point to the config file by setting the environment variable `AGENT_TOOLBOX_INFO_FILE` to your custom config:
 


### PR DESCRIPTION
This file moved in a recent refactoring.