### PR TITLE
Replace get_agent_network_definition tool with middleware injection for agent network instructions editor and writer

### DIFF
--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -29,6 +29,7 @@ from langchain.agents.middleware.types import ResponseT
 from langchain_core.messages import BaseMessage
 from langchain_core.messages import SystemMessage
 
+from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 
 
@@ -75,9 +76,13 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         :param handler: Handler to execute the model call
         :return: Model response from handler
         """
-        network_def: dict[str, Any] | None = self.sly_data.get(AGENT_NETWORK_DEFINITION)
+        network_def: dict[str, Any] | list[dict[str, Any]] | None = self.sly_data.get(AGENT_NETWORK_DEFINITION)
 
         if network_def:
+            if isinstance(network_def, list):
+                connectivity_dict_converter = ConnectivityDictionaryConverter()
+                network_def = connectivity_dict_converter.to_dict(network_def)
+
             self.logger.debug(
                 ">>>>>>>>>>>>>>>>>>>Injecting Agent Network Definition into System Prompt>>>>>>>>>>>>>>>>>>>"
             )
@@ -85,7 +90,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
             system_message: BaseMessage | None = request.system_message
             if system_message is not None:
-                original_content = system_message.content if isinstance(system_message.content, str) else ""
+                original_content: str = system_message.content if isinstance(system_message.content, str) else ""
                 system_message = SystemMessage(content=f"{original_content}\n\n{definition_prompt}")
             else:
                 system_message = SystemMessage(content=definition_prompt)
@@ -102,4 +107,4 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         :return: Formatted prompt string
         """
         definition_str: str = json.dumps(network_def, indent=2)
-        return f"\n## Current Agent Network Definition\n\n```json\n{definition_str}\n```"
+        return f"## Current Agent Network Definition\n\n```json\n{definition_str}\n```"

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -76,7 +76,9 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         network_def: dict[str, Any] | None = self.sly_data.get(AGENT_NETWORK_DEFINITION)
 
         if network_def:
-            self.logger.debug(">>>>>>>>>>>>>>>>>>>Injecting Agent Network Definition into System Prompt>>>>>>>>>>>>>>>>>>>")
+            self.logger.debug(
+                ">>>>>>>>>>>>>>>>>>>Injecting Agent Network Definition into System Prompt>>>>>>>>>>>>>>>>>>>"
+            )
             definition_prompt: str = self.format_definition_prompt(network_def)
 
             system_message: BaseMessage | None = request.system_message

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -19,6 +19,7 @@ import logging
 from typing import Any
 from typing import Awaitable
 from typing import Callable
+from typing import override
 
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.agents.middleware.types import ContextT
@@ -60,6 +61,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         self.sly_data = sly_data
         self.logger = logging.getLogger(self.__class__.__name__)
 
+    @override
     async def awrap_model_call(
         self,
         request: ModelRequest[ContextT],

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -1,0 +1,101 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import json
+import logging
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware.types import ContextT
+from langchain.agents.middleware.types import ModelRequest
+from langchain.agents.middleware.types import ModelResponse
+from langchain.agents.middleware.types import ResponseT
+from langchain_core.messages import BaseMessage
+from langchain_core.messages import SystemMessage
+
+from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
+
+
+class AgentNetworkDefinitionMiddleware(AgentMiddleware):
+    """
+    Middleware that reads the agent network definition from sly_data and injects it
+    into the system prompt before each model call.
+
+    This allows the LLM to reason about the current agent network structure without
+    requiring it to be passed explicitly through the chat stream.
+    """
+
+    def __init__(self, sly_data: dict[str, Any]) -> None:
+        """
+        Initialize agent network definition middleware.
+
+        :param sly_data: A dictionary whose keys are defined by the agent hierarchy,
+                but whose values are meant to be kept out of the chat stream.
+
+                This dictionary is largely to be treated as read-only.
+                It is possible to add key/value pairs to this dict that do not
+                yet exist as a bulletin board, as long as the responsibility
+                for which coded_tool publishes new entries is well understood
+                by the agent chain implementation and the coded_tool implementation
+                adding the data is not invoke()-ed more than once.
+
+                Keys expected for this implementation are:
+                    "agent_network_definition": an outline of an agent network
+        """
+        self.sly_data = sly_data
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        """
+        Inject the agent network definition from sly_data into the system prompt
+        before each model call.
+
+        :param request: Model request containing messages and state
+        :param handler: Handler to execute the model call
+        :return: Model response from handler
+        """
+        network_def: dict[str, Any] | None = self.sly_data.get(AGENT_NETWORK_DEFINITION)
+
+        if network_def:
+            self.logger.debug(">>>>>>>>>>>>>>>>>>>Injecting Agent Network Definition into System Prompt>>>>>>>>>>>>>>>>>>>")
+            definition_prompt: str = self.format_definition_prompt(network_def)
+
+            system_message: BaseMessage | None = request.system_message
+            if system_message is not None:
+                original_content = system_message.content if isinstance(system_message.content, str) else ""
+                system_message = SystemMessage(content=f"{original_content}\n\n{definition_prompt}")
+            else:
+                system_message = SystemMessage(content=definition_prompt)
+
+            return await handler(request.override(system_message=system_message))
+
+        return await handler(request)
+
+    def format_definition_prompt(self, network_def: dict[str, Any]) -> str:
+        """
+        Format the agent network definition as a system prompt section.
+
+        :param network_def: The agent network definition dictionary
+        :return: Formatted prompt string
+        """
+        definition_str: str = json.dumps(network_def, indent=2)
+        return f"\n## Current Agent Network Definition\n\n```json\n{definition_str}\n```"

--- a/registries/agent_network_instructions_editor.hocon
+++ b/registries/agent_network_instructions_editor.hocon
@@ -58,8 +58,6 @@
 You are responsible for generating and editing instructions of agents based on the agent network description and definition.
 Only answer inquiries that are directly within your area of expertise. Do not try to help for other matters. Do not mention what you can NOT do. Only mention what you can do.
 
-Always start by calling `get_agent_network_definition` to load the current network and existing instructions.
-
 **Only create or edit `instructions` for agents that have an `instructions` field in the network definition. These are non-function agents.**
 
 Behavior by mode:
@@ -80,8 +78,14 @@ Guardrails:
                     "sly_data": ["agent_network_definition"]
                 }
             },
-            "tools": ["get_agent_network_definition", "instructions_writer"],
+            "tools": ["instructions_writer"],
             "middleware": [
+                {
+                    "class": "middleware.agent_network_designer.agent_network_definition_middleware.AgentNetworkDefinitionMiddleware",
+                    "args": {
+                        "sly_data": true
+                    }
+                },
                 {
                     "class": "middleware.agent_network_designer.validation.agent_network_instructions_validation_middleware.AgentNetworkInstructionsValidationMiddleware",
                     "args": {
@@ -98,7 +102,6 @@ You are an instructions writer for agents in an agent network. Your job is to cr
 If `new_instructions` are provided, use them directly without modification. Otherwise, generate new instructions based on the following guidelines:
 
 **Writing requirements**
-- Always start by calling `get_agent_network_definition` to load the current network and existing instructions.
 - Make instructions clear, comprehensive, and specific to the agent’s scope of responsibilities.
 - Provide step-by-step guidance focused on tasks this agent performs; avoid generic platitudes.
 - Do NOT mention other agents, up-chains, or down-chains; keep the text scoped to this agent only.
@@ -126,7 +129,15 @@ If `new_instructions` are provided, use them directly without modification. Othe
                     "required": ["agent_name", "agent_network_description"]
                 }
             },
-            "tools": ["get_agent_network_definition", "set_agent_instructions_tool"],
+            "tools": ["set_agent_instructions_tool"],
+            "middleware": [
+                {
+                    "class": "middleware.agent_network_designer.agent_network_definition_middleware.AgentNetworkDefinitionMiddleware",
+                    "args": {
+                        "sly_data": true
+                    }
+                }
+            ]
         },
 
         {
@@ -149,15 +160,7 @@ If `new_instructions` are provided, use them directly without modification. Othe
                     "required": ["agent_name", "new_instructions"]
                 }
             },
-        },
-
-        {
-            "name": "get_agent_network_definition",
-            "class": "coded_tools.get_agent_network_definition.GetAgentNetworkDefinition",
-            "function": {
-                "description": "Get the agent network definition."
-            }
-        },
+        }
 
     ]
 }

--- a/registries/agent_network_instructions_editor.hocon
+++ b/registries/agent_network_instructions_editor.hocon
@@ -63,7 +63,7 @@ Only answer inquiries that are directly within your area of expertise. Do not tr
 Behavior by mode:
 - `create`: Generate initial instructions for every non-function agent in the network. Call `instructions_writer` once for each of these agents.
 - `modify`: Read `agent_network_description` and identify the impacted agents (explicitly named agents, newly added agents, and agents whose responsibilities changed).
-Call `instructions_writer` to update instructions for these impacted agents. If the user provides the exact instructions, use them directly. After applying the requested modifications, perform a final check by calling `get_agent_network_definition` and call `instructions_writer` for any agents that still lack them.
+Call `instructions_writer` to update instructions for these impacted agents. If the user provides the exact instructions, use them directly.
 Do not edit unaffected agents except when they lack instructions or the user explicitly requests broader edits. Call `instructions_writer` once per impacted agent.
 
 Guardrails:


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

- Add `AgentNetworkDefinitionMiddleware` that reads `agent_network_definition` from `sly_data` and injects it into the system prompt via `awrap_model_call`, eliminating the need for agents to explicitly call `get_agent_network_definition` as a tool step.
- Add `middleware/agent_network_designer/agent_network_definition_middleware.py`
- Wire the new middleware into `agent_network_instructions_editor.hocon` for both the instructions editor and instructions writer agents
- Remove `get_agent_network_definition` tool and its explicit call instructions from both agents

Fixes #827 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
