### PR TITLE
Upgrade to neuro-san==0.5.60

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Neuro SAN
-neuro-san==0.5.56
+neuro-san==0.5.60
 neuro-san-web-client==0.1.12
 nsflow==0.5.20
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ aiofiles>=24.1.0
 
 # For MCP servers and clients
 langchain-mcp-adapters>=0.1.7
+
+# Neuro-SAN now requires explicit installation of langchain LLM providers' libs
+langchain-anthropic>=0.3.11,<0.4


### PR DESCRIPTION
Upgrading to neuro-san==0.5.60 to get:
* @Noravee 's new token accounting 
* Start of intra-agent JSON <-> refactoring (more will come later)
* metadata in Connectivity() responses
* large message line ingestion for clients
* logging fidelity fixes
* lazy LLM provider imports

W/rt the last one we also need to pull in langchain-anthropic here so that pylint is happy.
See question below about how much we really want to import here.