### PR TITLE
Turn on agent_network_designer

### DIFF
--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -141,7 +141,7 @@
     "macys.hocon": true,
     "LinkedInJobSeekerSupportNetwork.hocon": true,
     # Experimental and research
-    "agent_network_designer.hocon": false,
+    "agent_network_designer.hocon": true,
     "agent_network_editor.hocon": true,
     "agent_network_instructions_editor.hocon": true,
     "agent_network_query_generator.hocon": true,


### PR DESCRIPTION
Turn on `agent_network_designer` to activate the Editor mode in nsflow.