### PR TITLE
Fix test workflow for fork PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "**"
   pull_request:
-    types: [opened, reopened]
     branches:
       - main
 
@@ -15,6 +14,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    concurrency:
+      group: test-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true
     if: >
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' && github.base_ref == 'main')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    concurrency:
-      group: test-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: true
     if: >
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main')
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.repository)
     container:
       image: python:3.13-slim
 


### PR DESCRIPTION
## Description

Fixes the `Test` workflow not running on fork PRs after new commits are pushed, which causes the required `test` check to block the PR indefinitely (as seen in #817).

In `07113f3`, we added `types: [opened, reopened]` to the `pull_request` trigger to prevent duplicate test runs — when a branch with an open PR is pushed, GitHub fires both a `push` event and a `pull_request` `synchronize` event, producing two identical runs.

However, fork PRs never fire a `push` event in the base repo. The only available trigger is `pull_request`, and with `synchronize` excluded, any commits pushed to a fork PR after it was opened produced no test run at all.

This PR:
1. **Removes the explicit `types`** to restore the default (`opened`, `synchronize`, `reopened`)
2. **Changes the `if` condition** so the `pull_request`-triggered job only runs for fork PRs (`head.repo.full_name != github.repository`), since internal branches are already covered by the `push` trigger

This avoids duplicates without using a concurrency group (which would cancel one run and leave a red mark in the GitHub PR checks UI).

## Impact

- Fork PRs will no longer get stuck waiting for the `test` required check after new commits are pushed
- Internal PRs continue to avoid duplicate test runs — `push` covers them, `pull_request` is skipped
- No cancelled runs cluttering the PR checks UI

### Reviewer notes
- Verify the branch protection required check `test` is satisfied by `Test / test (push)` for internal PRs (not just `Test / test (pull_request)`)
- The `base_ref == 'main'` guard was removed from the `if` condition; this is safe because the `pull_request` trigger already has `branches: [main]`
- When the `if` condition skips the job for an internal PR's `pull_request` event, confirm this doesn't produce a "skipped" status that looks odd in the UI

## Type of Change

- [x] Bug fix

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/1eb0ff7699a7452f862a0fe9b76a7210
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
