### PR TITLE
Revert "#740 Upgrade to nsflow 0.6.12"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Neuro SAN
 neuro-san==0.6.41
-nsflow==0.6.12
+nsflow==0.6.11
 
 # For the airline_policy demo, to extract text from documents
 pypdf>=6.1.3


### PR DESCRIPTION
Reverts cognizant-ai-lab/neuro-san-studio#741

There's a risk of inadvertently messing up existing agent networks. Disabling the "Edit existing agent network" functionality for now by reverting to nsflow 0.6.11