### PR TITLE
Fix validation errors

### DIFF
--- a/registries/agent_network_html_creator.hocon
+++ b/registries/agent_network_html_creator.hocon
@@ -30,7 +30,7 @@
         # call each other is defined within their own specs.
         # This could be a graph, potentially even with cycles.
         {
-            "name": "Agent Network HTML Creator",
+            "name": "Agent_Network_HTML_Creator",
 
             # Note that there are no parameters defined for this guy's "function" key.
             # This is the primary way to identify this tool as a front-man,

--- a/registries/airline_policy.hocon
+++ b/registries/airline_policy.hocon
@@ -34,7 +34,7 @@ Do not mention what you can NOT do. Only mention what you can do.
         # call each other is defined within their own specs.
         # This could be a graph, potentially even with cycles.
         {
-            "name": "Airline 360 Assistant",
+            "name": "Airline_360_Assistant",
 
             "function": {
                 # The description acts as an initial prompt. 

--- a/registries/pdf_rag.hocon
+++ b/registries/pdf_rag.hocon
@@ -26,7 +26,7 @@
         # call each other is defined within their own specs.
         # This could be a graph, potentially even with cycles.
         {
-            "name": "PDF RAG Assistant",
+            "name": "PDF_RAG_Assistant",
 
             # Note that there are no parameters defined for this guy's "function" key.
             # This is the primary way to identify this tool as a front-man,


### PR DESCRIPTION
Fix some agent name validation errors that would prevent some agents from coming up.
Do this before it becomes a problem with the new server-side validation that would skip networks with problems.

After fixing these 3 errors, the neuro-san-studio server starts with no validation errors.