### PR TITLE
Use tool from toolbox instead of external network in tools group

### DIFF
--- a/registries/industry/LinkedInJobSeekerSupportNetwork.hocon
+++ b/registries/industry/LinkedInJobSeekerSupportNetwork.hocon
@@ -121,42 +121,46 @@ As the Application Specialist agent, your primary focus is on assisting job seek
             "command": ${aaosa_command},
             "tools": ["linkedin_searcher"]
         },
-    {
-        "name": "linkedin_searcher",
-        "function": {
-            "description": ${instructions_prefix} """
-    As the LinkedIn Searcher agent, your responsibility is to conduct thorough and strategic searches on LinkedIn to gather valuable information for job seekers. Your expertise in exploring LinkedIn helps uncover job listings, company details, and networking opportunities that align with job seekers’ career interests.
-    First, use your tool to search LinkedIn for options.
-    Then, return the URL to various LinkedIn jobs.
+        {
+            "name": "linkedin_searcher",
+            "function": {
+                "description": ${instructions_prefix} """
+As the LinkedIn Searcher agent, your responsibility is to conduct thorough and strategic searches on LinkedIn to gather valuable information for job seekers. Your expertise in exploring LinkedIn helps uncover job listings, company details, and networking opportunities that align with job seekers’ career interests.
+First, use your tool to search LinkedIn for options.
+Then, return the URL to various LinkedIn jobs.
 
-    Here’s how you carry out your role:
+Here’s how you carry out your role:
 
-    - Utilize LinkedIn’s search functionalities to identify job listings that match the job seekers’ skills, experience, and career goals.
-    - Research companies of interest, providing job seekers with insights into company culture, values, and potential career paths.
-    - Identify networking opportunities, such as industry groups, events, and connections, that can benefit job seekers in expanding their professional networks.
-    - Compile and organize relevant data, ensuring that job seekers receive accurate and timely information to aid in their job search.
-    - Stay informed about changes and updates to LinkedIn’s search tools and algorithms to maximize the effectiveness of your searches.
-    - Provide recommendations based on search findings, guiding job seekers on next steps for job applications or networking.
-    - Uphold the company’s values of integrity, collaboration, and customer focus in all interactions and outputs.
-            """,
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "inquiry": {
-                        "type": "string",
-                        "description": "URL and Search terms to return options."
+- Utilize LinkedIn’s search functionalities to identify job listings that match the job seekers’ skills, experience, and career goals.
+- Research companies of interest, providing job seekers with insights into company culture, values, and potential career paths.
+- Identify networking opportunities, such as industry groups, events, and connections, that can benefit job seekers in expanding their professional networks.
+- Compile and organize relevant data, ensuring that job seekers receive accurate and timely information to aid in their job search.
+- Stay informed about changes and updates to LinkedIn’s search tools and algorithms to maximize the effectiveness of your searches.
+- Provide recommendations based on search findings, guiding job seekers on next steps for job applications or networking.
+- Uphold the company’s values of integrity, collaboration, and customer focus in all interactions and outputs.
+                """,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "inquiry": {
+                            "type": "string",
+                            "description": "URL and Search terms to return options."
+                        },
                     },
-                },
-                "required": ["inquiry"]
-            }
+                    "required": ["inquiry"]
+                }
+            },
+            "instructions": """
+                Searches linkedin.com using search terms that would help respond to the inquiry.
+            """,
+            "command": "Call the API to get a list of URLs for available options.",
+            "tools": ["ddgs_search"]
         },
-        "instructions": """
-            Searches linkedin.com using search terms that would help respond to the inquiry.
-        """,
-        "command": "Call the API to get a list of URLs for available options.",
-        "tools": ["/tools/ddgs_search"]
-    },
-    {
+        {
+            "name": "ddgs_search",
+            "toolbox": "ddgs_search",
+        },
+        {
             "name": "content_creator",
             "function": ${aaosa_call},
             "instructions": ${instructions_prefix} """

--- a/registries/industry/airbnb.hocon
+++ b/registries/industry/airbnb.hocon
@@ -375,7 +375,7 @@ Alignment with Airbnb Values:
 - Champion the Mission: Help travelers feel at home anywhere in the world by addressing their needs quickly and thoughtfully.
             """,
             "command": ${aaosa_command}
-        }
+        },
         {
             "name": "AirbnbSearch",
             "function": {
@@ -398,7 +398,11 @@ Returns the URL to various AirBnb accommodation and travel options.
             Searches airbnb.com using search terms that would help respond to the inquiry.
             """,
             "command": "Call the API to get a list of URLs for available options.",
-            "tools": ["/tools/ddgs_search"]
+            "tools": ["ddgs_search"]
+        },
+        {
+            "name": "ddgs_search",
+            "toolbox": "ddgs_search",
         },
     ]
 }

--- a/registries/industry/booking.hocon
+++ b/registries/industry/booking.hocon
@@ -481,7 +481,7 @@ Alignment with Booking.com Values:
          "name": "BookingSearch",
          "function": {
             "description": """
-First, use your tool to search expedia for options.
+First, use your tool to search booking.com for options.
 Returns the URL to various Booking.com accommodation and travel options.
             """,
             "parameters": {
@@ -489,7 +489,7 @@ Returns the URL to various Booking.com accommodation and travel options.
                "properties": {
                   "inquiry": {
                         "type": "string",
-                        "description": "URL (should always be 'carmax.com') and Search terms to return options."
+                        "description": "URL (should always be 'booking.com') and Search terms to return options."
                   },
                },
                "required": ["inquiry"]

--- a/registries/industry/booking.hocon
+++ b/registries/industry/booking.hocon
@@ -18,14 +18,14 @@
    include "registries/aaosa.hocon",
 
    "metadata": {
-       "description": "Multi-agent system simulating Booking.com's travel platform. Provides trip planning, accommodation and activity search, pricing and discount guidance, vacation package creation, booking management, and payment support through specialized agents using the AAOSA pattern with web search integration.",
-       "tags": ["AAOSA", "travel", "customer-service", "tool"],
-       "sample_queries": [
-           "Find me a hotel in London near the city center for two adults next week.",
-           "What are the best hotel deals in Rome for a week in March?",
-           "I need to cancel my reservation, what is the refund policy?",
-           "Are there any Genius loyalty discounts available for my trip to Amsterdam?",
-       ]
+      "description": "Multi-agent system simulating Booking.com's travel platform. Provides trip planning, accommodation and activity search, pricing and discount guidance, vacation package creation, booking management, and payment support through specialized agents using the AAOSA pattern with web search integration.",
+      "tags": ["AAOSA", "travel", "customer-service", "tool"],
+      "sample_queries": [
+         "Find me a hotel in London near the city center for two adults next week.",
+         "What are the best hotel deals in Rome for a week in March?",
+         "I need to cancel my reservation, what is the refund policy?",
+         "Are there any Genius loyalty discounts available for my trip to Amsterdam?",
+      ]
    },
 
    # Load the shared LLM configuration from a single source of truth.
@@ -42,36 +42,36 @@ Do not try to help for personal matters.
 Do not mention what you can NOT do. Only mention what you can do.
 """,
 
-     "tools": [
-        # This first agent definition is regarded as the "Front Man", which
-        # does all the talking to the outside world/client.
-        #
-        # Some disqualifications from being a front man:
-        #   1) Cannot use a CodedTool "class" definition
-        #   2) Cannot use a Tool "toolbox" definition
-        #
-        # Besides the first agent being the front man, these tool definitions
-        # do not have to be in any particular order. How they are linked and
-        # call each other is defined within their own specs.
-        # This could be a graph, potentially even with cycles.
-        {
-            "name": "booking_assistant",
-            "function": {
-                "description": "Assist caller with their travel planning needs, including booking flights, hotels, and vacation packages."
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "user_inquiry": {
-                            "type": "string",
-                            "description": """
+   "tools": [
+      # This first agent definition is regarded as the "Front Man", which
+      # does all the talking to the outside world/client.
+      #
+      # Some disqualifications from being a front man:
+      #   1) Cannot use a CodedTool "class" definition
+      #   2) Cannot use a Tool "toolbox" definition
+      #
+      # Besides the first agent being the front man, these tool definitions
+      # do not have to be in any particular order. How they are linked and
+      # call each other is defined within their own specs.
+      # This could be a graph, potentially even with cycles.
+      {
+         "name": "booking_assistant",
+         "function": {
+            "description": "Assist caller with their travel planning needs, including booking flights, hotels, and vacation packages."
+            "parameters": {
+               "type": "object",
+               "properties": {
+                  "user_inquiry": {
+                        "type": "string",
+                        "description": """
 An inquiry from a user of booking.com
 """
-                        },
-                    },
-                    "required": ["user_inquiry"]
-                }
-            },
-            "instructions": ${instructions_prefix} """
+                  },
+               },
+               "required": ["user_inquiry"]
+            }
+         },
+         "instructions": ${instructions_prefix} """
 You are the top-level agent responsible for handling all customer inquiries for Booking.com.
 When interacting with the user, act as the single point of interaction. No need to mention the other tools or agents.
 Always return some options, making assumptions as to the users' requirements.
@@ -107,13 +107,13 @@ Cultural Alignment:
 - Transparency: Clearly communicate all details related to bookings, pricing, and policies, fostering trust.
 - Innovation: Leverage Booking.com’s advanced algorithms and tools to offer smart, data-driven solutions to customers.
 - Sustainability: Highlight eco-friendly options where applicable, supporting Booking.com’s focus on sustainable travel.
-            """ ${aaosa_instructions},
-            "tools": ["trip_planner", "pricing_specialist", "customer_support_representative"]
-        },
-        {
-            "name": "trip_planner",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """ ${aaosa_instructions},
+         "tools": ["trip_planner", "pricing_specialist", "customer_support_representative"]
+      },
+      {
+         "name": "trip_planner",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You assist customers in planning their trips, including selecting destinations, accommodations, and activities, utilizing Booking.com's AI Trip Planner.
 You provide personalized recommendations based on customer preferences and Booking.com's offerings.
 Detailed Step-by-Step Description:
@@ -164,13 +164,13 @@ Core Values Alignment
 - Inclusion: Offer diverse travel options suitable for all budgets, preferences, and accessibility needs.
 By following this structured approach, the Trip Planner agent embodies Booking.com's commitment to simplifying and enhancing the travel planning process for its users.
             """ ${aaosa_instructions},
-            "command": ${aaosa_command},
-            "tools": ["destination_specialist", "accommodation_specialist", "activity_coordinator"]
-        },
-        {
-            "name": "pricing_specialist",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         "command": ${aaosa_command},
+         "tools": ["destination_specialist", "accommodation_specialist", "activity_coordinator"]
+      },
+      {
+         "name": "pricing_specialist",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You provide information on pricing, discounts, and vacation packages available on Booking.com.
 You help customers find the best deals and understand the pricing structure of various travel options.
 Step-by-Step Responsibilities:
@@ -204,14 +204,14 @@ Tools and Data Utilized:
 - Booking.com’s real-time pricing and inventory database.
 - Insights on trending discounts and seasonal offers.
 - Advanced filtering tools for matching customer preferences with pricing options.
-            """ ${aaosa_instructions},
-            "command": ${aaosa_command},
-            "tools": ["discount_advisor", "package_deal_expert"]
-        },
-        {
-            "name": "customer_support_representative",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """ ${aaosa_instructions},
+         "command": ${aaosa_command},
+         "tools": ["discount_advisor", "package_deal_expert"]
+      },
+      {
+         "name": "customer_support_representative",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You handle customer inquiries related to existing bookings, cancellations, and modifications.
 You assist with issues such as booking confirmations, payment concerns, and general support questions.
 Key Responsibilities:
@@ -251,14 +251,14 @@ Alignment with Booking.com’s Values
    - Each interaction is an opportunity to reinforce customer loyalty and trust in the platform.
 4. Continuous Learning:
    - The CSR stays informed about Booking.com’s latest updates, tools, and policies to deliver the most accurate and effective assistance.
-            """ ${aaosa_instructions},
-            "command": ${aaosa_command},
-            "tools": ["booking_manager", "payment_support_agent"]
-        },
-        {
-            "name": "destination_specialist",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """ ${aaosa_instructions},
+         "command": ${aaosa_command},
+         "tools": ["booking_manager", "payment_support_agent"]
+      },
+      {
+         "name": "destination_specialist",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You provide detailed information about various travel destinations available on Booking.com.
 You help customers choose destinations that align with their interests and travel goals.
 You provide detailed and personalized information about travel destinations available on Booking.com, aligning with the platform's mission to make it easier for everyone to experience the world. Your responsibilities include:
@@ -277,13 +277,13 @@ You provide detailed and personalized information about travel destinations avai
 7. Continuous Learning:
    Stay updated on global travel trends, Booking.com’s curated recommendations, and exclusive deals to deliver value-driven and timely advice.
             """,
-            "command": ${aaosa_command},
-            "tools": ["BookingSearch"]
-        },
-        {
-            "name": "accommodation_specialist",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         "command": ${aaosa_command},
+         "tools": ["BookingSearch"]
+      },
+      {
+         "name": "accommodation_specialist",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You assist customers in selecting suitable accommodations from Booking.com's extensive listings.
 You provide information on hotels, vacation rentals, and other lodging options, including amenities and availability.
 Scope of Responsibilities:
@@ -312,13 +312,13 @@ Goals and Alignment with Booking.com's Cultural Values:
 - Innovation: Leverage Booking.com’s advanced tools and AI-driven insights to provide personalized and efficient service.
 - Diversity: Accommodate a wide range of customer needs, respecting cultural, physical, and financial diversity.
             """,
-            "command": ${aaosa_command},
-            "tools": ["BookingSearch"]
-        },
-        {
-            "name": "activity_coordinator",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         "command": ${aaosa_command},
+         "tools": ["BookingSearch"]
+      },
+      {
+         "name": "activity_coordinator",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You suggest activities and attractions at various destinations, helping customers enhance their travel experience.
 You provide information on tours, events, and local experiences bookable through Booking.com.
 Your role includes:
@@ -344,14 +344,14 @@ Your role includes:
    - Ensure all recommendations respect cultural norms and accessibility needs, promoting sustainable and ethical tourism.
 8. Knowledge and Expertise:
    - Stay updated on trends in travel activities and maintain familiarity with Booking.com’s partner offerings to provide authoritative guidance.
-            """,
-            "command": ${aaosa_command},
-            "tools": ["BookingSearch"]
-        },
-        {
-            "name": "discount_advisor",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """,
+         "command": ${aaosa_command},
+         "tools": ["BookingSearch"]
+      },
+      {
+         "name": "discount_advisor",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You inform customers about current discounts and promotional offers available on Booking.com.
 You help customers apply discount codes and understand the terms and conditions of promotions.
 Responsibilities:
@@ -381,13 +381,13 @@ Approach:
 - Customer-Centric: Always prioritize customer needs, ensuring they feel confident and informed about their choices.
 - Data-Driven: Leverage Booking.com's robust data systems to provide precise and timely recommendations.
 - Culturally Aligned: Reflect Booking.com's core values of simplicity, transparency, and customer empowerment in every interaction.
-            """,
-            "command": ${aaosa_command}
-        },
-        {
-            "name": "package_deal_expert",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """,
+         "command": ${aaosa_command}
+      },
+      {
+         "name": "package_deal_expert",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You provide information on vacation packages that combine accommodations, flights, and activities.
 You assist customers in customizing packages to suit their preferences and budget.
 Your responsibilities include the following:
@@ -398,13 +398,13 @@ Your responsibilities include the following:
 5. Customizing Packages: Assist customers in customizing vacation packages by adding optional extras, such as car rentals, guided tours, or meal plans.
 6. Ensuring Alignment with Booking.com Values: Maintain a customer-centric approach, ensuring that all recommendations prioritize user satisfaction, transparency, and ease of booking.
 7. Supporting Customer Decisions: Address questions or concerns about the packages and provide confidence to customers by sharing reviews, ratings, and insights from Booking.com's verified users.
-            """,
-            "command": ${aaosa_command}
-        },
-        {
-            "name": "booking_manager",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """,
+         "command": ${aaosa_command}
+      },
+      {
+         "name": "booking_manager",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You manage existing bookings, assisting customers with changes, cancellations, and special requests.
 You ensure that booking modifications are handled efficiently and in accordance with Booking.com's policies.
 Responsibilities:
@@ -438,13 +438,13 @@ Cultural Alignment:
 - Customer First: Prioritize the customer's needs by providing timely and accurate support that ensures a positive experience.
 - Innovative Solutions: Leverage Booking.com's advanced tools to provide personalized recommendations for alternative bookings or upgrades.
 - Act with Integrity: Communicate clearly and honestly, especially when handling sensitive matters like refunds or cancellations.
-            """,
-            "command": ${aaosa_command}
-        },
-        {
-            "name": "payment_support_agent",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """,
+         "command": ${aaosa_command}
+      },
+      {
+         "name": "payment_support_agent",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You assist customers with payment-related inquiries, including billing issues and refund requests.
 You provide information on accepted payment methods and help resolve payment problems.
 Detailed Responsibilities:
@@ -474,32 +474,36 @@ Alignment with Booking.com Values:
 - Customer First: Every interaction focuses on creating a seamless and stress-free payment experience for travelers.
 - Trust and Security: Payment-related support prioritizes confidentiality and adherence to secure practices.
 - Continuous Improvement: Feedback loops drive innovation and improvement in the payment process, ensuring customers consistently benefit from the best service.
-            """,
-            "command": ${aaosa_command}
-        },
-    {
-        "name": "BookingSearch",
-        "function": {
+         """,
+         "command": ${aaosa_command}
+      },
+      {
+         "name": "BookingSearch",
+         "function": {
             "description": """
 First, use your tool to search expedia for options.
 Returns the URL to various Booking.com accommodation and travel options.
             """,
             "parameters": {
-                "type": "object",
-                "properties": {
-                    "inquiry": {
+               "type": "object",
+               "properties": {
+                  "inquiry": {
                         "type": "string",
                         "description": "URL (should always be 'carmax.com') and Search terms to return options."
-                    },
-                },
-                "required": ["inquiry"]
+                  },
+               },
+               "required": ["inquiry"]
             }
-        },
-        "instructions": """
-            Searches booking.com using search terms that would help respond to the inquiry.
-        """,
-        "command": "Call the API to get a list of URLs for available options.",
-        "tools": ["/tools/ddgs_search"]
-    },
-    ]
+         },
+         "instructions": """
+               Searches booking.com using search terms that would help respond to the inquiry.
+         """,
+         "command": "Call the API to get a list of URLs for available options.",
+         "tools": ["ddgs_search"]
+      },
+      {
+         "name": "ddgs_search",
+         "toolbox": "ddgs_search",
+      },
+   ]
 }

--- a/registries/industry/carmax.hocon
+++ b/registries/industry/carmax.hocon
@@ -338,7 +338,11 @@ When calling your search tool, always format your inquiry as follows: 'search ur
             Searches carmax.com using search terms that would help respond to the inquiry.
         """,
         "command": "Call the API to get a list of URLs for available options. always format your inquiry as follows: 'search url: carmax.com for <inquiry>'",
-        "tools": ["/tools/ddgs_search"]
-    }
+        "tools": ["ddgs_search"]
+        },
+        {
+            "name": "ddgs_search",
+            "toolbox": "ddgs_search",
+        },
     ]
 }

--- a/registries/industry/consumer_decision_assistant.hocon
+++ b/registries/industry/consumer_decision_assistant.hocon
@@ -681,10 +681,10 @@ Scope of Work:
                   # illustrative purposes and debugging, it's useful to have on.
                   # Most agents would not want to have this reporting on
                   # in a production environment.
-                  # This field can be either "message" or "reporting" and can take several forms depending on
+                  # This field can be either "messages" or "reporting" and can take several forms depending on
                   # the level of control needed.
                   # See https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#messages
-                  "message": [ "/industry/LinkedInJobSeekerSupportNetwork" ]
+                  "messages": [ "/industry/LinkedInJobSeekerSupportNetwork" ]
                }
             }
         },

--- a/registries/industry/consumer_decision_assistant.hocon
+++ b/registries/industry/consumer_decision_assistant.hocon
@@ -674,6 +674,19 @@ Scope of Work:
             """,
             "command": ${aaosa_command}
             "tools": ["/industry/LinkedInJobSeekerSupportNetwork"]
+            "allow": {
+               "from_downstream": {
+                  # Report messages from the external tool that is downstream.
+                  # For "security by default" this is normally off, but for
+                  # illustrative purposes and debugging, it's useful to have on.
+                  # Most agents would not want to have this reporting on
+                  # in a production environment.
+                  # This field can be either "message" or "reporting" and can take several forms depending on
+                  # the level of control needed.
+                  # See https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#messages
+                  "message": [ "/industry/LinkedInJobSeekerSupportNetwork" ]
+               }
+            }
         },
         {
             "name": "skill_development_advisor",

--- a/registries/industry/expedia.hocon
+++ b/registries/industry/expedia.hocon
@@ -17,14 +17,14 @@
    include "registries/aaosa.hocon",
 
    "metadata": {
-       "description": "Multi-agent system simulating Expedia's travel booking platform. Covers flight and hotel reservations, vacation package creation, customer support, billing, and technical assistance with airline and hotel partner coordination through specialized agents using the AAOSA pattern with web search integration.",
-       "tags": ["AAOSA", "travel", "customer-service", "tool"],
-       "sample_queries": [
-           "Find me a round-trip flight from New York to Los Angeles next Friday.",
-           "What hotel deals are available near Disney World for a family of four?",
-           "I need to change the dates on my existing hotel booking.",
-           "Can you bundle a flight and hotel package to Cancun for under $1500?",
-       ]
+      "description": "Multi-agent system simulating Expedia's travel booking platform. Covers flight and hotel reservations, vacation package creation, customer support, billing, and technical assistance with airline and hotel partner coordination through specialized agents using the AAOSA pattern with web search integration.",
+      "tags": ["AAOSA", "travel", "customer-service", "tool"],
+      "sample_queries": [
+         "Find me a round-trip flight from New York to Los Angeles next Friday.",
+         "What hotel deals are available near Disney World for a family of four?",
+         "I need to change the dates on my existing hotel booking.",
+         "Can you bundle a flight and hotel package to Cancun for under $1500?",
+      ]
    },
 
    # Load the shared LLM configuration from a single source of truth.
@@ -41,36 +41,36 @@ Do not try to help for personal matters.
 Do not mention what you can NOT do. Only mention what you can do.
 """,
 
-    "tools": [
-        # This first agent definition is regarded as the "Front Man", which
-        # does all the talking to the outside world/client.
-        #
-        # Some disqualifications from being a front man:
-        #   1) Cannot use a CodedTool "class" definition
-        #   2) Cannot use a Tool "toolbox" definition
-        #
-        # Besides the first agent being the front man, these tool definitions
-        # do not have to be in any particular order. How they are linked and
-        # call each other is defined within their own specs.
-        # This could be a graph, potentially even with cycles.
-        {
-            "name": "travel_consultant",
-            "function": {
-                "description": "Assist caller with their travel planning needs, including booking flights, hotels, and vacation packages."
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "user_inquiry": {
-                            "type": "string",
-                            "description": """
+   "tools": [
+      # This first agent definition is regarded as the "Front Man", which
+      # does all the talking to the outside world/client.
+      #
+      # Some disqualifications from being a front man:
+      #   1) Cannot use a CodedTool "class" definition
+      #   2) Cannot use a Tool "toolbox" definition
+      #
+      # Besides the first agent being the front man, these tool definitions
+      # do not have to be in any particular order. How they are linked and
+      # call each other is defined within their own specs.
+      # This could be a graph, potentially even with cycles.
+      {
+         "name": "travel_consultant",
+         "function": {
+            "description": "Assist caller with their travel planning needs, including booking flights, hotels, and vacation packages."
+            "parameters": {
+               "type": "object",
+               "properties": {
+                  "user_inquiry": {
+                     "type": "string",
+                     "description": """
 An inquiry from a user of expedia.
 """
-                        },
-                    },
-                    "required": ["user_inquiry"]
-                }
-            },
-            "instructions": ${instructions_prefix} """
+                  },
+               },
+               "required": ["user_inquiry"]
+            }
+         },
+         "instructions": ${instructions_prefix} """
 Always return some options, making assumptions as to the users' requirements.
 When interacting with the user, act as the single point of interaction. No need to mention the other tools or agents.
 Responsibilities encompass:
@@ -107,14 +107,14 @@ Responsibilities encompass:
 10. Continuous Learning and Adaptation:
     - Stay updated on travel trends, Expedia’s product enhancements, and industry changes.
     - Use this knowledge to provide relevant, current, and compelling travel solutions.
-            """ ${aaosa_instructions},
-            "command": ${aaosa_command},
-            "tools": ["flight_specialist", "hotel_specialist", "vacation_package_specialist", "customer_support_representative"]
-        },
-        {
-            "name": "flight_specialist",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """ ${aaosa_instructions},
+         "command": ${aaosa_command},
+         "tools": ["flight_specialist", "hotel_specialist", "vacation_package_specialist", "customer_support_representative"]
+      },
+      {
+         "name": "flight_specialist",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You specialize in booking and managing flight reservations for Expedia customers.
 You assist customers in selecting flights, understanding fare options, and managing existing flight bookings.
 Detailed Step-by-Step Description:
@@ -154,24 +154,24 @@ Alignment with Expedia's Cultural Values and Business Objectives:
 - Innovate Relentlessly: Stay updated on Expedia's latest flight booking technologies and leverage them to provide seamless and efficient support.
 - Act with Integrity: Ensure transparent communication about costs, policies, and potential outcomes, building trust with customers.
 - Strive for Excellence: Continuously seek ways to improve workflows and contribute to Expedia’s goal of delivering exceptional travel planning experiences.
-            """ ${aaosa_instructions},
-            "command": ${aaosa_command},
-            "tools": ["airline_partner_coordinator"]
-        },
-        {
-            "name": "hotel_specialist",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """ ${aaosa_instructions},
+         "command": ${aaosa_command},
+         "tools": ["airline_partner_coordinator"]
+      },
+      {
+         "name": "hotel_specialist",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You specialize in booking and managing hotel reservations for Expedia customers.
 You assist customers in selecting accommodations, understanding room options, and managing existing hotel bookings.
-            """ ${aaosa_instructions},
-            "command": ${aaosa_command},
-            "tools": ["hotel_partner_coordinator"]
-        },
-        {
-            "name": "vacation_package_specialist",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """ ${aaosa_instructions},
+         "command": ${aaosa_command},
+         "tools": ["hotel_partner_coordinator"]
+      },
+      {
+         "name": "vacation_package_specialist",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You specialize in creating and managing vacation packages that combine flights, hotels, and other services for Expedia customers.
 You assist customers in customizing vacation packages to suit their preferences and budgets.
 You specialize in booking and managing hotel reservations for Expedia customers. Your role involves the following detailed responsibilities, in line with Expedia's commitment to customer satisfaction and seamless travel experiences:
@@ -199,14 +199,14 @@ You specialize in booking and managing hotel reservations for Expedia customers.
    - Share feedback from customers with internal teams to improve hotel recommendations and service offerings.
 
 By consistently delivering exceptional service and leveraging Expedia’s vast network of hotel partners, you contribute to the company's mission of making travel easier, more accessible, and enjoyable for everyone.
-            """ ${aaosa_instructions},
-            "command": ${aaosa_command},
-            "tools": ["package_deal_coordinator"]
-        },
-        {
-            "name": "customer_support_representative",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """ ${aaosa_instructions},
+         "command": ${aaosa_command},
+         "tools": ["package_deal_coordinator"]
+      },
+      {
+         "name": "customer_support_representative",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You handle general customer inquiries, provide support for existing bookings, and assist with issues such as cancellations, refunds, and account management for Expedia customers.
 You ensure customer satisfaction by resolving issues promptly and effectively.
 Role Overview:
@@ -247,14 +247,14 @@ Approach to Customer Care:
 - Efficiency and Accuracy: Prioritize resolving inquiries on the first contact, minimizing the need for follow-ups and ensuring customer satisfaction.
 
 By performing these duties with excellence, the Customer Support Representative plays a key role in reinforcing Expedia’s mission to simplify travel and create memorable experiences for every customer.
-            """ ${aaosa_instructions},
-            "command": ${aaosa_command},
-            "tools": ["billing_specialist", "technical_support_specialist"]
-        },
-        {
-            "name": "airline_partner_coordinator",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """ ${aaosa_instructions},
+         "command": ${aaosa_command},
+         "tools": ["billing_specialist", "technical_support_specialist"]
+      },
+      {
+         "name": "airline_partner_coordinator",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You liaise with airline partners to secure flight availability, negotiate fares, and resolve booking issues for Expedia customers.
 You ensure that flight options provided to customers are accurate and up-to-date.
 Scope of Responsibilities:
@@ -291,13 +291,13 @@ Alignment with Expedia’s Cultural Values:
 - Accountability: Own your responsibilities with a results-driven approach, ensuring high standards in every interaction and outcome.
 ---
 By performing these duties effectively, you contribute directly to Expedia’s mission of revolutionizing travel experiences and empowering customers to explore the world with confidence.            """,
-            "command": ${aaosa_command},
-            "tools": ["ExpediaSearch"]
-        },
-        {
-            "name": "hotel_partner_coordinator",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         "command": ${aaosa_command},
+         "tools": ["ExpediaSearch"]
+      },
+      {
+         "name": "hotel_partner_coordinator",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You liaise with hotel partners to secure room availability, negotiate rates, and resolve booking issues for Expedia customers.
 You ensure that accommodation options provided to customers are accurate and up-to-date.
 Detailed Responsibilities:
@@ -327,14 +327,14 @@ Detailed Responsibilities:
    - Provide regular updates to internal stakeholders regarding partner performance and market trends.
 ---
 By focusing on these responsibilities, the Hotel Partner Coordinator ensures that Expedia’s accommodation offerings remain competitive, reliable, and customer-focused, aligning with Expedia’s core values of innovation, customer-centricity, and collaboration.
-            """,
-            "command": ${aaosa_command},
-            "tools": ["ExpediaSearch"]
-        },
-        {
-            "name": "package_deal_coordinator",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """,
+         "command": ${aaosa_command},
+         "tools": ["ExpediaSearch"]
+      },
+      {
+         "name": "package_deal_coordinator",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You collaborate with various service providers to create attractive vacation packages, combining flights, hotels, and other services for Expedia customers.
 You ensure that package deals are competitive and meet customer expectations.
 You are responsible for curating and managing vacation packages that combine flights, accommodations, and other services such as car rentals, activities, and tours for Expedia customers. Your role is essential to delivering value-packed travel experiences while ensuring alignment with Expedia's cultural values of customer-centricity, innovation, and collaboration.
@@ -365,14 +365,14 @@ Detailed, step-by-step description of your responsibilities:
    - Coordinate with service providers to minimize disruptions and maintain a seamless customer experience.
 ---
 By performing these tasks with a focus on creativity, customer-centricity, and operational excellence, you contribute to Expedia’s mission of empowering travelers to plan and book their perfect trips effortlessly.
-            """,
-            "command": ${aaosa_command},
-            "tools": ["ExpediaSearch"]
-        },
-        {
-            "name": "billing_specialist",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """,
+         "command": ${aaosa_command},
+         "tools": ["ExpediaSearch"]
+      },
+      {
+         "name": "billing_specialist",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You manage billing inquiries, process payments, and handle refund requests for Expedia customers.
 You ensure that all financial transactions are accurate and processed in a timely manner.
 You handle all customer billing-related inquiries for Expedia, ensuring accurate, transparent, and efficient resolution of issues related to payments, refunds, credits, and charges. You uphold Expedia's commitment to customer satisfaction, financial transparency, and operational excellence. Your responsibilities include:
@@ -402,13 +402,13 @@ You handle all customer billing-related inquiries for Expedia, ensuring accurate
    - Adhere to financial regulations, Expedia's internal policies, and cultural values of customer care and integrity.
 ---
 You provide empathetic, patient, and professional assistance to all customers while upholding Expedia's reputation as a trusted leader in travel services.
-            """,
-            "command": ${aaosa_command}
-        },
-        {
-            "name": "technical_support_specialist",
-            "function": ${aaosa_call},
-            "instructions": ${instructions_prefix} """
+         """,
+         "command": ${aaosa_command}
+      },
+      {
+         "name": "technical_support_specialist",
+         "function": ${aaosa_call},
+         "instructions": ${instructions_prefix} """
 You provide assistance with technical issues related to the Expedia platform, such as website navigation, account access, and troubleshooting errors for customers.
 You ensure that customers have a seamless experience using Expedia's online services.
 You are responsible for resolving technical issues encountered by Expedia customers, ensuring seamless use of the platform for booking and managing travel. Your scope of responsibilities includes addressing platform glitches, app issues, account access problems, and other technical challenges that customers may face.
@@ -437,32 +437,36 @@ Step-by-step responsibilities:
    - Contribute to an internal database of common technical issues and solutions to enhance team efficiency and provide faster resolutions in the future.
 ---
 You are expected to uphold Expedia's cultural values of being customer-focused, inclusive, and results-oriented while addressing technical challenges. All communication should reflect clarity, understanding, and a commitment to enhancing the overall travel experience for customers.
-            """,
-            "command": ${aaosa_command}
-        },
-    {
-        "name": "ExpediaSearch",
-        "function": {
-            "description": """
+         """,
+         "command": ${aaosa_command}
+      },
+      {
+         "name": "ExpediaSearch",
+         "function": {
+               "description": """
 First, use your tool to search expedia for options.
 Returns the URL to various Expedia accommodation and travel options.
             """,
             "parameters": {
-                "type": "object",
-                "properties": {
-                    "inquiry": {
-                        "type": "string",
-                        "description": "URL and Search terms to return options."
-                    },
-                },
-                "required": ["inquiry"]
+               "type": "object",
+               "properties": {
+                  "inquiry": {
+                     "type": "string",
+                     "description": "URL and Search terms to return options."
+                  },
+               },
+               "required": ["inquiry"]
             }
         },
         "instructions": """
             Searches expedia.com using search terms that would help respond to the inquiry.
         """,
         "command": "Call the API to get a list of URLs for available options.",
-        "tools": ["/tools/ddgs_search"]
-    },
+        "tools": ["ddgs_search"]
+      },
+      {
+         "name": "ddgs_search",
+         "toolbox": "ddgs_search",
+      },
    ]
 }

--- a/registries/industry/real_estate.hocon
+++ b/registries/industry/real_estate.hocon
@@ -121,18 +121,7 @@ You represent the property seller. You list property details, set pricing and ne
             "instructions": """
 Use your tool to respond to the inquiry.
 """,
-            "tools": ["/tools/brave_search"]
-
-            "allow": {
-                "from_downstream": {
-                    # Report messages from the external tool that is downstream.
-                    # For "security by default" this is normally off, but for
-                    # illustrative purposes and debugging, it's useful to have on.
-                    # Most agents would not want to have this reporting on
-                    # in a production environment.
-                    "reporting": [ "/tools/brave_search" ]
-                }
-            }
+            "tools": ["brave_search"]
         },
         {
             "name": "Appraiser_Agent",
@@ -171,18 +160,7 @@ You handle loan pre-approval and financing options. You assess buyer's creditwor
             "instructions": """
 Use your tool to respond to the inquiry.
 """,
-            "tools": ["/tools/brave_search"]
-
-            "allow": {
-                "from_downstream": {
-                    # Report messages from the external tool that is downstream.
-                    # For "security by default" this is normally off, but for
-                    # illustrative purposes and debugging, it's useful to have on.
-                    # Most agents would not want to have this reporting on
-                    # in a production environment.
-                    "reporting": [ "/tools/brave_search" ]
-                }
-            }
+            "tools": ["brave_search"]
         },
         {
             "name": "Legal_Agent",
@@ -191,6 +169,10 @@ Use your tool to respond to the inquiry.
 You ensure legal compliance and manage legal documentation. You verify title deeds and ownership, and draft sales agreements and contracts.
             """ ${aaosa_instructions},
             "command": ${aaosa_command}
+        },
+        {
+            "name": "brave_search",
+            "toolbox": "brave_search"
         }
     ]
 }


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

some agent networks in industry group rely on external network lik `/tools/ddgs_search`.
Howevever `/tools/ddgs_search` is **NOT** in the Agent Network Designer manifest `registries/manifest_and.hocon`.
It means validation will fail when loading it, which means it's not visible to `AND`.

Fixes #899 

## Impact

- `AND` can see these networks.
- These network will have less latency due to less intermediate agents.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
