### PR TITLE
Fix music_nerd_pro empty response by updating LLM instructions

### DIFF
--- a/registries/basic/music_nerd_pro.hocon
+++ b/registries/basic/music_nerd_pro.hocon
@@ -75,7 +75,8 @@ This service comes for a fee. For each question you're about to answer, use your
 running fees.
 
 For each question you receive, call your Accountant tool to calculate the running cost.
-Then answer with a JSON message that has two keys:
+First, answer the question in plain text.
+Then, at the end of your response, include a JSON block with two keys:
 1. An "answer" key whose value has the answer to the question
 2. A "running_cost" key whose value has the running cost computed by the Accountant tool.
 """,

--- a/registries/basic/music_nerd_pro_sly.hocon
+++ b/registries/basic/music_nerd_pro_sly.hocon
@@ -64,7 +64,8 @@ You’re Music Nerd Pro, the go-to brain for all things rock, pop, and everythin
 You’re equal parts playlist curator, music historian, and pop culture mythbuster—with a sixth sense for sonic nostalgia and a deep respect for the analog gods.
 
 For each question you receive, call your Accountant agent to calculate the running cost. Otherwise you won't get paid!
-Then answer with a JSON message that has two keys:
+First, answer the question in plain text.
+Then, at the end of your response, include a JSON block with two keys:
 1. An "answer" key whose value has the answer to the question
 2. A "running_cost" key whose value has the running cost computed by the Accountant agent.
 """,


### PR DESCRIPTION
## Description

Fixes the `music_nerd_pro` and `music_nerd_pro_sly` agent networks showing empty responses in the UI by updating the LLM instructions to produce plain text alongside JSON.

## Impact

The `structure_formats: "json"` config (added in `ea2b60b`) tells the framework's `JsonStructureParser` to extract JSON from the LLM response into a separate `structure` field, with the remainder going into `text`. The original instructions told the LLM to respond with **pure JSON** (`{"answer": "...", "running_cost": ...}`), so the entire response was extracted into `structure` — leaving `text` as `""`. The UI only renders `text`, so the answer appeared empty.

**Previous approach** (reverted): Removing `structure_formats` broke integration tests that assert on the `structure` field (`structure.answer`, `structure.running_cost`).

**Current approach**: Updated the LLM instructions to say "First, answer the question in plain text. Then, at the end of your response, include a JSON block." This way:
- `text` field contains the plain-text answer → UI displays it
- `structure` field still gets the extracted JSON → integration tests pass
- `structure_formats: "json"` is preserved (matching the pattern used by `coffee_finder.hocon`, which works correctly)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

### Human Review Checklist
- [ ] Verify that the LLM reliably follows the "plain text first, then JSON block" instruction format — if it occasionally responds with pure JSON, the empty text issue could recur
- [ ] Confirm integration tests (`basic/music_nerd_pro/combination_responses_with_history_direct.hocon`) still pass with the updated instructions — the `structure` field assertions (`keywords: "Beatles"`, `running_cost: 3.0`) depend on the JSON being parseable
- [ ] Check that `music_nerd_pro_sly` sly_data flow still works correctly with the instruction change

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/20bb0b85a967421f800894c6e328a20a
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
