### PR TITLE
UN-3528: Update a2a example

### DIFF
--- a/coded_tools/a2a_research_report/a2a_research_report.py
+++ b/coded_tools/a2a_research_report/a2a_research_report.py
@@ -75,7 +75,7 @@ class A2aResearchReport(CodedTool):
 
         if not topic:
             return "Error: No topic provided."
-        
+
         logger.info("Writing report on %s", topic)
 
         # It could take a long time before remote agents response.
@@ -95,8 +95,7 @@ class A2aResearchReport(CodedTool):
                 return "Failed to the agent card. Cannot continue."
 
             # Create client
-            config = ClientConfig(httpx_client=httpx_client)
-            factory = ClientFactory(config=config)
+            factory = ClientFactory(config=ClientConfig(httpx_client=httpx_client))
             client: Client = factory.create(agent_card)
             logger.info("A2A Client initialized.")
 
@@ -112,9 +111,8 @@ class A2aResearchReport(CodedTool):
                 responses.append(response)
 
             # Last response is typically the final message
-            final_response: Message = responses[-1]
             # Convert to a dictionary
-            result: dict[str, Any] = final_response.model_dump(mode='json', exclude_none=True)
+            result: dict[str, Any] = responses[-1].model_dump(mode='json', exclude_none=True)
             logger.info("Got the following response: %s", str(result))
 
             # Extract text from the response

--- a/docs/examples/a2a_research_report.md
+++ b/docs/examples/a2a_research_report.md
@@ -16,10 +16,7 @@ of this agent network is to show how one can connect to A2A server using coded t
 
 - This agent is **disabled by default**. To test it:
     - Manually enable it in the `manifest.hocon` file.
-    - As A2A is not published to pypi yet
-        - Clone the repo from [https://github.com/google/a2a-python/tree/main](https://github.com/google/a2a-python/tree/main)
-        - `pip install .`
-    - Install `crewai`
+    - `pip install a2a-sdk crewai`
     - Run the A2A server:
 
     ```bash

--- a/registries/a2a_research_report.hocon
+++ b/registries/a2a_research_report.hocon
@@ -12,11 +12,11 @@
 
 # ***Important Notes***
 # This is an example of Agent2Agent (A2A) Protocol implementation in neuro-san
-# Before running this agent network
-# - cloning the repo from https://github.com/google/a2a-python/tree/main
-# - pip install .
-# - run A2A server and make sure that its port matches with that of the client in
-# coded tool/a2a_research_report/a2a_research_report
+# Before running this agent network, ensure the following:
+# - Install dependencies: pip install a2a-sdk crewai
+# - Start the A2A server: python server.py
+# - Make sure the server port matches the client configuration in coded_tool/a2a_research_report/a2a_research_report.
+# - The server code is located at: servers/a2a/server.py
 
 
 {

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -93,8 +93,8 @@
     "mcp_bmi_streamable_http.hocon": false,
 
     # The following agent network is an example of Agent2Agent (A2A) Protocol implementation:
-    # Make sure to start the A2A server before turning the agent on.
-    # The A2Aserver can be found at cservers/A2A/server.py and run by command
+    # Make sure to pip install a2a-sdk crewai and start the server by python server.py before turning the agent on.
+    # The A2Aserver can be found at servers/A2A/server.py and run by command
     # python server.py
     "a2a_research_report.hocon": false,
 

--- a/servers/a2a/README.md
+++ b/servers/a2a/README.md
@@ -1,0 +1,70 @@
+# CrewAI A2A Research Report Agent
+
+A research report generation system using CrewAI agents integrated with the A2A (Agent-to-Agent) protocol. This project demonstrates how to connect agents from another framework with Neuro-SAN using A2A protocal.
+
+## Overview
+
+This system consists of:
+- **A2A Server**: Hosts CrewAI agents that perform research and generate reports
+- **A2A Client**: Coded tool that connects to the server to request research reports
+- **CrewAI Agents**: Two specialized agents working together - a researcher and a reporting analyst
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[A2A Client <br> Coded Tool] --- B[A2A Server]
+    B --- C[CrewAI Agents]
+    subgraph C[CrewAI Agents]
+    Researcher --- Analyst
+    end
+```
+
+## Installation
+
+### Dependencies
+
+```bash
+pip install a2a-sdk crewai
+```
+
+## Usage
+
+### 1. Start the A2A Server
+
+```bash
+python server.py --host localhost --port 9999
+```
+
+The server will:
+- Initialize CrewAI agents (researcher and reporting analyst)
+- Set up A2A protocol endpoints
+- Listen for research requests
+
+### 2. Turn on the agent network
+
+- Go to registries/manifest.hocon
+- Find `a2a_research_report.hocn` and change its value to `true`
+
+### 3. Run Nsflow
+
+nsflow is a developer-oriented web client. From the root of the repo, run the command:
+
+```bash
+python -m run
+```
+
+and select `a2a_research_report`
+
+## Disclaimer
+
+This code is provided as a sample and is **not production-ready**.  
+It is intended solely for demonstration purposes, showing how to connect to another framework using the Agent-to-Agent (A2A) protocol.  
+
+For more details, please refer to the official documentation and references.
+
+## References
+
+- [A2A Protocol Specification](https://google.github.io/A2A/specification)
+- [CrewAI Documentation](https://docs.crewai.com/)
+- [A2A Python SDK](https://github.com/google/a2a-python)

--- a/servers/a2a/agent_executor.py
+++ b/servers/a2a/agent_executor.py
@@ -28,7 +28,7 @@ from agent import CrewAiResearchReport
 
 class CrewAiAgentExecutor(AgentExecutor):
     """Agent executor for crewAI agents
-    
+
     adapted from https://github.com/a2aproject/a2a-samples/blob/main/samples/python/agents/helloworld/agent_executor.py
     """
 

--- a/servers/a2a/agent_executor.py
+++ b/servers/a2a/agent_executor.py
@@ -15,56 +15,44 @@ See https://github.com/google/a2a-python/tree/main/examples
 #
 # END COPYRIGHT
 
-from typing import Any
-from uuid import uuid4
 from typing_extensions import override
 
 # pylint: disable=import-error
-from a2a.server.agent_execution import BaseAgentExecutor
+from a2a.server.agent_execution import AgentExecutor
+from a2a.server.agent_execution import RequestContext
 from a2a.server.events import EventQueue
-from a2a.types import Message
-from a2a.types import MessageSendParams
-from a2a.types import Part
-from a2a.types import Role
-from a2a.types import SendMessageRequest
-from a2a.types import Task
-from a2a.types import TextPart
+from a2a.utils import new_agent_text_message
 
 from agent import CrewAiResearchReport
 
 
-class CrewAiAgentExecutor(BaseAgentExecutor):
-    """Agent executor for crewAI agents"""
+class CrewAiAgentExecutor(AgentExecutor):
+    """Agent executor for crewAI agents
+    
+    adapted from https://github.com/a2aproject/a2a-samples/blob/main/samples/python/agents/helloworld/agent_executor.py
+    """
 
     def __init__(self):
         self.agent = CrewAiResearchReport()
 
     @override
-    async def on_message_send(
-        self,
-        request: SendMessageRequest,
-        event_queue: EventQueue,
-        task: Task | None,
-    ) -> None:
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        """
+        Handles incoming requests that expect a response or a stream of events.
+        It processes the user's input (available via context) and uses the event_queue to send back Message
+        """
+        # Get query from the context
+        query: str = context.get_user_input()
+        if not context.message:
+            raise ValueError("No message provided")
 
-        # Get topic from the request message
-        params: MessageSendParams = request.params
-        topic: str = self._get_user_query(params)
+        # Invoke the underlying agent
+        result = await self.agent.ainvoke(query)
+        await event_queue.enqueue_event(new_agent_text_message(result))
 
-        # invoke the underlying agent
-        agent_response: dict[str, Any] = await self.agent.ainvoke(topic)
-
-        # return response message
-        message: Message = Message(
-            role=Role.agent,
-            parts=[Part(TextPart(text=agent_response))],
-            messageId=str(uuid4()),
-        )
-        event_queue.enqueue_event(message)
-
-    def _get_user_query(self, task_send_params: MessageSendParams) -> str:
-        """Helper to get user query from task send params."""
-        part = task_send_params.message.parts[0].root
-        if not isinstance(part, TextPart):
-            raise ValueError('Only text parts are supported')
-        return part.text
+    @override
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        """
+        Handles requests to cancel an ongoing task. Cancellation is not supported for this example.
+        """
+        raise NotImplementedError

--- a/servers/a2a/server.py
+++ b/servers/a2a/server.py
@@ -5,8 +5,7 @@ See https://github.com/google/a2a-python/tree/main/examples
 and https://google.github.io/A2A/specification
 
 Before running this server
- - cloning the repo from https://github.com/google/a2a-python/tree/main then `pip install .`
- - install crewai
+ - `pip install a2a-sdk crewai`
  - run server by `python server.py`
 """
 
@@ -23,10 +22,11 @@ Before running this server
 
 # pylint: disable=import-error
 import click
+import uvicorn
 
-from a2a.server import A2AServer
-from a2a.server.request_handlers import DefaultA2ARequestHandler
-from a2a.types import AgentAuthentication
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
 from a2a.types import AgentCapabilities
 from a2a.types import AgentCard
 from a2a.types import AgentSkill
@@ -65,15 +65,12 @@ def main(host: str, port: int):
         defaultOutputModes=['text'],
         capabilities=AgentCapabilities(),
         skills=[skill],
-        authentication=AgentAuthentication(schemes=['public']),
     )
 
-    request_handler = DefaultA2ARequestHandler(
-        agent_executor=CrewAiAgentExecutor()
-    )
+    request_handler = DefaultRequestHandler(agent_executor=CrewAiAgentExecutor(), task_store=InMemoryTaskStore())
 
-    server = A2AServer(agent_card=agent_card, request_handler=request_handler)
-    server.start(host=host, port=port)
+    server = A2AStarletteApplication(agent_card=agent_card, http_handler=request_handler)
+    uvicorn.run(server.build(), host=host, port=port)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The A2A protocol is still under development. Since this example was created, the **A2A Python SDK** has changed, and the current code will not run correctly with the latest version of A2A.  

To address this:  
- Update both the **A2A client** and **A2A server** so the example can run successfully.  
- Revise the setup instructions, as A2A is now available on PyPI (previously it was not).  
- Add a README file in the `servers/a2a` folder with usage and configuration details.  
