### PR TITLE
Add target to run agent network designer integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,19 @@ test-integration: install
 	export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5 && \
 	pytest -s -m "integration" --timer-top-n 100
 
+# Test the Agent Network Designer (AND)
+test-designer: install
+	# Start the neuro-san server
+	./build_scripts/server_start.sh
+
+	# Run the Agent Network Designer integration tests
+	@. venv/bin/activate && \
+	export PYTHONPATH=`pwd` && \
+	export AGENT_TOOL_PATH=coded_tools/ && \
+	export AGENT_MANIFEST_FILE=registries/manifest.hocon && \
+	export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5 && \
+	pytest --capture=no --verbose -m "integration_agent_network_designer" --timer-top-n 100
+
 help: ## Show this help message and exit
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test-integration: install
 # Test the Agent Network Designer (AND)
 test-designer: install
 	# Start the neuro-san server
-	./build_scripts/server_start.sh
+	export NEURO_SAN_SERVER_HTTP_PORT=8080 && ./build_scripts/server_start.sh
 
 	# Run the Agent Network Designer integration tests
 	@. venv/bin/activate && \

--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,17 @@ test-integration: install
 
 # Test the Agent Network Designer (AND)
 test-designer: install
-	# Start the neuro-san server
-	export NEURO_SAN_SERVER_HTTP_PORT=8080 && ./build_scripts/server_start.sh
-
-	# Run the Agent Network Designer integration tests
 	@. venv/bin/activate && \
+	cleanup() { \
+		if [ -f server.pid ]; then \
+			kill "$$(cat server.pid)" 2>/dev/null || true; \
+			rm -f server.pid; \
+		fi; \
+	}; \
+	trap cleanup EXIT; \
+	echo "# Start the neuro-san server" && \
+	export NEURO_SAN_SERVER_HTTP_PORT=8080 && ./build_scripts/server_start.sh && \
+	echo "# Run the Agent Network Designer integration tests" && \
 	export PYTHONPATH=`pwd` && \
 	export AGENT_TOOL_PATH=coded_tools/ && \
 	export AGENT_MANIFEST_FILE=registries/manifest.hocon && \


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Added a target to the Makefile to easily run the Agent Network Designer integration tests:

## Impact

Developers can now run the tests in 1 command:
```
make test-designer
```

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
