### PR TITLE
Send git sha as well as ref, for immutability in downstream deployment workflows

### DIFF
--- a/.github/workflows/dispatch-to-deploy.yml
+++ b/.github/workflows/dispatch-to-deploy.yml
@@ -74,6 +74,7 @@ jobs:
           client-payload: |
             {
               "ref":"${{ steps.r.outputs.ref }}",
+              "sha":"${{ github.sha }}",
               "image_tag":"",
               "source_repo":"${{ github.repository }}",
               "sender":"${{ github.actor }}",


### PR DESCRIPTION
As part of separating neuro-san deployment from this repo, this PR adds the current git sha to the information that's passed into the downstream github workflows. This ensures we have immutable results, as using just the ref does not necessarily ensure a singular point in the tree. 