### PR TITLE
Add validation that tools is a list in agent network editor

### DIFF
--- a/coded_tools/agent_network_editor/update_agent.py
+++ b/coded_tools/agent_network_editor/update_agent.py
@@ -78,6 +78,8 @@ class UpdateAgent(CodedTool):
         new_down_chains: list[str] = args.get("new_down_chains")
         if new_down_chains is None:
             return "Error: No down chains list provided."
+        if not isinstance(new_down_chains, list) or not all(isinstance(item, str) for item in new_down_chains):
+            return "Error: down chains must be a list of strings."
 
         logger = logging.getLogger(self.__class__.__name__)
         logger.info(">>>>>>>>>>>>>>>>>>>Update Agent Network Definiton>>>>>>>>>>>>>>>>>>")

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -16,6 +16,7 @@
 
 from typing import Any
 
+from neuro_san.internals.validation.network.keyword_network_validator import KeywordNetworkValidator
 from neuro_san.internals.validation.network.structure_network_validator import StructureNetworkValidator
 from neuro_san.internals.validation.network.toolbox_network_validator import ToolboxNetworkValidator
 from neuro_san.internals.validation.network.url_network_validator import UrlNetworkValidator
@@ -65,6 +66,11 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
             StructureNetworkValidator().validate(network_def)
             + ToolboxNetworkValidator(toolbox_tools).validate(network_def)
             + UrlNetworkValidator(subnetwork_names, mcp_servers).validate(network_def)
+            # Check that "tools" field is a list of str.
+            # Note that keywords argument is for check specific keywords.
+            # Available keywords are "description", "instructions", and "tools".
+            # If keywords is not provided, all keywords will be checked.
+            + KeywordNetworkValidator(keywords=["tools"]).validate(network_def)
         )
 
     def format_error(self, error_list: list[str]) -> str:


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Make sure that agent does not assign string value to `tools`, which should a list of strings.
- Add check in the update agent tool
- Add validation in the middleware

Fixes #909 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
