### PR TITLE
UN-3200 Streamable HTTP in MCP

### DIFF
--- a/coded_tools/mcp_bmi_sse/bmi_calculator.py
+++ b/coded_tools/mcp_bmi_sse/bmi_calculator.py
@@ -59,20 +59,24 @@ class BmiCalculator(CodedTool):
         # and a server can also have multiple tools.
         # Note that mcp server can contain tools, resources, and prompts
         # but langchain-mcp-adapter only works with **tools**.
-        async with MultiServerMCPClient(
+        client = MultiServerMCPClient(
             {
                 # This key only used as a reference here and may be different
                 # from the actual name in mcp server.
                 "bmi": {
-                    # sse is prefered over stdio as transport method.
-                    # make sure the port here matches the one in  your server.
-                    "url": "http://localhost:8000/sse",
-                    "transport": "sse",
+                    # streamable_http is prefered over stdio as transport method.
+                    # make sure the port here matches the one in your server.
+                    "url": "http://localhost:8000/mcp/",
+                    "transport": "streamable_http",
                 }
             }
-        ) as client:
-            # `get_tools` method returns a list of StructuredTool ordered by
-            # server and tool's order in the server, respectively.
-            # Note that to `invoke` or `ainvoke` for StructureTool require
-            # dictionary input.
-            return await client.get_tools()[0].ainvoke({"weight": weight, "height": height})
+        )
+
+        # `get_tools` method returns a list of StructuredTool ordered by
+        # server and tool's order in the server, respectively.
+        # In this example, there is only one server and one tool in the server.
+        tools = await client.get_tools()
+
+        # Note that to `invoke` or `ainvoke` for StructureTool require
+        # dictionary input.
+        return await tools[0].ainvoke({"weight": weight, "height": height})

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ python-dotenv==1.0.1
 aiofiles>=24.1.0
 
 # For MCP servers and clients
-langchain-mcp-adapters>=0.0.9
+langchain-mcp-adapters>=0.1.7

--- a/servers/mcp/bmi_server.py
+++ b/servers/mcp/bmi_server.py
@@ -16,5 +16,5 @@ def calculate_bmi(weight: float, height: float) -> float:
 
 
 if __name__ == "__main__":
-    # sse is prefered over stdio as transport method.
-    mcp.run(transport="sse")
+    # streamable http is prefered over stdio as transport method.
+    mcp.run(transport="streamable-http")


### PR DESCRIPTION
### Changes
- Modify both mcp server (`bmi_server.py`) and mcp client in the coded tool (`bmi_calculator.py`) to use streamable http
- Change the agent network name from `mcp_bmi_sse` to `mcp_bmi_streamable_http`
- Update `langchain-mcp-adapters` in `requirements.txt` to the latest version

### Test
- `mcp_bmi_streamable_http`