### PR TITLE
Remove slash at the end of MCP servers in mcp_info.hocon

### DIFF
--- a/mcp/mcp_info.hocon
+++ b/mcp/mcp_info.hocon
@@ -19,13 +19,13 @@
 #     },
 
 {
-    "https://mcp.deepwiki.com/mcp/": {
+    "https://mcp.deepwiki.com/mcp": {
         "tools": ["read_wiki_structure", "ask_question"]
     },
 
     # Uncomment this section to use GitHub Copilot MCP server.
     # Make sure to set the environment variable GITHUB_TOKEN with a valid token.
-    # "https://api.githubcopilot.com/mcp/": {
+    # "https://api.githubcopilot.com/mcp": {
     #     "headers": {
     #        # ${GITHUB_TOKEN} is an environment variable that should contain a valid GitHub Copilot token.
     #         "Authorization": "Bearer" ${GITHUB_TOKEN}


### PR DESCRIPTION
As of neuro-san==0.5.66, the neuro-san's validator expect MCP server to end with `mcp`. However the servers in `mcp_info.hocon` end with `mcp/`.