### PR TITLE
#788 Fix Google Custom Search URL in docs

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -20,8 +20,6 @@ https://citeseerx.ist.psu.edu/
 
 # API endpoints (not browsable)
 https://api.search.brave.com/
-https://customsearch.googleapis.com/
-https://www.googleapis.com/customsearch/
 
 # Sites that timeout or block CI requests
 https://docs.servicenow.com/

--- a/docs/search_tools.md
+++ b/docs/search_tools.md
@@ -77,7 +77,7 @@ DDGS requires no API key, even though it may search Brave or Google. That is bec
 result pages and avoids official API endpoints (which require keys). For example, no Google API key needed, because
 it does not call
 
-[https://customsearch.googleapis.com/](https://customsearch.googleapis.com/)
+[https://www.googleapis.com/customsearch/v1](https://www.googleapis.com/customsearch/v1)
 
 Instead, it scrapes:
 


### PR DESCRIPTION
## Description

Updates the Google Custom Search API URL in `docs/search_tools.md` to the correct endpoint and cleans up `.lycheeignore`.

Fixes #788

## Impact

- The DDGS section of search_tools.md now references the correct Google Custom Search endpoint (`https://www.googleapis.com/customsearch/v1`)
- Lychee link checker will now validate the corrected URL instead of skipping it

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/6ea6807280a94f768a34d32311f02659
Requested by: @shrushtiimehta