### PR TITLE
Set pytest asyncio loop scope to function in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,5 @@ markers =
     integration_agent_network_designer: integration tests for agent network designer
     integration_basic_music_nerd_pro: integration tests for music nerd pro
     integration_industry_airline_policy_web_search: industry integration tests for airline policy web search
+
+asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Sets scope of asyncio loop of pytest to be function.

Fixes:
Warning in pytest output
This doesn't quite fix the same warning as was described in NS-888, but it fixes a different related annoyance.

## Impact

There is now one asyncio event loop per pytest test method.
This is the same setting for pytest that is in neuro-san.

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
