### PR TITLE
change duckduckgo_search to ddgs

### DIFF
--- a/coded_tools/website_search/website_search.py
+++ b/coded_tools/website_search/website_search.py
@@ -3,7 +3,7 @@ from typing import Any
 from typing import Dict
 from typing import Union
 
-from duckduckgo_search import DDGS
+from ddgs import DDGS
 from neuro_san.interfaces.coded_tool import CodedTool
 
 


### PR DESCRIPTION
The library name was changed from `duckduckgo_search` to `ddgs`.