### PR TITLE
Fix broken code-interpreter doc URL

### DIFF
--- a/docs/examples/tools/openai_code_interpreter.md
+++ b/docs/examples/tools/openai_code_interpreter.md
@@ -154,7 +154,7 @@ When developing or debugging the OpenAI Code Interpreter Assistant, keep the fol
 - [OpenAI Tools Guide](https://platform.openai.com/docs/guides/tools?api-mode=responses)  
   Complete guide to OpenAI's built-in tools and their capabilities.
 
-- [OpenAI Code Interpreter Documentation](https://platform.openai.com/docs/guides/tools-code-interpreter)  
+- [OpenAI Code Interpreter Documentation](https://developers.openai.com/api/docs/guides/tools-code-interpreter)  
   Detailed documentation for OpenAI's code interpreter functionality.
 
 - [LangChain OpenAI Responses API](https://python.langchain.com/docs/integrations/chat/openai/#responses-api)  


### PR DESCRIPTION
## Description

Update the broken OpenAI Code Interpreter documentation link in `docs/examples/tools/openai_code_interpreter.md`.

The old URL (`platform.openai.com/docs/guides/code-interpreter`) now returns a 404. Replaced with the current canonical URL at `developers.openai.com/api/docs/guides/tools-code-interpreter`.

## Impact

Fixes a broken link in the Resources section of the OpenAI Code Interpreter example documentation.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)
---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/6ea6807280a94f768a34d32311f02659
Requested by: @shrushtiimehta