### PR TITLE
#756 Make Lychee treat 403 responses as valid (not dead links)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,8 +68,11 @@ jobs:
           curl --silent --location \
           https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
           | tar --extract --gzip --directory /tmp
-          # Accept 429 (rate limit) and 503 (temporary outage) to prevent flaky CI failures
-          /tmp/lychee --max-retries 3 --retry-wait-time 3 --verbose --accept '200,203,204,429,503' --exclude-path venv './**/*.md'
+          # To prevent flaky CI failures, accept:
+          # - 403 (Forbidden) if the server blocks bots or requests without a browser-like User-Agent
+          # - 429 (rate limit)
+          # - 503 (temporary outage) 
+          /tmp/lychee --max-retries 3 --retry-wait-time 3 --verbose --accept '200,203,204,403,429,503' --exclude-path venv './**/*.md'
 
       - name: Run make test
         shell: bash


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Lychee gets a 403 Forbidden because claude.ai probably:
- blocks bots / CLI tools
- Blocks requests without a browser-like User-Agent

This PR makes Lychee treat 403 responses as valid (not dead links): Lychee was blocked, but the link probably still works.

Fixes #756 

## Impact

Test should not fail randomly while checking claude.ai links

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
