### PR TITLE
Add a .gitattributes file for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Added a .gitattributes file for consistent line endings between Unix-like file systems and Windows.