### PR TITLE
Exclude claude.ai from lychee link check

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -17,6 +17,8 @@ https://medium.com/@evolutionmlmail
 https://dl.acm.org/
 https://community.openai.com/
 https://citeseerx.ist.psu.edu/
+https://claude.ai/
+https://platform.claude.com/
 
 # API endpoints (not browsable)
 https://api.search.brave.com/


### PR DESCRIPTION
## Description

Add `claude.ai` and `platform.claude.com` to `.lycheeignore` to fix intermittent CI failures in the dead link checker.

`claude.ai` blocks automated HTTP requests with `403 Forbidden`, causing the lychee link check step to fail on the Claude Optimizer artifact URL referenced in `docs/user_guide.md`. `platform.claude.com` is also referenced in the docs and may exhibit the same behavior.

Fixes #756

## Impact

Eliminates flaky CI failures caused by `claude.ai` returning 403 to the link checker. No functional changes.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)
