### PR TITLE
Turn off build-push job in synced clones

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -24,6 +24,8 @@ on:
 
 jobs:
   build-and-push:
+    # don't run this job in sync'd clones
+    if: github.repository == 'cognizant-ai-lab/neuro-san-studio'
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.set-vars.outputs.image_tag }}


### PR DESCRIPTION
We have our build-push job here which runs on merge to get the latest bits where they need to go. But we don't want to push stuff from our synced-private-sandbox version of this repo. So this little change causes the workflow to run only in this original public repo.