### PR TITLE
Use agent network definition middleware instead of tool in agent_network_query_generator

### DIFF
--- a/registries/agent_network_query_generator.hocon
+++ b/registries/agent_network_query_generator.hocon
@@ -52,7 +52,6 @@
 You generate example queries that the created agent network can handle.
 Only answer inquiries that are directly within your area of expertise. Do not try to help for other matters. Do not mention what you can NOT do. Only mention what you can do.
 
-First get the agent network definition using `get_agent_network_definition`.
 Ensure the queries align with the agents' capabilities.
 Provide a diverse range of queries to illustrate the network's functions.
 The queries should show how multiple sub networks might contribute to a consolidated response from the top agent.
@@ -66,14 +65,15 @@ Make some of the examples transactional. If not stated, return no more than 3-4 
                     "sly_data": ["agent_network_definition", "agent_network_queries"]
                 }
             },
-            "tools": ["get_agent_network_definition", "set_sample_queries_tool"]
-        },
-        {
-            "name": "get_agent_network_definition",
-            "class": "coded_tools.get_agent_network_definition.GetAgentNetworkDefinition",
-            "function": {
-                "description": "Get the agent network definition."
-            }
+            "tools": ["set_sample_queries_tool"],
+            "middleware": [
+                {
+                    "class": "middleware.agent_network_designer.agent_network_definition_middleware.AgentNetworkDefinitionMiddleware",
+                    "args": {
+                        "sly_data": true
+                    }
+                }
+            ]
         },
         {
             "name": "set_sample_queries_tool",


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

The agent is required to call the tool to get `agent_network_definition` so do it in middleware so that we do not have to worry that the model might not call the tool.

Fixes #857 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
