### PR TITLE
fix arxiv coded tool bug where top_k_results is none

### DIFF
--- a/coded_tools/tools/arxiv_rag.py
+++ b/coded_tools/tools/arxiv_rag.py
@@ -77,6 +77,7 @@ class ArxivRag(CodedTool):
 
         # Initialize ArxivRetriever with the provided arguments
         retriever = ModifiedArxivRetriever(
+            # LMMs can decide to set a "top_k_results" key to None in args. Make sure we always use an int by default.
             top_k_results=args.get("top_k_results") or 3,
             get_full_documents=get_full_document,
             doc_content_chars_max=args.get("doc_content_chars_max", 4000),


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

`top_k_results` has to be integer. If the value provided by LLM is `None`, pydantic error will be raised.

## Impact

<!-- Brief description of what the consequences of this PR are -->

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
