### PR TITLE
 Add instructions_writer agent to the instructions editor network

### DIFF
--- a/coded_tools/agent_network_instructions_editor/set_agent_instructions.py
+++ b/coded_tools/agent_network_instructions_editor/set_agent_instructions.py
@@ -92,4 +92,4 @@ class SetAgentInstructions(CodedTool):
         await ProgressHandler.report_progress(args, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
-        return network_def
+        return f"The instructions for '{the_agent_name}' have been set in 'agent_network_definition' successfully."

--- a/registries/agent_network_instructions_editor.hocon
+++ b/registries/agent_network_instructions_editor.hocon
@@ -98,6 +98,7 @@ You are an instructions writer for agents in an agent network. Your job is to cr
 If `new_instructions` are provided, use them directly without modification. Otherwise, generate new instructions based on the following guidelines:
 
 **Writing requirements**
+- Always start by calling `get_agent_network_definition` to load the current network and existing instructions.
 - Make instructions clear, comprehensive, and specific to the agent’s scope of responsibilities.
 - Provide step-by-step guidance focused on tasks this agent performs; avoid generic platitudes.
 - Do NOT mention other agents, up-chains, or down-chains; keep the text scoped to this agent only.
@@ -115,21 +116,17 @@ If `new_instructions` are provided, use them directly without modification. Othe
                         },
                         "agent_network_description": {
                             "type": "string",
-                            "description": "the description of the agent network."
+                            "description": "the description of the agent network or a clear description of the change you want to make to the existing instructions of the agent."
                         },
-                        "agent_network_definition": {
+                        "new_instructions": {
                             "type": "string",
-                            "description": "the definition or graph of the agent network, which may include the agent's current instructions."
+                            "description": "the new instructions for the agent. This is an optional field. Only use this field if the instructions are explicitly provided by the user."
                         },
-                        // "new_instructions": {
-                        //     "type": "string",
-                        //     "description": "the new instructions for the agent. This is an optional field. If provided, use these instructions directly without modification."
-                        // },
                     },
-                    "required": ["agent_name", "agent_network_description", "agent_network_definition"]
+                    "required": ["agent_name", "agent_network_description"]
                 }
             },
-            "tools": ["set_agent_instructions_tool"],
+            "tools": ["get_agent_network_definition", "set_agent_instructions_tool"],
         },
 
         {

--- a/registries/agent_network_instructions_editor.hocon
+++ b/registries/agent_network_instructions_editor.hocon
@@ -63,22 +63,14 @@ Always start by calling `get_agent_network_definition` to load the current netwo
 **Only create or edit `instructions` for agents that have an `instructions` field in the network definition. These are non-function agents.**
 
 Behavior by mode:
-- `create`: Generate initial instructions for every non-function agent in the network. Use the network description and each agent’s role/title to author concise, actionable guidance.
-Call `set_agent_instructions_tool` once per agent you authored or meaningfully improved. Do not overwrite agents that already have explicit, adequate instructions unless you can provide a clear improvement.
+- `create`: Generate initial instructions for every non-function agent in the network. Call `instructions_writer` once for each of these agents.
 - `modify`: Read `agent_network_description` and identify the impacted agents (explicitly named agents, newly added agents, and agents whose responsibilities changed).
-Update instructions for these impacted agents. If the user provides the exact instructions, use them directly. After applying the requested modifications, perform a final check by calling `get_agent_network_definition` and create instructions for any agents that still lack them.
-Do not rewrite unaffected agents except when they lack instructions or the user explicitly requests broader edits. Call `set_agent_instructions_tool` once per impacted agent and once for any agent authored during the final sweep.
-
-Writing requirements (apply to every instruction you set):
-- Ensure that each and every non-function agent has the instructions.
-- Make instructions clear, comprehensive, and specific to the single agent’s scope of responsibilities.
-- Provide step-by-step guidance focused on tasks this agent performs; avoid generic platitudes.
-- Do NOT mention other agents, up-chains, or down-chains; keep the text scoped to this agent only.
-- Align with the company’s cultural values and business objectives.
-- Output plain text (no formatting characters) and wrap lines at ~120 characters.
+Call `instructions_writer` to update instructions for these impacted agents. If the user provides the exact instructions, use them directly. After applying the requested modifications, perform a final check by calling `get_agent_network_definition` and call `instructions_writer` for any agents that still lack them.
+Do not edit unaffected agents except when they lack instructions or the user explicitly requests broader edits. Call `instructions_writer` once per impacted agent.
 
 Guardrails:
 - Only create or edit `instructions` for agents that have an `instructions` field in the network definition.
+- Ensure that each and every agent with `instructions` field has the instructions.
 - Skip agents that are not referenced/affected by the current request.
 - Do not modify instructions if they are semantically unchanged.
 - Be surgical: avoid network-wide rewrites during `modify`; touch only what the request necessitates.
@@ -88,7 +80,7 @@ Guardrails:
                     "sly_data": ["agent_network_definition"]
                 }
             },
-            "tools": ["get_agent_network_definition", "set_agent_instructions_tool"],
+            "tools": ["get_agent_network_definition", "instructions_writer"],
             "middleware": [
                 {
                     "class": "middleware.agent_network_designer.validation.agent_network_instructions_validation_middleware.AgentNetworkInstructionsValidationMiddleware",
@@ -97,6 +89,47 @@ Guardrails:
                     }
                 }
             ]
+        },
+
+        {
+            "name": "instructions_writer",
+            "instructions": """
+You are an instructions writer for agents in an agent network. Your job is to create clear, concise, and actionable instructions for agents based on the agent network definition and description provided to you.
+If `new_instructions` are provided, use them directly without modification. Otherwise, generate new instructions based on the following guidelines:
+
+**Writing requirements**
+- Make instructions clear, comprehensive, and specific to the agent’s scope of responsibilities.
+- Provide step-by-step guidance focused on tasks this agent performs; avoid generic platitudes.
+- Do NOT mention other agents, up-chains, or down-chains; keep the text scoped to this agent only.
+- Align with the company’s cultural values and business objectives.
+- Output plain text (no formatting characters) and wrap lines at ~120 characters.    
+"""
+            "function": {
+                "description": "Write the instructions for a specified agent in an agent network."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "agent_name": {
+                            "type": "string",
+                            "description": "the name of the agent whose instruction is being set."
+                        },
+                        "agent_network_description": {
+                            "type": "string",
+                            "description": "the description of the agent network."
+                        },
+                        "agent_network_definition": {
+                            "type": "string",
+                            "description": "the definition or graph of the agent network, which may include the agent's current instructions."
+                        },
+                        // "new_instructions": {
+                        //     "type": "string",
+                        //     "description": "the new instructions for the agent. This is an optional field. If provided, use these instructions directly without modification."
+                        // },
+                    },
+                    "required": ["agent_name", "agent_network_description", "agent_network_definition"]
+                }
+            },
+            "tools": ["set_agent_instructions_tool"],
         },
 
         {

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -53,7 +53,7 @@
         # This is a support network for agent_network_designer
         # We want it served up, but not listed as a public agent network
         "serve": true,
-        "public": false
+        "public": true
     },
     "agent_network_query_generator.hocon": { 
         # This is a support network for agent_network_designer

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -53,7 +53,7 @@
         # This is a support network for agent_network_designer
         # We want it served up, but not listed as a public agent network
         "serve": true,
-        "public": true
+        "public": false
     },
     "agent_network_query_generator.hocon": { 
         # This is a support network for agent_network_designer


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Summary

- Introduces a dedicated `instructions_writer` agent to the `agent_network_instructions_editor` network, decoupling instruction authoring from the top-level editor agent.
- The editor now delegates per-agent instruction writing to `instructions_writer` instead of doing it inline, keeping the editor's role focused on orchestration.
- `set_agent_instructions` now returns a human-readable completion message instead of the full network definition, reducing noise in the response chain. This is to remove the redundancy since the agent gets the network definition from  the `get_agent_network_definition` anyway.

## Changes

- `registries/agent_network_instructions_editor.hocon`: Added `instructions_writer` agent with its own tools (`get_agent_network_definition`, `set_agent_instructions_tool`), function schema, and writing guidelines. Updated editor instructions to call `instructions_writer` per agent instead of embedding authoring logic directly.
- `coded_tools/agent_network_instructions_editor/set_agent_instructions.py`: Changed return value to a confirmation string rather than the full network definition.

## Fixes 
#700, #827 

## Next steps
Change `get_agent_network_definition` from tool to middleware. It is more efficient to inject the network definition since each agent has to call this tool.

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
