### PR TITLE
Reorganize manifest.hocon and add smaller manifest_deploy.hocon

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Neuro SAN enables multiple large language model (LLM)-powered agents to collabor
 ---
 
 ### Use Cases:
-A number of examples that can be built using Neuro SAN:
+Here are a few examples of use-cases that have been implemented with Neuro SAN.
+For more examples, check out [docs/examples.md](docs/examples.md).
 <table>
   <thead>
     <tr>
@@ -105,16 +106,6 @@ A number of examples that can be built using Neuro SAN:
       <td>Handles customer inquiries, inventory management, and supports sales processes to optimize operations and service quality.</td>
     </tr>
     <tr>
-      <td>🧠 <strong>Six Thinking Hats</strong></td>
-      <td>Structured decision-making and brainstorming.</td>
-      <td>Emulates Edward de Bono's methodology, assigning distinct perspectives (logical, emotional, creative) to specialized agents.</td>
-    </tr>
-    <tr>
-      <td>🏠 <strong>Smart Home Management</strong></td>
-      <td>Home automation and device control.</td>
-      <td>Coordinates smart home devices, allowing users to control lighting, temperature, and security via natural language.</td>
-    </tr>
-    <tr>
       <td>📞 <strong>Telco Network Support</strong></td>
       <td>Technical support and network issue resolution.</td>
       <td>Diagnoses network problems, guides troubleshooting, and escalates complex issues, reducing downtime and enhancing customer service.</td>
@@ -124,61 +115,10 @@ A number of examples that can be built using Neuro SAN:
       <td>Generates treatment plan for a given therapy vignette.</td>
       <td>A good example of using multiple different expert agents working together to come up with a single plan.</td>
     </tr>
-    <tr>
-      <td>📝 <strong>Kwik Memory Agent</strong></td>
-      <td>Enhanced memory retention and retrieval.</td>
-      <td>Improves agent capability in storing and recalling information, enhancing long-term contextual awareness.</td>
-    </tr>
-    <tr>
-      <td>📄 <strong>PDF_RAG Agent</strong></td>
-      <td>Retrieval-Augmented Generation from PDF documents.</td>
-      <td>Processes and extracts accurate information from PDF files for analysis and summarization tasks.</td>
-    </tr>
-    <tr>
-      <td>🚀 <strong>Agentforce Agent</strong></td>
-      <td>Integration with Salesforce's AgentForce for enterprise workflows.</td>
-      <td>Allows Neuro-SAN agents to interact with Salesforce AgentForce, automating customer relationship management processes.</td>
-    </tr>
-    <tr>
-      <td>🔌 <strong>Agentspace Adapter</strong></td>
-      <td>Connecting agents across different platforms.</td>
-      <td>Acts as a communication bridge between Neuro-SAN and other agent ecosystems, enhancing interoperability.</td>
-    </tr>
-    <tr>
-      <td>🤝 <strong>CrewAI Agent</strong></td>
-      <td>Integration with CrewAI for collaborative tasks.</td>
-      <td>Enables seamless coordination between Neuro-SAN agents and CrewAI, facilitating cross-framework collaboration.</td>
-    </tr>
-    <tr>
-      <td>🧰 <strong>MCP Agent</strong></td>
-      <td>Utilization of Model Context Protocol for tool integration.</td>
-      <td>Integrates external tools and services into agent workflows, expanding capabilities using the Model Context Protocol.</td>
-    </tr>
-    <tr>
-      <td>🔄 <strong>A2A based Agent</strong></td>
-      <td>Agent-to-Agent communication via Google A2A protocol.</td>
-      <td>Enables efficient, decentralized agent communication and task delegation using the A2A protocol.</td>
-    </tr>
-    <tr>
-      <td>🔍 <strong>Log Analyzer</strong></td>
-      <td>An example agent network that is run against agent network logs via the log_analyzer app.</td>
-      <td>This is an example of how to run agents to validate and analyze other agents via their interaction logs.</td>
-    </tr>
-    <tr>
-      <td>🌐 <strong>CRUSE Agent</strong></td>
-      <td>An example agent network that can attach to any agent network and make its interface context-reactive via the cruse flask app.</td>
-      <td>This is an example of how to dynamically call different agents and how to build a context reactive user experience (CRUSE).</td>
-    </tr>
-    <tr>
-      <td>💭 <strong>Conscious Agent</strong></td>
-      <td>An example agent network that is run continuously via the conscious_assistant flask app.</td>
-      <td>This is an example of how to run agents continuously, initiating them from code, and how to make tool calls to non-default packages.</td>
-    </tr>
-    <tr>
-      <td colspan="3"><strong>And Many More...</strong></td>
-    </tr>
   </tbody>
 </table>
+
+And many more: check out [docs/examples.md](docs/examples.md).
 
 ---
 
@@ -266,7 +206,7 @@ You can get your OpenAI API key from <https://platform.openai.com/signup>. After
 
   - On PowerShell:
 
-    ```bash
+    ```powershell
     $env:OPENAI_API_KEY="XXX"
     ```
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -114,7 +114,7 @@ ENV PYTHONPATH=${APP_SOURCE}
 
 # Where to find the tool registry manifest file which lists all the agent hocon
 # files to serve up from this server instance.
-ENV AGENT_MANIFEST_FILE=${APP_SOURCE}/registries/manifest.hocon
+ENV AGENT_MANIFEST_FILE=${APP_SOURCE}/registries/manifest_deploy.hocon
 
 # An llm_info hocon file with user-provided llm descriptions that are to be used
 # in addition to the neuro-san defaults.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -29,6 +29,7 @@ Here are a few examples ordered by level of complexity.
   * [🧪 Experimental and Research](#-experimental-and-research)
     * [Agent Network Designer](#agent-network-designer)
     * [KWIK Agents](#kwik-agents)
+    * [CRUSE](#cruse)
     * [Conscious Assistant](#conscious-assistant)
     * [Log Analyzer](#log-analyzer)
 <!-- TOC -->

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
 # All Rights Reserved.
 # Issued under the Academic Public License.
@@ -12,64 +11,36 @@
 {
     # Currently we list each hocon file we want to serve as a key with a boolean value.
     # Eventually we might have a dictionary value with server specifications for each.
-    "hello_world.hocon": true,
-    "insurance_underwriting_agents.hocon": true,
-    "airline_policy.hocon": true,
-    "advanced_calculator.hocon": true,
-    "brave_search.hocon": false,
-    "smart_home.hocon": true,
-    "agent_network_designer.hocon": true,
-    "consumer_decision_assistant.hocon": true,
-    "airbnb.hocon": true,
-    "expedia.hocon": true,
-    "macys.hocon": true,
-    "carmax.hocon": true,
-    "booking.hocon": true,
-    "website_search.hocon": true,
+
+    # Basic examples
     "music_nerd.hocon": true,
     "music_nerd_local.hocon": true,
     "music_nerd_pro.hocon": true,
     "music_nerd_pro_local.hocon": true,
     "music_nerd_pro_sly.hocon": true,
     "music_nerd_pro_sly_local.hocon": true,
+    "hello_world.hocon": true,
+    "advanced_calculator.hocon": false,
+    "smart_home.hocon": true,
+
+    # Tool integration examples
+    "brave_search.hocon": false,
     "agentforce.hocon": true,
     "agentspace_adapter.hocon": false,
-    "banking_ops.hocon": true,
-    "cpg_agents.hocon": true,
-    "insurance_agents.hocon": true,
-    "intranet_agents.hocon": true,
-    "intranet_agents_with_tools.hocon": true,
-    "real_estate.hocon": false,
-    "retail_ops_and_customer_service.hocon": true,
-    "six_thinking_hats.hocon": true,
-    "telco_network_support.hocon": true,
     "pdf_rag.hocon": true,
-    "agentic_rag.hocon": true,
-    "kwik_agents.hocon": true,
-    "therapy_vignette_supervisors.hocon": true,
-
-    # Set the following agent network to true before running apps/cruse/interface_flask.py
-    "cruse_agent.hocon": false,
-
-    # Set the following agent network to true before running apps/conscious_assistant/interface_flask.py
-    "conscious_agent.hocon": false,
-
-    # Set the following agent network to true before running apps/log_analyzer/log_analyzer.py
-    "log_analysis_agents.hocon": false,
-
+    "agentic_rag.hocon": false,
+    "kwik_agents.hocon": false,
     # Before turning on and running the following agent network, make sure that:
     # The MCP server is running.
     # The server can be found at servers/MCP/bmi_server.py and run using the following command
     # python bmi_server.py
     "mcp_bmi_streamable_http.hocon": false,
-
     # The following agent network is an example of Agent2Agent (A2A) Protocol implementation:
     # Make sure to start the A2A server before turning the agent on.
     # The A2Aserver can be found at cservers/A2A/server.py and run by command
     # python server.py
     "a2a_research_report.hocon": false,
-
-    # To use this agent network, you will need to 
+    # To use this agent network, you will need to
     # - pip install -U langchain-google-community\[gmail\]
     # - set up your credentials explained in
     # https://developers.google.com/workspace/gmail/api/quickstart/python#authorize_credentials_for_a_desktop_application.
@@ -77,6 +48,35 @@
     # you can start using the agent network.
     "gmail.hocon": false,
 
+    # Use cases
+    "airline_policy.hocon": true,
+    "banking_ops.hocon": true,
+    "cpg_agents.hocon": true,
+    "insurance_agents.hocon": false,  # This is a deprecated version of insurance_underwriting_agents.hocon
+    "insurance_underwriting_agents.hocon": true,
+    "intranet_agents.hocon": false,  # This is a deprecated version of intranet_agents_with_tools.hocon
+    "intranet_agents_with_tools.hocon": true,
+    "real_estate.hocon": false,
+    "retail_ops_and_customer_service.hocon": true,
+    "telco_network_support.hocon": true,
+    "therapy_vignette_supervisors.hocon": true,
+    "consumer_decision_assistant.hocon": true,
+    # The following agent networks are used as sub-networkds by consumer_decision_assistant.hocon
+    "airbnb.hocon": true,
+    "booking.hocon": true,
+    "carmax.hocon": true,
+    "expedia.hocon": true,
+    "macys.hocon": true,
     "LinkedInJobSeekerSupportNetwork.hocon": true
+    "website_search.hocon": true,
 
+    # Experimental and research
+    "agent_network_designer.hocon": true,
+    "six_thinking_hats.hocon": true,
+    # Set the following agent network to true before running apps/cruse/interface_flask.py
+    "cruse_agent.hocon": false,
+    # Set the following agent network to true before running apps/conscious_assistant/interface_flask.py
+    "conscious_agent.hocon": false,
+    # Set the following agent network to true before running apps/log_analyzer/log_analyzer.py
+    "log_analysis_agents.hocon": false,
 }

--- a/registries/manifest_deploy.hocon
+++ b/registries/manifest_deploy.hocon
@@ -1,0 +1,33 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+{
+    # Currently we list each hocon file we want to serve as a key with a boolean value.
+    # Eventually we might have a dictionary value with server specifications for each.
+
+    # Industry-specific agent networks
+    "airline_policy.hocon": true,
+    "banking_ops.hocon": true,
+    "cpg_agents.hocon": true,
+    "insurance_underwriting_agents.hocon": true,
+    "intranet_agents_with_tools.hocon": true,
+    "retail_ops_and_customer_service.hocon": true,
+    "telco_network_support.hocon": true,
+    "therapy_vignette_supervisors.hocon": true,
+    "consumer_decision_assistant.hocon": true,
+    # The following agent networks are used as sub-networkds by consumer_decision_assistant.hocon
+    "airbnb.hocon": true,
+    "expedia.hocon": true,
+    "macys.hocon": true,
+    "carmax.hocon": true,
+    "booking.hocon": true,
+    "website_search.hocon": true,
+    "LinkedInJobSeekerSupportNetwork.hocon": true
+}


### PR DESCRIPTION
- Categorized .hocon files in `manifest.hocon`
- Created a smaller manifest_deploy.hocon for actual use cases
- Reduced the number of examples in README.md to make it a little more accessible
- Update the table of content of examples.md