### PR TITLE
813 sub task antegen consolidate duplicate documentation

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1732,32 +1732,14 @@ There are two ways to create a test case: automatically with the
 or manually.
 
 ##### Automatic Test Generation
-
-The `agent_network_test_generator` agent network can analyze an existing agent network
-and produce test fixtures automatically. Start the server, open the client, select
-`agent_network_test_generator`, and type a prompt such as:
-
-```text
-Generate test cases for basic/coffee_finder_advanced
-```
-
-You can control how many scenarios are generated with the `test_level` parameter:
-
-```text
-Generate test cases for basic/coffee_finder_advanced with minimum coverage
-Generate test cases for basic/music_nerd_pro with max coverage
-```
-
-| Level     | Scenarios | Description                                                        |
-|-----------|-----------|--------------------------------------------------------------------|
-| `minimum` | 2--3      | One core happy-path and one critical edge case.                    |
-| `normal`  | 5--7      | Happy paths, edge cases, and at least one error/boundary scenario. |
-| `max`     | 10--15    | Exhaustive coverage of all capabilities and edge cases.            |
-
-The generator saves fixtures under `tests/fixtures/<agent_name>/`. Review the generated
-files before committing — you may need to adjust `gist` criteria, `keywords`, `value`
-checks, or `sly_data` values. See
-[Agent Network Test Generator](agent_network_test_generator.md) for full details.
+ 
+The `agent_network_test_generator` agent network can analyze an existing network and
+produce test fixtures automatically. Start the server, select
+`agent_network_test_generator`, and provide a prompt like
+`Generate test cases for basic/coffee_finder_advanced`.
+ 
+For test levels, example prompts, and review tips, see the full
+[Agent Network Test Generator](agent_network_test_generator.md) documentation.
 
 ##### Manual creation
 
@@ -1770,30 +1752,10 @@ in the neuro-san repository.
 For existing examples, look at the fixtures under `tests/fixtures/` in this repository.
 
 ##### Register the fixture
-
+ 
 Generated and manually created fixtures are **not** automatically picked up by CI.
-To include a fixture in the integration test suite, add its path to the appropriate
-`@parameterized.expand` list in
-[test\_integration\_test\_hocons.py](../tests/integration/test_integration_test_hocons.py):
-
-```python
-@parameterized.expand(
-    DynamicHoconUnitTests.from_hocon_list(
-        [
-            # existing fixtures ...
-            "basic/coffee_finder_advanced/coffee_where_sly_data_8am.hocon",
-            # add your new fixture here
-            "basic/coffee_finder_advanced/your_new_fixture.hocon",
-        ]
-    ),
-    skip_on_empty=True,
-)
-```
-
-Each test method is tagged with `@pytest.mark` markers that mirror the folder grouping
-(e.g. `integration_basic`, `integration_basic_coffee_finder_advanced`). If you are adding
-fixtures for a new agent network that does not have an existing test method, create a new
-method following the same pattern.
+See [Running a Generated Test Fixture — Option B](agent_network_test_generator.md#option-b-register-in-the-integration-test-suite)
+for how to add them to the integration test suite.
 
 #### Run test
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1732,12 +1732,12 @@ There are two ways to create a test case: automatically with the
 or manually.
 
 ##### Automatic Test Generation
- 
+
 The `agent_network_test_generator` agent network can analyze an existing network and
 produce test fixtures automatically. Start the server, select
 `agent_network_test_generator`, and provide a prompt like
 `Generate test cases for basic/coffee_finder_advanced`.
- 
+
 For test levels, example prompts, and review tips, see the full
 [Agent Network Test Generator](agent_network_test_generator.md) documentation.
 
@@ -1752,7 +1752,7 @@ in the neuro-san repository.
 For existing examples, look at the fixtures under `tests/fixtures/` in this repository.
 
 ##### Register the fixture
- 
+
 Generated and manually created fixtures are **not** automatically picked up by CI.
 See [Running a Generated Test Fixture — Option B](agent_network_test_generator.md#option-b-register-in-the-integration-test-suite)
 for how to add them to the integration test suite.

--- a/registries/agent_network_test_generator.hocon
+++ b/registries/agent_network_test_generator.hocon
@@ -109,6 +109,7 @@ Each scenario you return must include:
 - `description`: what the scenario tests.
 - `interactions`: a list of the EXACT user messages for each turn, with sly_data and expected behaviour. For multi-turn scenarios, this list MUST contain multiple entries (one per turn). For example, a 3-turn scenario MUST have 3 interaction entries.
 
+# Canonical descriptions in docs/agent_network_test_generator.md — keep in sync.
 The `test_level` parameter controls how many scenarios you must generate:
 - `minimum`: Generate 2-3 scenarios. Focus on the single most important happy-path and one critical edge case.
 - `normal`: Generate 5-7 scenarios. Cover the main happy paths, a few edge cases, and at least one error/boundary scenario.


### PR DESCRIPTION
This PR is the fix that @deepsaia has suggested in the 1st release of ANTeGen.

 Summary of the 3 changes:

- Trim user_guide.md "Automatic Test Generation" replace with a short paragraph + link to agent_network_test_generator.md
Trim user_guide.md "Register the fixture"  replace with a brief sentence + link
Add sync comment in HOCON (registries/agent_network_test_generator.hocon) — # Canonical descriptions in docs/agent_network_test_generator.md — keep in sync.