### PR TITLE
normalize connectivity list form in AND validator and persistence middlewares

### DIFF
--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -118,11 +118,19 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         :param runtime: Runtime context
         :return: Dict with error message and jump directive, or None if valid
         """
-        network_def: dict[str, Any] = self.sly_data.get(AGENT_NETWORK_DEFINITION)
+        network_def: dict[str, Any] | list[dict[str, Any]] | None = self.sly_data.get(AGENT_NETWORK_DEFINITION)
         if not network_def:
             return self._error_response(
                 "No agent network found. Please create a new agent network using `/agent_network_editor` tool"
             )
+
+        # The network definition may arrive in connectivity (list) format — e.g. when the
+        # previous turn's output was round-tripped through sly_data. Normalize to the
+        # internal dict format before validating, and persist the normalized form so
+        # downstream middleware/tools see a consistent shape.
+        if isinstance(network_def, list):
+            network_def = ConnectivityDictionaryConverter().to_dict(network_def)
+            self.sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
         error_list: list[str] = await self._validate_network(network_def)
         if error_list:

--- a/middleware/agent_network_designer/validation/agent_network_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_validation_middleware.py
@@ -24,6 +24,7 @@ from langchain.agents.middleware.types import hook_config
 from langchain_core.messages import HumanMessage
 from langgraph.runtime import Runtime
 
+from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 
 
@@ -95,9 +96,15 @@ class AgentNetworkValidationMiddleware(AgentMiddleware):
         :param runtime: Runtime context
         :return: Dict with error message and jump directive, or None if valid
         """
-        network_def: dict[str, Any] = self.sly_data.get(AGENT_NETWORK_DEFINITION)
+        network_def: dict[str, Any] | list[dict[str, Any]] | None = self.sly_data.get(AGENT_NETWORK_DEFINITION)
         if not network_def:
             return {"messages": [HumanMessage(self.no_network_error_message())], "jump_to": "model"}
+
+        # Normalize connectivity (list) format to internal dict format before validating.
+        # Mirrors AgentNetworkDefinitionMiddleware's handling.
+        if isinstance(network_def, list):
+            network_def = ConnectivityDictionaryConverter().to_dict(network_def)
+            self.sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
         label: str = self.validation_label()
         self.logger.info(">>>>>>>>>>>>>>>>>>>Validate Agent Network %s>>>>>>>>>>>>>>>>>>", label)


### PR DESCRIPTION
## Description
Fix AttributeError: 'list' object has no attribute 'keys' raised by the network validator chain when sly_data["agent_network_definition"] is in connectivity (list) form.

AgentNetworkDefinitionMiddleware.awrap_model_call already normalizes a list-shaped definition to the internal dict form before injecting it into the system prompt. The sibling AgentNetworkPersistenceMiddleware.aafter_agent and the AgentNetworkValidationMiddleware base class (used by the Structure and Instructions validators) did not — so when sly_data carries a list, the downstream validator hits name_to_spec.keys() on the list and crashes.

This PR applies the same isinstance(list) → ConnectivityDictionaryConverter().to_dict normalization in both places, and writes the normalized form back to sly_data so downstream middleware and tools see a consistent shape.

##  Impact

- Restores the agent network designer on follow-up messages in an existing session (previously hard-failed with the AttributeError above).
- Behavior for the already-working dict case is unchanged — the new branch only fires when sly_data["agent_network_definition"] is a list.
- Writing the normalized dict back to sly_data means subsequent tools/middleware in the same session no longer need to re-normalize.

Reproducer: start agent_network_designer, let it complete a network (structure + instructions + queries), then send any follow-up message on the same session.

Traceback before the fix:
```
  File ".../middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py", line 127, in
  aafter_agent
      error_list: list[str] = await self._validate_network(network_def)
  File ".../middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py", line
  65, in validate
      StructureNetworkValidator().validate(network_def)
  File ".../neuro_san/internals/validation/network/abstract_network_validator.py", line 47, in validate
      name_to_spec_errors: List[str] = self.validate_name_to_spec_dict(name_to_spec)
  File ".../neuro_san/internals/validation/network/cycles_network_validator.py", line 72, in find_cyclical_agents
      for agent in name_to_spec.keys():
  AttributeError: 'list' object has no attribute 'keys'
```

## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Dependency upgrade
  - [ ] Refactoring / Improvement
  - [ ] Documentation
  - [ ] New agent / tool

  ## Checklist

  - [x] Tested locally
  - [ ] Added/updated tests
  - [ ] Updated relevant documentation
  - [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core
  functionality)

