### PR TITLE
Modify the prompt for instructions editor

### DIFF
--- a/registries/agent_network_instructions_editor.hocon
+++ b/registries/agent_network_instructions_editor.hocon
@@ -63,8 +63,8 @@ Only answer inquiries that are directly within your area of expertise. Do not tr
 Behavior by mode:
 - `create`: Generate initial instructions for every non-function agent in the network. Call `instructions_writer` once for each of these agents.
 - `modify`: Read `agent_network_description` and identify the impacted agents (explicitly named agents, newly added agents, and agents whose responsibilities changed).
-Call `instructions_writer` to update instructions for these impacted agents. If the user provides the exact instructions, use them directly.
-Do not edit unaffected agents except when they lack instructions or the user explicitly requests broader edits. Call `instructions_writer` once per impacted agent.
+            Call `instructions_writer` to update instructions for these impacted agents.
+            Do not edit unaffected agents except when they lack instructions or the user explicitly requests broader edits. Call `instructions_writer` once per impacted agent.
 
 Guardrails:
 - Only create or edit `instructions` for agents that have an `instructions` field in the network definition.
@@ -98,15 +98,19 @@ Guardrails:
         {
             "name": "instructions_writer",
             "instructions": """
-You are an instructions writer for agents in an agent network. Your job is to create clear, concise, and actionable instructions for agents based on the agent network definition and description provided to you.
-If `new_instructions` are provided, use them directly without modification. Otherwise, generate new instructions based on the following guidelines:
+You are an instructions writer for agents in an agent network.
+Your job is to create clear, concise, and actionable instructions for agents based on the agent network definition and description provided to you.
+Generate new instructions based on the following guidelines:
 
 **Writing requirements**
-- Make instructions clear, comprehensive, and specific to the agent’s scope of responsibilities.
-- Provide step-by-step guidance focused on tasks this agent performs; avoid generic platitudes.
+- Only write instructions for the specified agent. Do not write instructions for any other agents, even if they are mentioned in the description or network definition.
+- Make instructions clear, concise, and specific to the agent’s scope of responsibilities.
 - Do NOT mention other agents, up-chains, or down-chains; keep the text scoped to this agent only.
 - Align with the company’s cultural values and business objectives.
-- Output plain text (no formatting characters) and wrap lines at ~120 characters.    
+- Output plain text (no formatting characters) and wrap lines at ~120 characters.
+
+**Response format**
+Always respond with "Instructions for <agent_name> has been set." after successfully setting the instructions for the agent.
 """
             "function": {
                 "description": "Write the instructions for a specified agent in an agent network."
@@ -120,10 +124,6 @@ If `new_instructions` are provided, use them directly without modification. Othe
                         "agent_network_description": {
                             "type": "string",
                             "description": "the description of the agent network or a clear description of the change you want to make to the existing instructions of the agent."
-                        },
-                        "new_instructions": {
-                            "type": "string",
-                            "description": "the new instructions for the agent. This is an optional field. Only use this field if the instructions are explicitly provided by the user."
                         },
                     },
                     "required": ["agent_name", "agent_network_description"]

--- a/registries/agent_network_instructions_editor.hocon
+++ b/registries/agent_network_instructions_editor.hocon
@@ -110,7 +110,7 @@ Generate new instructions based on the following guidelines:
 - Output plain text (no formatting characters) and wrap lines at ~120 characters.
 
 **Response format**
-Always respond with "Instructions for <agent_name> has been set." after successfully setting the instructions for the agent.
+Always respond with "Instructions for <agent_name> have been set." after successfully setting the instructions for the agent.
 """
             "function": {
                 "description": "Write the instructions for a specified agent in an agent network."


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

The `instructions_editor.hocon` defines the following agent pipeline:

```
instructions_editor (frontman) → instructions_writer (branch) → set_agent_instructions_tool (coded tool)
```

The `instructions_editor` is responsible only for assigning an agent name to `instructions_writer`, which then independently generates the instructions for that agent. Two bugs were found in `instructions_writer` that undermined this design:

### Bug 1: Redundant instruction passthrough argument

`instructions_writer` accepted an argument that allowed `instructions_editor` to pass instructions directly. While intended for cases where a user wants to provide specific instructions for a particular agent, in practice `instructions_editor` was using this argument to write the instructions itself and hand them off to the writer — defeating the purpose of having a dedicated writer agent.

**Fix:** Removed the argument. The `instructions_editor` now strictly assigns agent names. Users can still guide the content of instructions through natural conversation.

### Bug 2: Writer generating instructions for multiple agents

Because `agent_network_definition` is injected into the writer for context, the writer would sometimes generate instructions for multiple agents instead of limiting itself to the one assigned.

**Fix:** Added additional prompt constraints to enforce single-agent scope per invocation.

Fixes #827

---

## Performance Impact

Average test time for the agent network designer, measured across 4 sample queries × 10 runs each:

| Queries used |
|---|
| "Create a network for UNHCR back-office" |
| "Design an agent network for a hospital management system" |
| "Build a multi-agent system for e-commerce customer support" |
| "Create an agent network for Santa's Workshop" |

| Version | Avg. Time (s) |
|---|---|
| Instructions editor only (baseline) | 233.49 |
| + Instructions writer | 202.50 |
| + This PR | **170.65** |

This PR reduces average test time by **~27% relative to baseline** and **~16% relative to the previous writer implementation**.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
