### PR TITLE
Fix registries/openai_web_search.hocon

### DIFF
--- a/registries/openai_web_search.hocon
+++ b/registries/openai_web_search.hocon
@@ -23,6 +23,7 @@
     "llm_config": {
         "model_name": "gpt-4o",
     },
+    "tools": [
         # This first agent definition is regarded as the "Front Man", which
         # does all the talking to the outside world/client.
         #


### PR DESCRIPTION
Server couldn't start because of a broken `registries/openai_web_search.hocon`. Was a copy paste issue from prior PR.