### PR TITLE
Update key in agentic rag from basetool to toolbox

### DIFF
--- a/registries/agentic_rag.hocon
+++ b/registries/agentic_rag.hocon
@@ -38,7 +38,7 @@
         # LangChain search tool using Bing; no need to define "function" since "args_schema" is pre-defined.
         {
             "name": "website_search",
-            "base_tool": "bing_search"
+            "toolbox": "bing_search"
             "args": {
                 "num_results": 3
             }


### PR DESCRIPTION
To use tool from toolbox, the key is changed from `basetool` to `toolbox`.