### PR TITLE
Provide workflow to nightly sync public repo to private

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,33 @@
+name: Nightly Sync from Public Repo
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Every night at 03:00 UTC
+  workflow_dispatch:     # Allow manual runs
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout private repo (sandbox)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Git identity
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Add upstream public repo
+        run: |
+          git remote add upstream https://github.com/cognizant-ai-lab/neuro-san-studio.git
+          git fetch upstream
+
+      - name: Merge upstream changes
+        run: |
+          git merge upstream/main --allow-unrelated-histories -m "🔄 Nightly sync from public neuro-san-studio"
+          git push origin main
+


### PR DESCRIPTION
This workflow will sync the public neuro-san-studio to to the private neuro-san-studio-sandbox nightly. The intent here is to allow WIP or IP sensitive work to proceed in a private space before it bubbles back up to the public repo. 