### PR TITLE
Add query as a parameter for frontman of network in industry group

### DIFF
--- a/registries/industry/airbnb.hocon
+++ b/registries/industry/airbnb.hocon
@@ -58,6 +58,18 @@ Do not mention what you can NOT do. Only mention what you can do.
             "name": "travel_planning_assistant",
             "function": {
                 "description": "I can assist you with all your travel planning needs, including booking flights, hotels, and vacation packages."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A traveler inquiry about Airbnb services, including searching for accommodations, booking flights, planning vacation packages, or resolving hosting-related questions.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": ${instructions_prefix} """
 You are the top-level agent responsible for handling all travel planning inquiries for Airbnb.

--- a/registries/industry/airline_policy.hocon
+++ b/registries/industry/airline_policy.hocon
@@ -61,6 +61,18 @@
                 Your name is Airline 360 Assistant. You are in charge of the airline's help desk, answering
                 customers' questions about Airline policies, procedures, and resources that they can access.
                 """
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A customer question about airline policies, procedures, baggage rules, flight changes, refunds, or other helpdesk-related inquiries.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """
 You are the top-level policy inquiry agent and the sole point of interaction. DO NOT mention other tools or agents.

--- a/registries/industry/airline_policy_web_search.hocon
+++ b/registries/industry/airline_policy_web_search.hocon
@@ -46,6 +46,18 @@
                 "description": """
                 Handles all customer questions about airline policies, procedures, and services and provides source links.
                 """
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A customer question about airline policies, procedures, or services that may require web search to retrieve up-to-date information and source links.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """
             You are the top-level airline policy inquiry agent and the sole point of interaction with the customer.

--- a/registries/industry/banking_ops.hocon
+++ b/registries/industry/banking_ops.hocon
@@ -59,6 +59,18 @@
             "name": "customer_service_representative",
             "function": {
                 "description": "Handles day-to-day customer inquiries and support for banking products such as checking accounts, loans, and credit cards."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A customer inquiry about banking products and services, such as checking accounts, savings accounts, loans, credit cards, or other banking-related questions.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """
 You are the top-level agent responsible for handling all incoming customer service requests.

--- a/registries/industry/consumer_decision_assistant.hocon
+++ b/registries/industry/consumer_decision_assistant.hocon
@@ -57,6 +57,18 @@ Do not mention what you can NOT do. Only mention what you can do.
             "name": "decision_consultant",
             "function": {
                 "description": "I can help you research and weigh options for any decision, ranging from retail purchasing to life choices and investments."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A decision-making inquiry where the user needs help researching and weighing options, ranging from retail purchases and financial investments to major life choices.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": ${instructions_prefix} """
 You are the top-level agent responsible for helping users make informed decisions across various domains by guiding them through research and evaluation processes.

--- a/registries/industry/cpg_agents.hocon
+++ b/registries/industry/cpg_agents.hocon
@@ -49,6 +49,18 @@
             "name": "chief_operating_officer",
             "function": {
                 "description": "Responsible for overall operations, supply chain, and product development in a global CPG company."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+An inquiry about consumer packaged goods operations, including product development, supply chain, marketing, or regional operations.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """
 You oversee the entire global operations for a consumer packaged goods (CPG) company. Your responsibilities include setting strategic goals, managing cross-departmental objectives, and ensuring all functional areas—product development, supply chain, marketing, and regional operations—work in harmony to meet company objectives.

--- a/registries/industry/insurance_agents.hocon
+++ b/registries/industry/insurance_agents.hocon
@@ -48,6 +48,18 @@
             "name": "customer_service_representative",
             "function": {
                 "description": "Handles general customer inquiries, policy information, and claims status updates."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A customer inquiry about insurance policies, coverage options, claims status, or other insurance-related questions.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """
 You are the front-line contact for customers. You assist with inquiries regarding policies, claims, and coverage options.

--- a/registries/industry/insurance_underwriting_agents.hocon
+++ b/registries/industry/insurance_underwriting_agents.hocon
@@ -59,6 +59,18 @@ if you are actually grounded in real data or you are operating a real applicatio
             "name": "insurance_agent",
             "function": {
                 "description": "I gather, analyze, and make decisions for underwriting insurance policies at an insurance company."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+An inquiry about insurance underwriting, including risk assessment, policy evaluation, applicant information, or underwriting decisions for business insurance.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": ${instructions_prefix} ${demo_mode} """
 You are the top-level agent responsible for handling all insurance inquiries for an insurance company's business insurance processes.

--- a/registries/industry/intranet_agents.hocon
+++ b/registries/industry/intranet_agents.hocon
@@ -52,6 +52,18 @@
                 # The description acts as an initial prompt. 
 
                 "description": "I can help you with your intranet needs."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+An employee inquiry about company intranet resources, internal documents, policies, or services.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """
 You are the top-level agent responsible for handling all inquiries.

--- a/registries/industry/intranet_agents_with_tools.hocon
+++ b/registries/industry/intranet_agents_with_tools.hocon
@@ -74,6 +74,18 @@
                 Your name is MyIntranet. You respond to employee inquiries related to company's intranet.
                 Your down-chain agents (or tools) will help you determine your scope of operations.
                 """
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+An employee inquiry about company intranet resources, internal tools, HR policies, IT support, or other corporate services.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": ${instructions_prefix} """
 You are the top-level agent responsible for handling all inquiries to company's intranet chatbot.

--- a/registries/industry/keybank.hocon
+++ b/registries/industry/keybank.hocon
@@ -57,6 +57,18 @@
             "name": "client_relationship_manager",
             "function": {
                 "description": "I can assist you with all your banking and financial service needs at KeyBank."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A client inquiry about KeyBank banking and financial services, including accounts, loans, investments, or relationship management.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": ${instructions_prefix} """
 You are the top-level agent responsible for handling all client inquiries.

--- a/registries/industry/news_sentiment_analysis.hocon
+++ b/registries/industry/news_sentiment_analysis.hocon
@@ -59,6 +59,18 @@
             "name": "news_query_manager",
             "function": {
                 "description": "I oversee sentiment analysis of media coverage, coordinating a pipeline to evaluate sentiment, bias, tone, and emotional framing across news sources."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A topic or subject for which media sentiment analysis is requested, covering sentiment, bias, tone, and emotional framing across news sources.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
                 },
             "instructions": ${instructions_prefix} """
             You are the top-level agent named news_query_manager, 

--- a/registries/industry/real_estate.hocon
+++ b/registries/industry/real_estate.hocon
@@ -61,6 +61,18 @@ Do not mention what you can NOT do. Only mention what you can do.
                 Your name is RealEstateAgent. You respond to user inquiries related to purchasing a property.
                 Your down-chain agents (or tools) will help you determine your scope of operations.
                 """
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A user inquiry about purchasing property, including property listings, financing options, neighborhood information, or other real estate consulting questions.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """
 You are the top-level agent responsible for handling all inquiries to company's real estate consulting services.

--- a/registries/industry/retail_ops_and_customer_service.hocon
+++ b/registries/industry/retail_ops_and_customer_service.hocon
@@ -52,6 +52,18 @@
             "name": "customer_service_rep",
             "function": {
                 "description": "I handle customer inquiries, complaints, and returns, and provide assistance regarding products and services. I also respond to associate inquiries."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A customer or associate inquiry about orders, returns, refunds, products, or other retail-related questions.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """You are the top-level agent responsible for customer support. You are the single point of contact for the user.
 Handle all issues related to orders, returns, refunds, and product inquiries. Respond with clear, final answers.

--- a/registries/industry/telco_network_orchestration.hocon
+++ b/registries/industry/telco_network_orchestration.hocon
@@ -103,6 +103,18 @@ If mode is 'Fulfill' or "Follow up", respond to the inquiry and return a json bl
                 "description": """
 An assistant that answer inquiries from the user.
                 """
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+An inquiry about national telecom network operations, including traffic rerouting, load balancing, regional performance, SLA compliance, or regulatory reporting.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """
 {instructions_prefix}

--- a/registries/industry/telco_network_support.hocon
+++ b/registries/industry/telco_network_support.hocon
@@ -49,6 +49,18 @@
             "name": "customer_support_rep",
             "function": {
                 "description": "I can help you with your network needs."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+A customer inquiry about telecom network services, connectivity issues, billing, or other telecom support needs.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": """
 You are the top-level agent responsible for handling all inquiries.

--- a/registries/industry/therapy_vignette_supervisors.hocon
+++ b/registries/industry/therapy_vignette_supervisors.hocon
@@ -55,6 +55,18 @@ Do not mention what you can NOT do. Only mention what you can do.
                 "description": """
 An assistant that answer inquiries from the user.
                 """
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": """
+An inquiry about therapy vignettes, clinical supervision, therapeutic approaches, or mental health support scenarios.
+"""
+                        },
+                    },
+                    "required": ["query"]
+                }
             },
             "instructions": ${instructions_prefix} """
 You are the moderator of a supervision session to come up with a treatment plan for a given vignette. The treatment plan should include the following: a diagnosis, therapeutic goals, interventions, and ethical considerations, as follows:


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Agent networks with a front man without `parameter` field cannot be used as external agents.
Use `query` as a parameter for front man of agent networks in industry group since these network can be used as external agents.

Fixes #900 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
