### PR TITLE
Add default MCP_SERVERS_INFO_FILE to run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -75,7 +75,8 @@ class NeuroSanRunner:
                 "AGENT_TOOLBOX_INFO_FILE", os.path.join(self.root_dir, "toolbox", "toolbox_info.hocon")
             ),
             "mcp_servers_info_file": os.getenv(
-                "MCP_SERVERS_INFO_FILE", os.path.join(self.root_dir, "mcp", "mcp_info.hocon")),
+                "MCP_SERVERS_INFO_FILE", os.path.join(self.root_dir, "mcp", "mcp_info.hocon")
+            ),
             "logs_dir": self.logs_dir,
         }
 


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

MCP_SERVERS_INFO_FILE is an env variable that points to the file that contains MCP servers configuration.
If it's not set, MCP tools might not work correctly.

## Impact

`mcp/mcp_info.hocon` is now used by default if starting Neuro SAN with `run.py`

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [X] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
