### PR TITLE
Replace space with underscore in frontman names

### DIFF
--- a/registries/advanced_calculator.hocon
+++ b/registries/advanced_calculator.hocon
@@ -54,7 +54,7 @@ response.
         # call each other is defined within their own specs.
         # This could be a graph, potentially even with cycles.
         {
-            "name": "Math Geek",
+            "name": "Math_Geek",
 
             # Note that there are no parameters defined for this agent's "function" key.
             # This is the primary way to identify this tool as a front-man,

--- a/registries/agent_network_architect.hocon
+++ b/registries/agent_network_architect.hocon
@@ -52,7 +52,7 @@
         # call each other is defined within their own specs.
         # This could be a graph, potentially even with cycles.
         {
-            "name": "Agent Network Architect",
+            "name": "Agent_Network_Architect",
             "function": {
                 description = "Designs a multi-agent network and can email the configuration HOCON file to specified recipients."
             },

--- a/registries/agentic_rag.hocon
+++ b/registries/agentic_rag.hocon
@@ -26,7 +26,7 @@
         # call each other is defined within their own specs.
         # This could be a graph, potentially even with cycles.
         {
-            "name": "Agentic RAG Assistant",
+            "name": "Agentic_RAG_Assistant",
 
             # Note that there are no parameters defined for this guy's "function" key.
             # This is the primary way to identify this tool as a front-man,

--- a/registries/agentspace_adapter.hocon
+++ b/registries/agentspace_adapter.hocon
@@ -26,7 +26,7 @@
         # call each other is defined within their own specs.
         # This could be a graph, potentially even with cycles.
         {
-            "name": "AgentSpace searcher",
+            "name": "AgentSpace_searcher",
 
             "function": {
                 "description": "Assist caller with searching a query."

--- a/registries/arxiv_rag.hocon
+++ b/registries/arxiv_rag.hocon
@@ -20,7 +20,7 @@
     
     "tools": [
         {
-            "name": "Arxiv RAG Assistant",
+            "name": "Arxiv_RAG_Assistant",
 
             "function": {
               "description": "Answer caller's query with answers from tools.",

--- a/registries/confluence_rag.hocon
+++ b/registries/confluence_rag.hocon
@@ -33,7 +33,7 @@
         # call each other is defined within their own specs.
         # This could be a graph, potentially even with cycles.
         {
-            "name": "Confluence RAG Assistant",
+            "name": "Confluence_RAG_Assistant",
 
             # Note that there are no parameters defined for this guy's "function" key.
             # This is the primary way to identify this tool as a front-man,

--- a/registries/gmail.hocon
+++ b/registries/gmail.hocon
@@ -33,7 +33,7 @@
         # call each other is defined within their own specs.
         # This could be a graph, potentially even with cycles.
         {
-            "name": "Gmail Assistant",
+            "name": "Gmail_Assistant",
             "function": {
                 description = "An assistant that helps the user manage their Gmail inbox, including reading, searching, drafting, and sending emails."
             },

--- a/registries/wikipedia_rag.hocon
+++ b/registries/wikipedia_rag.hocon
@@ -20,7 +20,7 @@
 
     "tools": [
         {
-            "name": "Wikipedia RAG Assistant",
+            "name": "Wikipedia_RAG_Assistant",
 
             "function": {
               "description": "Answer caller's query with answers from tools.",


### PR DESCRIPTION
When networks are used as subnetworks, the frontman is treated as a tool.
Since tools in the OpenAI specification cannot contain spaces in their names, the frontman’s name must also follow this rule.