### PR TITLE
Do not run slack notifications for forked-PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,6 @@ jobs:
           source venv/bin/activate 
           make test
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           AGENT_TOOL_PATH: "./neuro_san/coded_tools"
           PYTHONPATH: ${{ env.PYTHONPATH }}:"."
 


### PR DESCRIPTION
As we discovered yesterday with Kaivan's PR, secrets are not available in github Actions for forked PRs. The Slack Notification steps in the tests.yaml rely on a secret and thus were failing, causing his PR to be blocked. This PR adds a check for the fork case and skips the slack notifications in this case.

I'll likely end up adding this logic to other repos in due time.