### PR TITLE
NS-743 Add sly_data_output_schema for networks using reservations

### DIFF
--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -24,7 +24,7 @@
             "Create an agent network for Santa's Workshop"
         ]
     },
-    
+
     # Load the shared LLM configuration from a single source of truth.
     # This allows users to change the model in one file rather than
     # modifying the configuration for each agent network.
@@ -61,6 +61,79 @@
                         }
                     },
                     "required": ["agent_network_description", "mode"]
+                },
+
+                # You can optionally specify the schema needed for any sly_data as input.
+                # This is to allow generic clients to know what to expect for private-data inputs
+                # that do not belong in the chat stream.
+                "sly_data_schema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_network_definition": {
+                            "type": "object",
+                            "description": "An internal representation of the agent network used for further iteration."
+                        },
+                        "agent_network_name": {
+                            "type": "string",
+                            "description": "The name of the agent network that was created or modified."
+                        },
+                    }
+                    # Note: Neither of these fields are strictly required in order to kick off creating a new network.
+                },
+
+                # You can also optionally specify the schema needed for any sly_data output.
+                # This is to allow generic clients to know what to expect for private-data outputs
+                # that do not belong in the chat stream.
+                "sly_data_output_schema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_network_definition": {
+                            "type": "object",
+                            "description": "An internal representation of the agent network used for further iteration."
+                        },
+                        "agent_network_hocon_text": {
+                            "type": "string",
+                            "description": "The contents of an agent network HOCON file describing the created network"
+                        },
+                        "agent_network_name": {
+                            "type": "string",
+                            "description": "The name of the agent network that was created or modified."
+                        },
+                        "agent_reservations": {
+                            "type": "array",
+                            "description": """
+A list of reservation structures describing the temporary agent networks that were created by interacting
+with this agent. By convention, the last one in the list is a top-level handle which may reference any others listed.
+""",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "reservation_id": {
+                                        "type": "string"
+                                        "description": """
+The unique identifier of the reserved temporary agent network.
+This can be used to invoke the newly created network later on the same server/cluster.
+"""
+                                    },
+                                    "lifetime_in_seconds": {
+                                        "type": "float",
+                                        "description": """
+Approximate lifetime (in seconds) of the temporary agent network reservation suitable for reporting to end users.
+"""
+                                    },
+                                    "expiration_time_in_seconds": {
+                                        "type": "float",
+                                        "description": """
+The number of seconds since the epoch (Jan 1, 1970) when the reservation will expire.
+After this time the network can no longer be counted upon to exist.
+"""
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    # Note: "agent_reservations" is not strictly required depending on env vars.
+                    "required": ["agent_network_definition", "agent_network_hocon_text", "agent_network_name"]
                 }
             },
             "instructions": """

--- a/registries/experimental/copy_cat.hocon
+++ b/registries/experimental/copy_cat.hocon
@@ -70,7 +70,48 @@ Also, if you give me some input text for the new temporary agent, I can immediat
 but that is optional.
 
 What is the name of the agent you want to copy?
+""",
+                # You can also optionally specify the schema needed for any sly_data output.
+                # This is to allow generic clients to know what to expect for private-data outputs
+                # that do not belong in the chat stream.
+                "sly_data_output_schema": {
+                    "type": "object",
+                    "properties": {
+                        "agent_reservations": {
+                            "type": "array",
+                            "description": """
+A list of reservation structures describing the temporary agent networks that were created by interacting
+with this agent. By convention, the last one in the list is a top-level handle which may reference any others listed.
+""",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "reservation_id": {
+                                        "type": "string"
+                                        "description": """
+The unique identifier of the reserved temporary agent network.
+This can be used to invoke the newly created network later on the same server/cluster.
 """
+                                    },
+                                    "lifetime_in_seconds": {
+                                        "type": "float",
+                                        "description": """
+Approximate lifetime (in seconds) of the temporary agent network reservation suitable for reporting to end users.
+"""
+                                    },
+                                    "expiration_time_in_seconds": {
+                                        "type": "float",
+                                        "description": """
+The number of seconds since the epoch (Jan 1, 1970) when the reservation will expire.
+After this time the network can no longer be counted upon to exist.
+"""
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": ["agent_reservations"]
+                }
             },
 
             "instructions": """


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Add sly_data_output_schema to copy_cat and agent_network_designer for generic clients to have a clue that reservations might be coming their way.  This new info is reported for the benefit of generic clients via the Function() API method and has no bearing on agent network functionality at all.

Specifically not trying to go around do do sly_data_schema and sly_data_output_schema for everything.
Goal is to get bits of MAUI development moving.

## Impact

<!-- Brief description of what the consequences of this PR are -->

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [X] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
