### PR TITLE
Remove pymupdf

### DIFF
--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -57,7 +57,10 @@
     "agent_network_html_creator.hocon": true,
     "agentforce.hocon": true,
     "agentspace_adapter.hocon": false,
-    "pdf_rag.hocon": true,
+
+    # To use this agent network, start by installing the required package:
+    #     pip install pymupdf >= 1.25.5
+    "pdf_rag.hocon": false,
     "agentic_rag.hocon": false,
     "kwik_agents.hocon": false,
 

--- a/registries/pdf_rag.hocon
+++ b/registries/pdf_rag.hocon
@@ -9,6 +9,10 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+# To use this agent network, start by installing the required package:
+#     pip install pymupdf >= 1.25.5
+
 {
     "llm_config": {
         "model_name": "gpt-4o",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,8 @@
 neuro-san==0.5.66
 nsflow==0.6.1
 
-# For the airline_policy demo and agentic rag, to extract text from documents
+# For the airline_policy demo, to extract text from documents
 pypdf>=5.4.0
-pymupdf>=1.25.5
 
 # To use a .env file for environment variables
 python-dotenv==1.0.1

--- a/toolbox/toolbox_info.hocon
+++ b/toolbox/toolbox_info.hocon
@@ -304,6 +304,8 @@
         }
     },
 
+    # To use tool, start by installing the required package:
+    #     pip install pymupdf >= 1.25.5
     "pdf_rag": {
         # This is a coded tool for RAG on PDF files.
         "class": "pdf_rag.PdfRag", 
@@ -320,6 +322,8 @@
         }
     },
 
+    # To use this tool, start by installing the required package:
+    #     pip install wikipedia
     "wikipedia_rag": {
         # This is a coded tool for RAG on Wikipedia pages.
         "class": "wikipedia_rag.WikipediaRag",
@@ -336,6 +340,8 @@
         }
     },
     
+    # To use this tool, start by installing the required package:
+    #     pip install arxiv
     "arxiv_rag": {
         # This is a coded tool for RAG on Arxiv Articles.
         "class": "arxiv_rag.ArxivRag",


### PR DESCRIPTION
- remove `pymupdf` from `requirements.txt`
- turn off `pdf_rag` by default
- add comments in network, manifest, and toolbox

**Note:** I’m not using `pypdf` here because it fails to handle certain PDFs (e.g., pages that are entirely figures or blank), which can cause errors.

As a quick fix, this PR disables the network by default and removes `pymupdf` from requirements.txt.
A more robust solution—such as adding exception handling or switching to another open-source PDF library—will be addressed in a future PR.