### PR TITLE
Make toolbox, subnetwork, mcp_tool optional in agent_network_editor schema

### DIFF
--- a/registries/agent_network_editor.hocon
+++ b/registries/agent_network_editor.hocon
@@ -63,7 +63,7 @@
                             "description": "Indicates whether to use MCP tools (default: true)"
                         }
                     },
-                    "required": ["agent_network_description", "mode", "toolbox", "subnetwork", "mcp_tool"]
+                    "required": ["agent_network_description", "mode"]
                 }
             },
             "instructions": """


### PR DESCRIPTION
## Description

`agent_network_editor`'s function schema listed `toolbox`, `subnetwork`, and `mcp_tool` as required fields, even though the agent's own instructions state these default to `true`. Callers that omit them receive a pydantic validation error and the agent stops.

## Impact

`agent_network_editor` no longer rejects calls that omit the three boolean flags. Behaviour is unchanged when they are provided.

Before (validation error when boolean flags omitted):
3 validation errors for parameters
toolbox  field required (type=value_error.missing)
subnetwork  field required (type=value_error.missing)
mcp_tool  field required (type=value_error.missing)

After (call succeeds with only required fields):
{"agent_network_description": "...", "mode": "create"}
→ agent_network_editor proceeds normally, defaulting toolbox/subnetwork/mcp_tool to true

Note: the original PR also modified the error message in `get_agent_network_definition`. Per maintainer feedback (#869 removes that tool entirely in favor of middleware injection), that change has been dropped and this PR is now scoped to just the schema fix.
 

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool
 
## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt`
