### PR TITLE
added chat_filter to enable debug

### DIFF
--- a/tests/fixtures/cpg_agents_test.hocon
+++ b/tests/fixtures/cpg_agents_test.hocon
@@ -30,6 +30,9 @@
     # descriptions of response checks
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # Supply chain inquiry from documentation example
             "text": "We're experiencing supply chain delays in our Southeast Asia region that are affecting our new product launch. Can you help me understand the root cause and develop a mitigation plan?",
 

--- a/tests/fixtures/industry/airline_policy/basic_eco_carryon_baggage.hocon
+++ b/tests/fixtures/industry/airline_policy/basic_eco_carryon_baggage.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+
             # This is what we send as input to streaming_chat()
             "text": """
 On a domestic basic economy flight, do I get a free carry-on bag?

--- a/tests/fixtures/industry/airline_policy/basic_eco_checkin_baggage.hocon
+++ b/tests/fixtures/industry/airline_policy/basic_eco_checkin_baggage.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 On a domestic basic economy flight, do I get a free check-in bag?

--- a/tests/fixtures/industry/airline_policy/basic_eco_checkin_baggage_at_gate_fee.hocon
+++ b/tests/fixtures/industry/airline_policy/basic_eco_checkin_baggage_at_gate_fee.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 On a Basic Economy flight, what do I pay if my bag has to be checked at the gate?

--- a/tests/fixtures/industry/airline_policy/general_baggage_tracker.hocon
+++ b/tests/fixtures/industry/airline_policy/general_baggage_tracker.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 What kind of tracker can I use for my checked-in bag?

--- a/tests/fixtures/industry/airline_policy/general_carryon_baggage_liquid_items.hocon
+++ b/tests/fixtures/industry/airline_policy/general_carryon_baggage_liquid_items.hocon
@@ -40,6 +40,9 @@
             # Note: This text case is expected to failed 100%!!!
             # These is no info regarding liquids in Carry-on Bags.txt file.
             
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 How should I pack liquids in my carry-on bag?

--- a/tests/fixtures/industry/airline_policy/general_carryon_baggage_size.hocon
+++ b/tests/fixtures/industry/airline_policy/general_carryon_baggage_size.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 What size carry-on bag can I bring on my flight?

--- a/tests/fixtures/industry/airline_policy/general_carryon_other_items.hocon
+++ b/tests/fixtures/industry/airline_policy/general_carryon_other_items.hocon
@@ -36,6 +36,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 What else can I bring for free besides my carry-on and personal item?

--- a/tests/fixtures/industry/airline_policy/general_carryon_person_item.hocon
+++ b/tests/fixtures/industry/airline_policy/general_carryon_person_item.hocon
@@ -36,6 +36,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 Can I bring a personal item on my flight without additional fee?

--- a/tests/fixtures/industry/airline_policy/general_carryon_person_item_size.hocon
+++ b/tests/fixtures/industry/airline_policy/general_carryon_person_item_size.hocon
@@ -36,6 +36,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 What size does my personal item need to be to fly for free?

--- a/tests/fixtures/industry/airline_policy/general_checkin_baggage_liquid_items.hocon
+++ b/tests/fixtures/industry/airline_policy/general_checkin_baggage_liquid_items.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 How should I pack liquids for my flight?

--- a/tests/fixtures/industry/airline_policy/general_child_car_seat.hocon
+++ b/tests/fixtures/industry/airline_policy/general_child_car_seat.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 Can my child use a car seat on the plane, and where should it be placed?

--- a/tests/fixtures/industry/airline_policy/general_child_stroller.hocon
+++ b/tests/fixtures/industry/airline_policy/general_child_stroller.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 Can I bring a stroller with me to the gate, and what happens to it after?

--- a/tests/fixtures/industry/airline_policy/general_children_formula.hocon
+++ b/tests/fixtures/industry/airline_policy/general_children_formula.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 Can I bring breast milk or formula through airport security?

--- a/tests/fixtures/industry/airline_policy/general_children_id_domestic_flights.hocon
+++ b/tests/fixtures/industry/airline_policy/general_children_id_domestic_flights.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 Do kids need an ID to fly on domestic flights?

--- a/tests/fixtures/industry/airline_policy/general_children_id_international_flights.hocon
+++ b/tests/fixtures/industry/airline_policy/general_children_id_international_flights.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 Do children need a passport for international flights?

--- a/tests/fixtures/industry/airline_policy/general_children_seating.hocon
+++ b/tests/fixtures/industry/airline_policy/general_children_seating.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 Do infants and young children need their own seat on a flight?

--- a/tests/fixtures/industry/airline_policy/general_family_with_children.hocon
+++ b/tests/fixtures/industry/airline_policy/general_family_with_children.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 What boarding and seating options are available for families traveling with young children?

--- a/tests/fixtures/industry/airline_policy/premier_gold_checkin_baggage_weights.hocon
+++ b/tests/fixtures/industry/airline_policy/premier_gold_checkin_baggage_weights.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 What’s the checked bag weight limit for Premier Gold?

--- a/tests/fixtures/industry/airline_policy/premium_eco_checkin_baggage_weights.hocon
+++ b/tests/fixtures/industry/airline_policy/premium_eco_checkin_baggage_weights.hocon
@@ -37,6 +37,9 @@
     # descriptions of response checks.
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # This is what we send as input to streaming_chat()
             "text": """
 What’s the checked bag weight limit for Premium Economy?

--- a/tests/fixtures/industry/consumer_decision_assistant_comprehensive.hocon
+++ b/tests/fixtures/industry/consumer_decision_assistant_comprehensive.hocon
@@ -30,6 +30,9 @@
     # These are independent questions, not a continuous conversation
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # Test 1: Travel decision specialist (Airbnb/Booking/Expedia)
             "text": "Help me book a trip to Dubai",
 

--- a/tests/fixtures/industry/telco_network_support_test.hocon
+++ b/tests/fixtures/industry/telco_network_support_test.hocon
@@ -30,6 +30,9 @@
     # descriptions of response checks
     "interactions": [
         {
+            # This is to enable streaming_chat contents to thinking file for debug.
+            # "chat_filter": "MAXIMAL",
+            
             # Simple network support inquiry
             "text": "We're experiencing network outages at our Boston office",
 


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Added the "chat_filter" interaction to all integration test cases.
This is helpful when you're debugging a test failure locally and want to see what is in the thinking file.
You can find more info about this in agent_hocon_reference.md

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
