### PR TITLE
Fix: Error if AGENT_NETWORK_DESIGNER_PROGRESS_STYLE is set to "connectivity"

### DIFF
--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -104,9 +104,8 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             if isinstance(network_def, list):
                 connectivity_dict_converter = ConnectivityDictionaryConverter()
                 network_def = connectivity_dict_converter.to_dict(network_def)
-
-            # Cache the agent network definition in sly_data for subsequent calls within the same session.
-            self.sly_data[AGENT_NETWORK_DEFINITION] = network_def
+                # Cache the agent network definition as dict in sly_data for subsequent calls within the same session.
+                self.sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
             self.logger.debug(
                 ">>>>>>>>>>>>>>>>>>>Injecting Agent Network Definition into System Prompt>>>>>>>>>>>>>>>>>>>"

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -105,6 +105,9 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                 connectivity_dict_converter = ConnectivityDictionaryConverter()
                 network_def = connectivity_dict_converter.to_dict(network_def)
 
+            # Cache the agent network definition in sly_data for subsequent calls within the same session.
+            self.sly_data[AGENT_NETWORK_DEFINITION] = network_def
+
             self.logger.debug(
                 ">>>>>>>>>>>>>>>>>>>Injecting Agent Network Definition into System Prompt>>>>>>>>>>>>>>>>>>>"
             )


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

If `AGENT_NETWORK_DESIGNER_PROGRESS_STYLE` is set to `"connectivity"`, AND will raise AttributeError: 'list' object has no attribute 'keys' when trying to modify the network.

This is because when set to `connectivity`, the `agent_network_definition` is converted to a list format when we persist the network. Thus, the fix is to convert it back to dict format when we first read `agent_network_definition` from the sly data.

See #887 

Fixes #888 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
