### PR TITLE
Revert "Exclude claude.ai from lychee link check"

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -17,8 +17,6 @@ https://medium.com/@evolutionmlmail
 https://dl.acm.org/
 https://community.openai.com/
 https://citeseerx.ist.psu.edu/
-https://claude.ai/
-https://platform.claude.com/
 
 # API endpoints (not browsable)
 https://api.search.brave.com/


### PR DESCRIPTION
Reverts cognizant-ai-lab/neuro-san-studio#760

Ignoring the links defeats the purpose of Lychee. We need to know when the Claude links rot.