### PR TITLE
Change tool response of agent network editor back to network definition

### DIFF
--- a/coded_tools/agent_network_editor/create_network.py
+++ b/coded_tools/agent_network_editor/create_network.py
@@ -99,4 +99,4 @@ class CreateNetwork(CodedTool):
         await ProgressHandler.report_progress(args, sly_data[AGENT_NETWORK_DEFINITION], sly_data[AGENT_NETWORK_NAME])
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
-        return f"Successfully created agent network definition for {agent_network_name}."
+        return sly_data[AGENT_NETWORK_DEFINITION]

--- a/coded_tools/agent_network_editor/remove_agent.py
+++ b/coded_tools/agent_network_editor/remove_agent.py
@@ -83,4 +83,4 @@ class RemoveAgent(CodedTool):
         await ProgressHandler.report_progress(args, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
-        return f"Successfully removed agent {the_agent_name} from the agent network definition."
+        return network_def

--- a/coded_tools/agent_network_editor/update_agent.py
+++ b/coded_tools/agent_network_editor/update_agent.py
@@ -90,4 +90,4 @@ class UpdateAgent(CodedTool):
         await ProgressHandler.report_progress(args, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
-        return f"Successfully updated down-chains for {the_agent_name} in the agent network definition."
+        return network_def


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

nsflow reads from tool response instead of progress report.
This PR changes the response back to network definition so that nsflow can show the progress.
Should be revert when the issue is fixed.

Temporary Fixes https://github.com/cognizant-ai-lab/nsflow/issues/186

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
