### PR TITLE
Update to neuro-san==0.5.51

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Neuro SAN
-neuro-san==0.5.50
+neuro-san==0.5.51
 neuro-san-web-client==0.1.12
 nsflow==0.5.16
 


### PR DESCRIPTION
This will get the AGENT_TOOL_RESULT messages flowing back into the stream with essential caller/callee origin information that disappeared with neuro-san==0.5.48