### PR TITLE
Replace Jinja2 url_for with static path for lychee

### DIFF
--- a/apps/conscious_assistant/templates/index.html
+++ b/apps/conscious_assistant/templates/index.html
@@ -24,7 +24,7 @@ END COPYRIGHT
     <!-- Google Fonts for a modern look -->
     <link href="https://fonts.googleapis.com/css?family=Inter:400,600&display=swap" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" type="text/css" href="/static/style.css">
 </head>
 <body>
     <div class="main-container">

--- a/apps/cruse/templates/index.html
+++ b/apps/cruse/templates/index.html
@@ -25,7 +25,7 @@ END COPYRIGHT
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" type="text/css" href="/static/style.css">
 </head>
 <body>
     <!-- Full-width header -->


### PR DESCRIPTION
## Description

Replace `{{ url_for('static', filename='style.css') }}` with `/static/style.css` in the `conscious_assistant` and `cruse` template files to fix false-positive lychee link checker errors.

Lychee scans raw HTML on disk and cannot evaluate Jinja2 template expressions — it treats the `{{ }}` syntax as a literal file path, producing "file not found" errors. Both Flask apps use `Flask(__name__)` with default settings, so `/static/style.css` resolves identically at runtime.

## Impact

**Advantages:**
- Eliminates two false-positive lychee errors without needing lychee config changes
- Simpler, more portable HTML — no server-side rendering dependency for a static asset path

**Disadvantages:**
- Loses the dynamic path resolution of `url_for`: if either app ever customizes `static_url_path` or `static_folder`, the hardcoded `/static/style.css` would need to be updated manually (currently neither app does this)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

### Human Review Checklist
- [ ] Confirm neither `conscious_assistant/interface_flask.py` nor `cruse/interface_flask.py` customizes `static_url_path` or `static_folder` (they currently use `Flask(__name__)` defaults)
- [ ] Verify CSS loads correctly when running either app locally

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/b6a5e9aaf4e542e786fad3d712589efb
Requested by: @shrushtiimehta
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
