### PR TITLE
Update README.md to include link to loopy_agent reference app

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,8 +334,8 @@ an app that evaluates F1 fan submissions about why they are the biggest F1 fans.
 a Flask web app that queries PDFs using RAG with topic-based long-term memory synthesis across documents.
 * [Vibe coding project evaluator](https://github.com/deepsaia/vibe-coding-eval):
 a scalable framework that evaluates vibe-coded projects on different criteria.
-* [Loopy Agents] (https://github.com/babakatwork/loopy_agent):
-* Run NeuroSAN agents continuously or on triggers through a separate service, with asynchronous messaging.
+* [Loopy Agents](https://github.com/babakatwork/loopy_agent):
+run Neuro SAN agents continuously or on triggers through a separate service, with asynchronous messaging.
 
 ### Utilities
 


### PR DESCRIPTION
Add link in readme to a useful example/reference app

## Description

Link to an example app that allows you to run NeuroSAN agents in a loop via separate service and interact with them async

## Impact

Running agents in a loop and being able to talk to them from other agent networks asynchronously is an important design pattern, and this reference app gives people a minimal yet general way to implement that and so I think including a link to it from our README makes sense.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [X] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [X] Updated relevant documentation
- [X] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)


---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
