### PR TITLE
Add  "/agent_network_query_generator" to messages field

### DIFF
--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -181,7 +181,7 @@ Operational notes:
                     "sly_data": ["agent_network_definition", "agent_network_name", "agent_network_queries", "mcp_servers", "subnetworks", "toolbox_info"],
                     # Allow all messages sent from specific downstream agents to be reported
                     # as if they came back from this agent network
-                    "messages": ["/agent_network_editor", "/agent_network_instructions_editor"]
+                    "messages": ["/agent_network_editor", "/agent_network_query_generator", "/agent_network_instructions_editor"]
                 },
                 "to_downstream": {
                     "sly_data": ["agent_network_definition", "agent_network_name", "agent_network_queries"]


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Add  `"/agent_network_query_generator"` to `allow.from_downstream.messages` field.
This is so that the messages from `agent_network_query_generator` can be send to the client.

Fixes #906 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
