### PR TITLE
Add permissions block to integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Adds an explicit `permissions` block to the integration workflow, resolving [code scanning alert #1](https://github.com/cognizant-ai-lab/neuro-san-studio/security/code-scanning/1) ("Workflow does not have permissions").

The other two workflows (`tests.yml`, `dispatch-to-deploy.yml`) already declare `permissions: contents: read`. This PR brings `integration.yml` in line with them.

## Impact

Restricts the `GITHUB_TOKEN` scope for integration workflow runs to read-only content access, following the principle of least privilege.

## Type of Change

- [x] Refactoring / Improvement

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt`

## Human Review Checklist

- [ ] Confirm `contents: read` is sufficient for all steps (checkout, apt-get install, pytest, Slack notification)

---

Link to Devin run: https://app.devin.ai/sessions/66ca913fd68f410cafd48b17886ef928
Requested by: @donn-leaf

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
