### PR TITLE
Bump build-common slack-notify to 1.0.3 and drop jq install

### DIFF
--- a/.github/workflows/agent_network_designer.yml
+++ b/.github/workflows/agent_network_designer.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          apt-get update && apt-get install --yes make curl netcat-openbsd procps net-tools jq
+          apt-get update && apt-get install --yes make curl netcat-openbsd procps net-tools
           make install
 
       - name: Show installed packages
@@ -58,8 +58,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.2
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@2cfeaf2a0356ce46aff80ae2a2983fe68d47bf4f
+        # 1.0.3
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@a5d90457ea6e44b8f24f878755f77c00216e2947
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

Consumes [build-common 1.0.3](https://github.com/cognizant-ai-lab/build-common/releases/tag/1.0.3), which replaces the bash + `jq` implementation of the `slack-notify` composite action with a pure-Python implementation (see [build-common PR #15](https://github.com/cognizant-ai-lab/build-common/pull/15)).

Two changes to `.github/workflows/agent_network_designer.yml`:

1. Bump the `slack-notify` pin from `1.0.2` (`2cfeaf2a`) to `1.0.3` (`a5d90457`).
2. Drop `jq` from the `apt-get install` line in the "Install dependencies" step. `jq` was added in commit [`372101ba`](https://github.com/cognizant-ai-lab/neuro-san-studio/commit/372101ba) *("Install jq for build-common slack-notify payload build")* specifically as a workaround for the old bash implementation of `slack-notify`, which shelled out to `jq` — a binary not present in the `python:3.13-slim` container this job runs in. The new Python `slack-notify` uses `json.dumps` from the stdlib, so `jq` is no longer needed.

## Impact

- The `Agent Network Designer Tests` workflow no longer installs `jq` on each run, trimming a few seconds off the `apt-get install` step.
- The next run of that workflow (either the daily `0 12 * * *` cron or a manual `workflow_dispatch`) will be the first real-world exercise of the Python-based `slack-notify` from this repo.

## Type of Change

- [x] Dependency upgrade
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally — *N/A; pure workflow-metadata change, the workflow itself is cron/dispatch-triggered and will not run on this PR's CI.*
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt`

## Notes for the reviewer

- **SHA verification:** `a5d90457ea6e44b8f24f878755f77c00216e2947` is the commit SHA of the `1.0.3` tag in `cognizant-ai-lab/build-common`. Confirm via `git ls-remote --tags https://github.com/cognizant-ai-lab/build-common.git 1.0.3` if you want to double-check.
- **No PR-time verification possible.** The `Agent Network Designer Tests` workflow triggers only on `schedule:` and `workflow_dispatch:` — it will *not* run on this PR. Recommend a manual `workflow_dispatch` run on this branch before merging to confirm both (a) the job installs cleanly without `jq`, and (b) the Slack notification still renders correctly end-to-end.
- **jq scope:** `jq` was only used by the deleted build-common bash script; it is not referenced elsewhere in this workflow or in `build_scripts/server_start.sh`. Grep for `\bjq\b` in the repo confirms no other consumer (the only other match is a Jira JQL docs comment in `toolbox/toolbox_info.hocon`).
- **First real-world exercise of the Python slack-notify.** If the new implementation regressed against the old bash+jq output in some subtle way that unit tests didn't catch, it will show up here as a garbled Slack card on the next nightly run rather than a hard failure.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/cca55dfe84544c048be5e625acb0f731
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
