### PR TITLE
Upgrade to neuro-san 0.5.49 for compatibility with python 3.13

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Versions (please complete the following information):**
  - OS: [e.g. Windows, macOS, Unix...]
- - Python version: [e.g. 3.12.9]
+ - Python version: [e.g. 3.13.5]
  - Repo version: [e.g. 0.1.5]
  - or neuro-san version [e.g. 0.5.18]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' && github.base_ref == 'main')
     container:
-      image: python:3.12-slim
+      image: python:3.13-slim
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Go to dir:
 cd neuro-san-studio
 ```
 
-Ensure you have a supported version of python (3.12 at this time):
+Ensure you have a supported version of python (e.g. 3.12 or 3.13):
 
 ```bash
 python --version

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,7 +17,7 @@
 # how you want, search for "ENV AGENT_" in this file.
 
 # Stage 1: Set python image as base image
-FROM python:3.12-slim AS builder
+FROM python:3.13-slim AS builder
 
 # Set the shell and options per hadolint recommendations
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -47,7 +47,7 @@ RUN if [ -f ${APP_SOURCE}/requirements.txt ]; \
 WORKDIR /
 
 # Stage 2: Final Stage - Use a slim Python image
-FROM python:3.12-slim AS final
+FROM python:3.13-slim AS final
 
 # Set the shell and options in each FROM section per hadolint recommendations
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -102,7 +102,7 @@ WORKDIR ${APP_SOURCE}
 
 # RUN echo "$(pip show neuro-san | grep Location | awk '{print $2}')"
 # This value below comes from the above RUN command. Cannot set ENV vars in Dockerfiles based on shell output.
-ENV PACKAGE_INSTALL=/usr/local/lib/python3.12/site-packages
+ENV PACKAGE_INSTALL=/usr/local/lib/python3.13/site-packages
 ENV APP_ENTRYPOINT=${APP_SOURCE}/deploy/entrypoint.sh
 
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Neuro SAN
-neuro-san==0.5.42
+neuro-san==0.5.49
 neuro-san-web-client==0.1.12
 nsflow==0.5.16
 


### PR DESCRIPTION
In order to support python 3.13:
- updated neuro-san to the latest version, that removes the requirement for an old protobuf dependency
- updated the Docker images to use python 3.13
- update the doc where needed