### PR TITLE
Provide build/deploy trigger as first step in separating deploy from repo

### DIFF
--- a/dispatch-to-deploy.yml
+++ b/dispatch-to-deploy.yml
@@ -58,5 +58,8 @@ jobs:
           repository: cognizant-ai-lab/neuro-san-deploy
           event-type: neurosan_build
           client-payload: |
-            {"ref":"${{ steps.r.outputs.ref }}","image_tag":""}
+            {"ref":"${{ steps.r.outputs.ref }}",
+             "image_tag":"",
+             "source_repo":"${{ github.repository }}",
+             "sender":"${{ github.actor }}"}
 

--- a/dispatch-to-deploy.yml
+++ b/dispatch-to-deploy.yml
@@ -1,0 +1,62 @@
+# .github/workflows/dispatch-to-deploy.yml (in neuro-san-studio)
+name: Dispatch to deploy repo
+
+on:
+  push:
+    branches: [ main ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Override ref to send to neuro-san-deploy (branch/tag/SHA)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read  # enough for this workflow
+
+jobs:
+  dispatch:
+    # only run from the canonical repo (not forks)
+    if: ${{ !github.event.repository.fork && github.repository == 'cognizant-ai-lab/neuro-san-studio' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve ref to send
+        id: r
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ github.event_name }}" in
+            release) REF="${{ github.event.release.tag_name }}" ;;
+            push)    REF="${{ github.ref_name }}" ;;
+            workflow_dispatch)
+                     REF="${{ inputs.ref || github.ref_name }}" ;;
+            *)       echo "Unsupported event"; exit 1 ;;
+          esac
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Will dispatch ref=$REF"
+
+      # 👇 This is where you "reference" the GitHub App
+      # Store these in neuro-san-studio settings:
+      #  - vars.DEPLOY_APP_ID                (the App ID)
+      #  - secrets.DEPLOY_APP_PRIVATE_KEY    (the App's .pem content)
+      - name: Create installation token (for neuro-san-deploy)
+        id: app
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.DEPLOY_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: cognizant-ai-lab
+          repositories: neuro-san-deploy   # repo where the App is installed
+
+      - name: Dispatch to neuro-san-deploy
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app.outputs.token }}
+          repository: cognizant-ai-lab/neuro-san-deploy
+          event-type: neurosan_build
+          client-payload: |
+            {"ref":"${{ steps.r.outputs.ref }}","image_tag":""}
+


### PR DESCRIPTION
As a first step in separating our deployment concerns from neuro-san-studio, this PR adds a new workflow which will trigger our build/deployments that live in a separate repo. I'd like to get this into main which will allow me to test the flow in a parallel state with our current flow. Once the new flow is working, I can remove the Dockerfile and the .github/workflows/build-push.yml from this repo.

The new file matches our current workflow trigger whereby we build a new container at merge to main and at github release events. Both the trigger here and the receiving neuro-san-deploy repo act only upon the canonical repo and _not_ forked repos.