### PR TITLE
Use hocon file name as agent network name when upload hocon file

### DIFF
--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -16,8 +16,8 @@
 
 import json
 import logging
-from pathlib import Path
 import re
+from pathlib import Path
 from typing import Any
 from typing import Awaitable
 from typing import Callable

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -16,6 +16,7 @@
 
 import json
 import logging
+from pathlib import Path
 import re
 from typing import Any
 from typing import Awaitable
@@ -33,6 +34,7 @@ from neuro_san.internals.persistence.abstract_async_config_restorer import Abstr
 
 from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
+from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 AGENT_NETWORK_HOCON_FILE: str = "agent_network_hocon_file"
@@ -93,7 +95,12 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                 ">>>>>>>>>>>>>>>>>>>Reading & Parsing Agent Network HOCON File "
                 "from Key 'agent_network_hocon_file' in Sly Data>>>>>>>>>>>>>>>>>>>"
             )
-            network_def = await self._hocon_to_definition(self.sly_data.get(AGENT_NETWORK_HOCON_FILE), self.sly_data)
+            hocon_file: str | None = self.sly_data.get(AGENT_NETWORK_HOCON_FILE)
+            network_def = await self._hocon_to_definition(hocon_file, self.sly_data)
+            # When loading from hocon, use the file name (without extension) as the agent network name.
+            # This is because the agent network name is only created when using the CreateNetwork tool.
+            if hocon_file and network_def:
+                self.sly_data[AGENT_NETWORK_NAME] = Path(hocon_file).stem
 
         # If we have a network definition from either source, inject it into the system prompt.
         if network_def:

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -111,8 +111,8 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             if isinstance(network_def, list):
                 connectivity_dict_converter = ConnectivityDictionaryConverter()
                 network_def = connectivity_dict_converter.to_dict(network_def)
-                # Cache the agent network definition as dict in sly_data for subsequent calls within the same session.
-                self.sly_data[AGENT_NETWORK_DEFINITION] = network_def
+            # Cache the agent network definition as dict in sly_data for subsequent calls within the same session.
+            self.sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
             self.logger.debug(
                 ">>>>>>>>>>>>>>>>>>>Injecting Agent Network Definition into System Prompt>>>>>>>>>>>>>>>>>>>"


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

This is necessary since the `agent_network_name` is put in sly data in `agent_network_editor.create_network()`. If the network exists and user only modifies it. This will be None.

Fixes #901 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
