### PR TITLE
Restrict PR trigger to opened and reopened

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "**"
   pull_request:
+    types: [opened, reopened]
     branches:
       - main
 


### PR DESCRIPTION
## Description

Adds explicit `types: [opened, reopened]` to the `pull_request` trigger in `tests.yml`, matching what `neuro-san` already does.

Without explicit types, GitHub defaults to `[opened, synchronize, reopened]`. Every push to a branch with an open PR targeting `main` fires **both** a `push` event and a `pull_request: synchronize` event, producing two identical Test workflow runs. The `push` trigger (`branches: "**"`) already covers every commit to every non-main branch, so the `synchronize` type is redundant.

## Impact

Eliminates duplicate CI runs on every push to a PR branch, halving Actions usage for PRs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Human Review Checklist

- [ ] Confirm no CI coverage gap: the `push` trigger on `branches: "**"` combined with the job-level `if` (`github.ref != 'refs/heads/main'`) still fires for every push to a PR branch
- [ ] Confirm `opened` and `reopened` types are still present so PRs get an initial status check

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt`

---

[Link to Devin Session](https://app.devin.ai/sessions/226d9b3a1b864c7094c8e8d80e783cde)
Requested by: @donn-leaf

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
