### PR TITLE
Correct PDF RAG errors and add feature enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ cython_debug/
 # Google credentials
 credentials.json
 token.json
+
+# pdf_rag demo
+vector_store.json

--- a/coded_tools/base_rag.py
+++ b/coded_tools/base_rag.py
@@ -74,9 +74,9 @@ class BaseRag(ABC):
         self.abs_vector_store_path: Optional[str] = None
         self.embeddings: Embeddings = OpenAIEmbeddings(model=EMBEDDINGS_MODEL, dimensions=VECTOR_SIZE)
 
-        logger.info(f"BaseRag - save_vector_store: {self.save_vector_store}")
-        logger.info(f"BaseRag - recreate_vector_store_on_start: {self.recreate_vector_store_on_start}")
-        logger.info(f"BaseRag - abs_vector_store_path: {self.abs_vector_store_path}")
+        logger.info("BaseRag - save_vector_store: %s", self.save_vector_store)
+        logger.info("BaseRag - recreate_vector_store_on_start: %s", self.recreate_vector_store_on_start)
+        logger.info("BaseRag - abs_vector_store_path: %s", self.abs_vector_store_path)
 
     @abstractmethod
     async def load_documents(self, loader_args: Any) -> List[Document]:
@@ -147,13 +147,15 @@ class BaseRag(ABC):
             if existing_store and self.recreate_vector_store_on_start:
                 # Delete the existing vector in-memory store (a JSON file)
                 try:
-                    logger.info(f"Deleting in-memory vector store at: '{self.abs_vector_store_path}")
+                    logger.info("Deleting in-memory vector store at: %s", self.abs_vector_store_path)
                     os.remove(self.abs_vector_store_path)
                 except PermissionError:
-                    logger.error(f"Permission denied: Cannot delete in-memory vector store at: '{self.abs_vector_store_path}")
+                    logger.error(
+                        "Permission denied: Cannot delete in-memory vector store at: %s", self.abs_vector_store_path
+                    )
                     logger.error("You may experience unexpected behaviour with the vector store.")
             else:
-                logger.info(f"Using existing in-memory vector store at: '{self.abs_vector_store_path}")
+                logger.info("Using existing in-memory vector store at: %s", self.abs_vector_store_path)
                 return existing_store
 
         # Load and process documents

--- a/coded_tools/pdf_rag.py
+++ b/coded_tools/pdf_rag.py
@@ -78,6 +78,9 @@ class PdfRag(CodedTool, BaseRag):
         # Save the generated vector store as a JSON file if True
         self.save_vector_store = args.get("save_vector_store", False)
 
+        # Re-create the generated vector store on start-up. Only valid for in-memory vector store if True
+        self.recreate_vector_store_on_start = args.get("recreate_vector_store_on_start", False)
+
         # Configure the vector store path
         self.configure_vector_store_path(args.get("vector_store_path"))
 

--- a/registries/pdf_rag.hocon
+++ b/registries/pdf_rag.hocon
@@ -52,6 +52,7 @@
 
                 # List of PDF URLs to use for Retrieval-Augmented Generation (RAG)
                 "urls": [
+                    """https://www.europarl.europa.eu/RegData/etudes/BRIE/2025/769564/EPRS_BRI(2025)769564_EN.pdf""",
                     """https://www.replicon.com/wp-content/uploads/2016/06/RFP-Template_Replicon.pdf""",
                     """https://www.usac.org/wp-content/uploads/rural-health-care/documents/samples/LargeProjectScopeRFP.pdf"""
                 ],
@@ -81,9 +82,12 @@
                 # Set to true to save the generated vector store as a JSON file. Only valid for in-memory vector store.
                 "save_vector_store": true,
 
+                # Set to true to re-create the generated vector store on start-up. Only valid for in-memory vector store.
+                "recreate_vector_store_on_start": false,
+
                 # Directory to save and load the vector store (use absolute path or path relative to "neuro-san-studio/coded_tools/pdf_rag/")
                 # Must be ".json". Only valid for in-memory vector store.
-                "vector_store_path": "vector_store.json"
+                "vector_store_path": "./pdf_rag/vector_store.json"
             }
         },
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,6 @@ neuro-san==0.5.61
 neuro-san-web-client==0.1.12
 nsflow==0.5.20
 
-# For the airline_policy demo and agentic rag, to extract text from documents
-pypdf>=5.4.0
-pymupdf>=1.25.5
-
 # To use a .env file for environment variables
 python-dotenv==1.0.1
 
@@ -18,3 +14,13 @@ langchain-mcp-adapters>=0.1.7
 
 # Neuro-SAN now requires explicit installation of langchain LLM providers' libs
 langchain-anthropic>=0.3.11,<0.4
+
+### Example Specific packages
+
+# For the airline_policy demo and agentic rag, to extract text from documents
+pypdf>=5.4.0
+pymupdf>=1.25.5
+
+# For the pdf_rag demo
+asyncpg==0.30.0
+langchain-postgres==0.0.15


### PR DESCRIPTION
This PR:
- Addresses missing python packages required to enable successful operation of the pdf_rag pattern 'out of the box'.
- Adds a new feature to re-create the in-memory vector-store on first start - new embeddings were not created if an existing vector store file was found.
- Adds an additional PDF document to the list of documents included in the vector store that provides additional meaningful content for audiences.