### PR TITLE
Fix duplicated quotation marks in generated hocon sample queries breaks nsflow display of the new network

### DIFF
--- a/coded_tools/agent_network_designer/hocon_agent_network_assembler.py
+++ b/coded_tools/agent_network_designer/hocon_agent_network_assembler.py
@@ -164,7 +164,7 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         if sample_queries:
             parts = []
             for query in sample_queries:
-                parts.append(f'"{query}"')
+                parts.append(f'"{query.replace('"', "")}"')
             formatted_queries = ",\n            ".join(parts)
         return formatted_queries
 


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Remove inner quotation marks from sample queries if there are any.

Fixes #572 

## Impact


## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
