### PR TITLE
#550 Use default llm_config in generated agent networks

### DIFF
--- a/coded_tools/agent_network_designer/hocon_agent_network_assembler.py
+++ b/coded_tools/agent_network_designer/hocon_agent_network_assembler.py
@@ -45,7 +45,7 @@ HOCON_HEADER_START = (
     "# This allows users to change the model in one file rather than\n"
     "# modifying the configuration for each agent network.\n"
     "# Note that the file path here is relative to the root level of the repo.\n"
-    'include "registries/llm_config.hocon",\n'
+    '    include "registries/llm_config.hocon",\n'
     "\n"
     '   "instructions_prefix": """\n'
     "You are part of a team of assistants in "


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Makes agent network designer / editor use the default `llm_config.hocon` instead of hard coding `gpt-4o`.

Fixes #550

## Impact

Means people that are not using OpenAI can now generate agent networks that work out-of-the-box with their LLM provider.

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [X] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
