### PR TITLE
#410 Add metadata for basic agent networks

### DIFF
--- a/registries/basic/coffee_finder.hocon
+++ b/registries/basic/coffee_finder.hocon
@@ -16,6 +16,18 @@
 
 include "registries/aaosa_basic.hocon"
 
+# Optional metadata describing this agent network
+metadata {
+    description = "Agent network that helps users find coffee at any time of the day. It shows how multiple agents can provide the same service and how the AAOSA instructions can be used to choose the best option depending on the context."
+    tags = ["AAOSA"]
+    sample_queries = [
+        "Where can I find coffee?",
+        "It's 8 pm, where can I get coffee?",
+        "It's now 2 am, where can I get coffee?",
+        "Where can I find coffee liquor?",
+    ]
+}
+
 llm_config {
     class = "openai"
     model_name = "gpt-4.1-mini"

--- a/registries/basic/coffee_finder_advanced.hocon
+++ b/registries/basic/coffee_finder_advanced.hocon
@@ -16,6 +16,21 @@
 
 include "registries/aaosa_basic.hocon"
 
+# Optional metadata describing this agent network
+metadata {
+    description =
+"""Agent network that helps users find places that sell coffee and place orders.
+It checks the current time, places orders and remembers user preferences."""
+    tags = ["AAOSA", "tool", "time", "sly_data", "memory"]
+    sample_queries = [
+        "Where can I get coffee?",
+        "Get me black coffee from Henry's",
+        "My name is Mike",
+        "What time is it?",
+        "Mike here. Get me the same as usual",
+    ]
+}
+
 llm_config {
     class = "openai"
     model_name = "gpt-4.1"

--- a/registries/basic/music_nerd.hocon
+++ b/registries/basic/music_nerd.hocon
@@ -14,6 +14,16 @@
 #
 # END COPYRIGHT
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent, used as a 'Hello world!' example, that can answer questions about music and follow up."
+        "tags": []
+        "sample_queries": [
+            "Which band wrote Yellow Submarine?",
+            "Where are they from?",
+        ]
+    }
+
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/registries/basic/music_nerd_llm_fallbacks.hocon
+++ b/registries/basic/music_nerd_llm_fallbacks.hocon
@@ -14,6 +14,16 @@
 #
 # END COPYRIGHT
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent, used as a 'Hello world!' example, that can answer questions about music and follow up. Implements a fallback mechanism in case its first configured LLM fails."
+        "tags": ["llm_config", "llm_fallbacks"]
+        "sample_queries": [
+            "Which band wrote Yellow Submarine?",
+            "Where are they from?",
+        ]
+    }
+
     "llm_config": {
         "fallbacks": [
             {

--- a/registries/basic/music_nerd_local.hocon
+++ b/registries/basic/music_nerd_local.hocon
@@ -14,6 +14,16 @@
 #
 # END COPYRIGHT
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent, used as a 'Hello world!' example, that can answer questions about music and follow up. Relies on a local LLM."
+        "tags": ["llm_config"]
+        "sample_queries": [
+            "Which band wrote Yellow Submarine?",
+            "Where are they from?",
+        ]
+    }
+
     "llm_config": {
         "model_name": "mistral",
     },

--- a/registries/basic/music_nerd_pro.hocon
+++ b/registries/basic/music_nerd_pro.hocon
@@ -14,6 +14,16 @@
 #
 # END COPYRIGHT
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent, used as a 'Hello world!' example, that can answer questions about music and follow up. Keeps track of the number of questions answered using a running_cost metric"
+        "tags": ["tool"]
+        "sample_queries": [
+            "Which band wrote Yellow Submarine?",
+            "Where are they from?",
+        ]
+    }
+
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/registries/basic/music_nerd_pro_local.hocon
+++ b/registries/basic/music_nerd_pro_local.hocon
@@ -14,6 +14,16 @@
 #
 # END COPYRIGHT
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent, used as a 'Hello world!' example, that can answer questions about music and follow up. Keeps track of the number of questions answered using a running_cost metric. Relies on a local tool-calling LLM."
+        "tags": ["tool", "llm_config"]
+        "sample_queries": [
+            "Which band wrote Yellow Submarine?",
+            "Where are they from?",
+        ]
+    }
+
     "llm_config": {
         "model_name": "llama3.1",
     },

--- a/registries/basic/music_nerd_pro_sly.hocon
+++ b/registries/basic/music_nerd_pro_sly.hocon
@@ -14,6 +14,16 @@
 #
 # END COPYRIGHT
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent, used as a 'Hello world!' example, that can answer questions about music and follow up. Keeps track of the number of questions answered using a running_cost variable in the sly data"
+        "tags": ["tool", "sly_data"]
+        "sample_queries": [
+            "Which band wrote Yellow Submarine?",
+            "Where are they from?",
+        ]
+    }
+
     "llm_config": {
         "model_name": "gpt-4o",
         # "model_name": "claude-3-5-haiku",

--- a/registries/basic/music_nerd_pro_sly_local.hocon
+++ b/registries/basic/music_nerd_pro_sly_local.hocon
@@ -14,6 +14,16 @@
 #
 # END COPYRIGHT
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent, used as a 'Hello world!' example, that can answer questions about music and follow up. Keeps track of the number of questions answered using a running_cost variable in the sly data. Relies on a local LLM."
+        "tags": ["tool", "sly_data", "llm_config"]
+        "sample_queries": [
+            "Which band wrote Yellow Submarine?",
+            "Where are they from?",
+        ]
+    }
+
     "llm_config": {
         "model_name": "llama3.1",
     },


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Adds metadata to agent networks in the `basic` folder: 
- description
- tags
- sample queries

Fixes #410 

## Impact

The tags can already be used to filter agent networks in nsflow. See screen shot below

## Screenshots / Logs / Examples (optional)

<img width="511" height="532" alt="image" src="https://github.com/user-attachments/assets/4131a256-e2bc-47f6-a4e6-4025ae91a87c" />

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Academic Public License](../LICENSE.txt).**
