### PR TITLE
Fix bug for email sending tool for agent_network_architect

### DIFF
--- a/coded_tools/agent_network_architect/send_gmail_hocon_html.py
+++ b/coded_tools/agent_network_architect/send_gmail_hocon_html.py
@@ -75,7 +75,7 @@ class SendGmailHoconHtml(CodedTool):
         # The attachments should be a HOCON file and a HTML file.
         valid_attachment_paths = [path for path in attachment_paths if os.path.isfile(path)]
 
-        # If they are both not valid, use sly_data instead.
+        # Since 2 valid files are expected, if they are not both valid, use sly_data instead.
         if len(valid_attachment_paths) < 2:
             # Extract "agent_name" from sly_data and use it to create file paths.
             agent_name: str = sly_data.get("agent_name")

--- a/coded_tools/agent_network_architect/send_gmail_hocon_html.py
+++ b/coded_tools/agent_network_architect/send_gmail_hocon_html.py
@@ -71,11 +71,12 @@ class SendGmailHoconHtml(CodedTool):
         if not to:
             return "Error: No receiver provided."
 
-        # Check if the path is valid
+        # Check if the path is valid.
+        # The attachments should be a HOCON file and a HTML file.
         valid_attachment_paths = [path for path in attachment_paths if os.path.isfile(path)]
 
-        # If there is no valid path
-        if not valid_attachment_paths:
+        # If they are both not valid, use sly_data instead.
+        if len(valid_attachment_paths) < 2:
             # Extract "agent_name" from sly_data and use it to create file paths.
             agent_name: str = sly_data.get("agent_name")
             if not agent_name:


### PR DESCRIPTION
# Fix fallback logic when only one attachment is valid
Previously, the fallback to sly_data was only triggered if both attachment paths were invalid. This caused issues in cases where only one of the two required files (HOCON or HTML) was present — the fallback logic was skipped even though the attachments were incomplete.

This change updates the condition to ensure the fallback is triggered whenever there are no valid attachments at all.