### PR TITLE
Use agent network definition middleware instead of tool in agent_network_editor

### DIFF
--- a/coded_tools/agent_network_editor/create_network.py
+++ b/coded_tools/agent_network_editor/create_network.py
@@ -99,4 +99,4 @@ class CreateNetwork(CodedTool):
         await ProgressHandler.report_progress(args, sly_data[AGENT_NETWORK_DEFINITION], sly_data[AGENT_NETWORK_NAME])
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
-        return sly_data[AGENT_NETWORK_DEFINITION]
+        return f"Successfully created agent network definition for {agent_network_name}."

--- a/coded_tools/agent_network_editor/create_network.py
+++ b/coded_tools/agent_network_editor/create_network.py
@@ -64,7 +64,7 @@ class CreateNetwork(CodedTool):
 
         :return:
             In case of successful execution:
-                the agent network definition as a dictionary.
+                a text string confirming successful creation of the agent network definition.
             otherwise:
                 a text string of an error message in the format:
                 "Error: <error message>"

--- a/coded_tools/agent_network_editor/remove_agent.py
+++ b/coded_tools/agent_network_editor/remove_agent.py
@@ -58,7 +58,7 @@ class RemoveAgent(CodedTool):
 
         :return:
             In case of successful execution:
-                the agent network definition as a dictionary.
+                a text string confirming successful removal of the agent from the agent network definition.
             otherwise:
                 a text string of an error message in the format:
                 "Error: <error message>"

--- a/coded_tools/agent_network_editor/remove_agent.py
+++ b/coded_tools/agent_network_editor/remove_agent.py
@@ -83,4 +83,4 @@ class RemoveAgent(CodedTool):
         await ProgressHandler.report_progress(args, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
-        return network_def
+        return f"Successfully removed agent {the_agent_name} from the agent network definition."

--- a/coded_tools/agent_network_editor/update_agent.py
+++ b/coded_tools/agent_network_editor/update_agent.py
@@ -60,7 +60,7 @@ class UpdateAgent(CodedTool):
 
         :return:
              In case of successful execution:
-                 the agent network definition as a dictionary.
+                 a text string confirming successful update of the agent in the agent network definition.
              otherwise:
                  a text string of an error message in the format:
                  "Error: <error message>"

--- a/coded_tools/agent_network_editor/update_agent.py
+++ b/coded_tools/agent_network_editor/update_agent.py
@@ -90,4 +90,4 @@ class UpdateAgent(CodedTool):
         await ProgressHandler.report_progress(args, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
-        return network_def
+        return f"Successfully updated down-chains for {the_agent_name} in the agent network definition."

--- a/registries/agent_network_editor.hocon
+++ b/registries/agent_network_editor.hocon
@@ -98,7 +98,8 @@ When adding tools to the network, follow this priority order depending on which 
   - Always call `create_new_network` first.  
   - In the resulting network, mark `is_tool_list[i] = true` only if `agent_names[i]` is a toolbox tool.
 - **Modify mode (`mode=modify`)**  
-  - Always call `get_agent_network` first.
+  - DO NOT call `create_new_network`.
+  - Call tools necessary to make the specified modifications to the existing network. This may include adding new agents, removing agents, or updating relationships between agents.
 
 - **Adding agents**: Use `add_agent_to_network`.  
   - Set `is_tool = true` only if the `agent_name` comes from the toolbox.  
@@ -182,12 +183,17 @@ Think of this as building or refining a hierarchical organizational chart. Each 
                 "add_agent_to_network",
                 "remove_agent_from_network",
                 "update_agent_in_network",
-                "get_agent_network_definition",
                 "get_mcp_tool",
                 "get_subnetwork",
                 "get_toolbox",
             ],
             "middleware": [
+                {
+                    "class": "middleware.agent_network_designer.agent_network_definition_middleware.AgentNetworkDefinitionMiddleware",
+                    "args": {
+                        "sly_data": true
+                    }
+                },
                 {
                     "class": "middleware.agent_network_designer.validation.agent_network_structure_validation_middleware.AgentNetworkStructureValidationMiddleware",
                     "args": {
@@ -287,14 +293,6 @@ Think of this as building or refining a hierarchical organizational chart. Each 
                     },
                     "required": ["agent_name", "new_down_chains"]
                 }
-            }
-        },
-
-        {
-            "name": "get_agent_network_definition",
-            "class": "coded_tools.get_agent_network_definition.GetAgentNetworkDefinition",
-            "function": {
-                "description": "Get the agent network definition."
             }
         },
 


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

The agent is required to call the tool to get agent_network_definition so do it in middleware so that we do not have to worry that the model might not call the tool.

Fixes #858

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
