### PR TITLE
Coffee Finder Advanced: fix for duplicate orders of the same item

### DIFF
--- a/registries/coffee_finder_advanced.hocon
+++ b/registries/coffee_finder_advanced.hocon
@@ -32,6 +32,7 @@ Always return order IDs and details when placing orders.
 Do not worry about the location.
 Call ALL your downstream agents to see if they can help with the inquiry before answering.
 Be as succinct as possible in your response, while explaining the reasoning process if needed.
+Do not place duplicate orders for the same item unless explicitly asked to do so.
 Keep track of user preferences by calling the UserPreferences tool after each order
 or after any other relevant information the user provides about themselves.
 Retrieve user preferences by calling your UserPreferences tool.


### PR DESCRIPTION
A single line fix works better for now.

Context:
When a users asks question like this, the agent places multiple orders, which is not expected.

> **Human:**  
>  
> My name is John Arthur  
> Get me the best coffee this evening
> 
> 
> **AI:**  
>  
> Your order for the best coffee has been successfully placed at:  
>  
> 1. **Bob's Coffee Shop** – Order ID: 101, Order Details: best coffee  
> 2. **Joe's Gas Station** – Order ID: 301, Order Details: best coffee  
>  
> *Henry's Fast Food* can also fulfill your order—if you'd like to proceed with them or have specific preferences, please let me know!
