### PR TITLE
remove class and use_model_name in llm_config

### DIFF
--- a/registries/conscious_agent.hocon
+++ b/registries/conscious_agent.hocon
@@ -11,8 +11,7 @@
 # END COPYRIGHT
 {
     "llm_config": {
-        "class": "openai",
-        "use_model_name": "gpt-4.1-2025-04-14",
+        "model_name": "gpt-4.1-2025-04-14",
     },
     "max_iterations": 40000,
     "max_execution_seconds": 6000,

--- a/registries/kwik_agents.hocon
+++ b/registries/kwik_agents.hocon
@@ -11,8 +11,7 @@
 # END COPYRIGHT
 {
     "llm_config": {
-        "class": "openai",
-        "use_model_name": "gpt-4.1-2025-04-14",
+        "model_name": "gpt-4.1-2025-04-14",
     },
     "max_iterations": 40000,
     "max_execution_seconds": 6000,


### PR DESCRIPTION
- `gpt-4.1-2025-04-14` or `gpt-4.1` is currently in the default llm info file and can be used by "model_name"
- `use_model_name` is not a valid key for llm_config. Only use it in llm info file for aliasing. For example
"gpt-4.1": {
    "use_model_name": "gpt-4.1-2025-04-14"
}
This will points to `gpt-4.1-2025-04-14` when "model_name" in `llm_config` is `gpt-4.1`.
- For models and providers extension in agent network
    - Default provider, new model:
        ```hocon
         "llm_config": {
                "class": "openai",
                "model_name": "gpt-4.1-mini",
                # Arguments for the model
        }
        ```
    - New provider:
    ```hocon
         "llm_config": {
                "class": "langchain_groq.chat_models.ChatGroq",
                # Arguments for the chat model constructor
                # Most of them have "model_name" as a parameter but some may use "model" or "model_id"
                # Please refer to langchain chat model
        }
        ```