### PR TITLE
fix: restrict log-level inference to prefix zone (#915)

### DIFF
--- a/plugins/log_bridge/process_log_bridge.py
+++ b/plugins/log_bridge/process_log_bridge.py
@@ -301,7 +301,7 @@ class ProcessLogBridge(ProcessLoggerInterface):
         - Cleans up the pipe and tee file when finished.
         :param pipe: A file-like object (stdout or stderr from a subprocess).
         :param process_name (str): Label for the process.
-        :param stream_tag (str): `"STDOUT"` or `"STDERR"`—used as part of the state key.
+        :param stream_tag (str): `"STDOUT"` or `"STDERR"`--used as part of the state key.
         """
         key = (process_name, stream_tag)
         state = self._streams[key]
@@ -453,9 +453,12 @@ class ProcessLogBridge(ProcessLoggerInterface):
         """
         Infer a log level from textual content.
         Rules:
-            - If the line contains a severity word (INFO, WARNING, ERROR, etc.)
-              that level is returned.
-            - If the line looks like a traceback, ERROR is returned.
+            - Only the log prefix (text before the first '{') is searched
+              for severity keywords, so that words like "error" inside
+              JSON message payloads do not cause false positives.
+            - If the prefix contains a severity word (INFO, WARNING, ERROR,
+              etc.) that level is returned.
+            - If the full line looks like a traceback, ERROR is returned.
             - Otherwise, the provided default is used.
         :param line (str): The raw text line.
         :param default (int): Fallback level.
@@ -463,7 +466,10 @@ class ProcessLogBridge(ProcessLoggerInterface):
         """
         if not line:
             return default
-        m = self._LEVEL_WORD.search(line)
+        # Search only the log prefix before any JSON payload.
+        brace_pos = line.find("{")
+        prefix = line[:brace_pos] if brace_pos > 0 else line
+        m = self._LEVEL_WORD.search(prefix)
         if not m:
             if "traceback" in line.lower():
                 return logging.ERROR
@@ -675,9 +681,9 @@ class ProcessLogBridge(ProcessLoggerInterface):
         """
         Emit a reconstructed multiline block.
         Decision logic:
-            - If block parses as JSON → emit as JSON.
-            - If it matches NeuroSan request-reporting → rebuild + emit.
-            - Otherwise → treat as text (flatten whitespace).
+            - If block parses as JSON -> emit as JSON.
+            - If it matches NeuroSan request-reporting -> rebuild + emit.
+            - Otherwise -> treat as text (flatten whitespace).
         :param state (dict): Per-stream state.
         :param block (str): Reassembled multiline block.
         """

--- a/plugins/log_bridge/process_log_bridge.py
+++ b/plugins/log_bridge/process_log_bridge.py
@@ -468,7 +468,7 @@ class ProcessLogBridge(ProcessLoggerInterface):
             return default
         # Search only the log prefix before any JSON payload.
         brace_pos = line.find("{")
-        prefix = line[:brace_pos] if brace_pos > 0 else line
+        prefix = line[:brace_pos] if brace_pos >= 0 else line
         m = self._LEVEL_WORD.search(prefix)
         if not m:
             if "traceback" in line.lower():

--- a/tests/plugins/test_process_log_bridge.py
+++ b/tests/plugins/test_process_log_bridge.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for ProcessLogBridge._infer_level_from_text (regression for #915)."""
+
+import logging
+from unittest.mock import patch
+
+from plugins.log_bridge.process_log_bridge import ProcessLogBridge
+
+
+class TestInferLevelFromText:
+    """Regression tests for _infer_level_from_text severity inference."""
+
+    @patch.object(ProcessLogBridge, "__init__", lambda self, **kw: None)
+    def _make_bridge(self) -> ProcessLogBridge:
+        bridge = ProcessLogBridge.__new__(ProcessLogBridge)
+        return bridge
+
+    def test_empty_line_returns_default(self):
+        bridge = self._make_bridge()
+        assert bridge._infer_level_from_text("", logging.INFO) == logging.INFO
+
+    def test_none_returns_default(self):
+        bridge = self._make_bridge()
+        assert bridge._infer_level_from_text(None, logging.INFO) == logging.INFO
+
+    def test_plain_error_prefix(self):
+        bridge = self._make_bridge()
+        line = "ERROR: something went wrong"
+        assert bridge._infer_level_from_text(line) == logging.ERROR
+
+    def test_plain_info_prefix(self):
+        bridge = self._make_bridge()
+        line = "INFO starting server on port 8080"
+        assert bridge._infer_level_from_text(line) == logging.INFO
+
+    def test_plain_warning_prefix(self):
+        bridge = self._make_bridge()
+        line = "WARNING deprecated config key"
+        assert bridge._infer_level_from_text(line) == logging.WARNING
+
+    def test_bracketed_timestamp_with_level(self):
+        bridge = self._make_bridge()
+        line = "[2026-04-18 12:17:41 UTC] ERROR    NeuroSan - some message"
+        assert bridge._infer_level_from_text(line) == logging.ERROR
+
+    def test_pipe_delimited_with_level(self):
+        bridge = self._make_bridge()
+        line = "2026-04-18 12:17:41 | WARNING  | module:func:42 - msg"
+        assert bridge._infer_level_from_text(line) == logging.WARNING
+
+    # ---- #915 regression: "error" inside JSON payload must NOT match ----
+
+    def test_error_word_inside_json_payload_returns_default(self):
+        """Exact scenario from #915: malformed JSON with 'error' in agent description."""
+        bridge = self._make_bridge()
+        line = (
+            '{"message": "Received a StreamingChat request for '
+            "'handle error messages and error text from users'\""
+            ", \"message_type\": \"Other\"}"
+        )
+        assert bridge._infer_level_from_text(line) == logging.INFO
+
+    def test_error_word_in_hocon_description_payload(self):
+        """Agent description containing 'error' after a '{' character."""
+        bridge = self._make_bridge()
+        line = (
+            'NeuroSan - {"agent_network_description": "Set instructions for '
+            'the basic_helpdesk agent network to handle error messages"}'
+        )
+        assert bridge._infer_level_from_text(line) == logging.INFO
+
+    def test_level_in_prefix_before_json_payload(self):
+        """Level word in prefix before '{' should still be detected."""
+        bridge = self._make_bridge()
+        line = 'ERROR NeuroSan - {"message": "some info message"}'
+        assert bridge._infer_level_from_text(line) == logging.ERROR
+
+    def test_warning_in_prefix_before_json_payload(self):
+        bridge = self._make_bridge()
+        line = 'WARNING server - {"status": "degraded"}'
+        assert bridge._infer_level_from_text(line) == logging.WARNING
+
+    # ---- traceback detection still works ----
+
+    def test_traceback_returns_error(self):
+        bridge = self._make_bridge()
+        line = "Traceback (most recent call last):"
+        assert bridge._infer_level_from_text(line) == logging.ERROR
+
+    def test_traceback_in_payload_returns_error(self):
+        bridge = self._make_bridge()
+        line = 'some prefix {"traceback": "Traceback (most recent call last):"}'
+        assert bridge._infer_level_from_text(line) == logging.ERROR
+
+    # ---- no false positives on normal text ----
+
+    def test_plain_text_no_level_returns_default(self):
+        bridge = self._make_bridge()
+        line = "Server started successfully on port 8080"
+        assert bridge._infer_level_from_text(line) == logging.INFO
+
+    def test_fatal_maps_to_critical(self):
+        bridge = self._make_bridge()
+        line = "FATAL: out of memory"
+        assert bridge._infer_level_from_text(line) == logging.CRITICAL
+
+    def test_debug_level(self):
+        bridge = self._make_bridge()
+        line = "DEBUG entering function foo"
+        assert bridge._infer_level_from_text(line) == logging.DEBUG
+
+    def test_line_with_only_brace_no_prefix_level(self):
+        """Line starting with '{' and no level word should return default."""
+        bridge = self._make_bridge()
+        line = '{"error": "something broke", "level": "info"}'
+        assert bridge._infer_level_from_text(line) == logging.INFO

--- a/tests/plugins/test_process_log_bridge.py
+++ b/tests/plugins/test_process_log_bridge.py
@@ -71,7 +71,7 @@ class TestInferLevelFromText:
         line = (
             '{"message": "Received a StreamingChat request for '
             "'handle error messages and error text from users'\""
-            ", \"message_type\": \"Other\"}"
+            ', "message_type": "Other"}'
         )
         assert bridge._infer_level_from_text(line) == logging.INFO
 

--- a/tests/plugins/test_process_log_bridge.py
+++ b/tests/plugins/test_process_log_bridge.py
@@ -31,37 +31,44 @@ class TestInferLevelFromText:
         return bridge
 
     def test_empty_line_returns_default(self):
+        """Verify empty string falls back to the provided default level."""
         bridge = self._make_bridge()
-        assert bridge._infer_level_from_text("", logging.INFO) == logging.INFO
+        assert bridge._infer_level_from_text("", logging.INFO) == logging.INFO  # pylint: disable=protected-access
 
     def test_none_returns_default(self):
+        """Verify None input falls back to the provided default level."""
         bridge = self._make_bridge()
-        assert bridge._infer_level_from_text(None, logging.INFO) == logging.INFO
+        assert bridge._infer_level_from_text(None, logging.INFO) == logging.INFO  # pylint: disable=protected-access
 
     def test_plain_error_prefix(self):
+        """Verify plain ERROR prefix is detected."""
         bridge = self._make_bridge()
         line = "ERROR: something went wrong"
-        assert bridge._infer_level_from_text(line) == logging.ERROR
+        assert bridge._infer_level_from_text(line) == logging.ERROR  # pylint: disable=protected-access
 
     def test_plain_info_prefix(self):
+        """Verify plain INFO prefix is detected."""
         bridge = self._make_bridge()
         line = "INFO starting server on port 8080"
-        assert bridge._infer_level_from_text(line) == logging.INFO
+        assert bridge._infer_level_from_text(line) == logging.INFO  # pylint: disable=protected-access
 
     def test_plain_warning_prefix(self):
+        """Verify plain WARNING prefix is detected."""
         bridge = self._make_bridge()
         line = "WARNING deprecated config key"
-        assert bridge._infer_level_from_text(line) == logging.WARNING
+        assert bridge._infer_level_from_text(line) == logging.WARNING  # pylint: disable=protected-access
 
     def test_bracketed_timestamp_with_level(self):
+        """Verify level detection in bracketed timestamp format."""
         bridge = self._make_bridge()
         line = "[2026-04-18 12:17:41 UTC] ERROR    NeuroSan - some message"
-        assert bridge._infer_level_from_text(line) == logging.ERROR
+        assert bridge._infer_level_from_text(line) == logging.ERROR  # pylint: disable=protected-access
 
     def test_pipe_delimited_with_level(self):
+        """Verify level detection in pipe-delimited log format."""
         bridge = self._make_bridge()
         line = "2026-04-18 12:17:41 | WARNING  | module:func:42 - msg"
-        assert bridge._infer_level_from_text(line) == logging.WARNING
+        assert bridge._infer_level_from_text(line) == logging.WARNING  # pylint: disable=protected-access
 
     # ---- #915 regression: "error" inside JSON payload must NOT match ----
 
@@ -73,7 +80,7 @@ class TestInferLevelFromText:
             "'handle error messages and error text from users'\""
             ', "message_type": "Other"}'
         )
-        assert bridge._infer_level_from_text(line) == logging.INFO
+        assert bridge._infer_level_from_text(line) == logging.INFO  # pylint: disable=protected-access
 
     def test_error_word_in_hocon_description_payload(self):
         """Agent description containing 'error' after a '{' character."""
@@ -82,50 +89,56 @@ class TestInferLevelFromText:
             'NeuroSan - {"agent_network_description": "Set instructions for '
             'the basic_helpdesk agent network to handle error messages"}'
         )
-        assert bridge._infer_level_from_text(line) == logging.INFO
+        assert bridge._infer_level_from_text(line) == logging.INFO  # pylint: disable=protected-access
 
     def test_level_in_prefix_before_json_payload(self):
         """Level word in prefix before '{' should still be detected."""
         bridge = self._make_bridge()
         line = 'ERROR NeuroSan - {"message": "some info message"}'
-        assert bridge._infer_level_from_text(line) == logging.ERROR
+        assert bridge._infer_level_from_text(line) == logging.ERROR  # pylint: disable=protected-access
 
     def test_warning_in_prefix_before_json_payload(self):
+        """Verify WARNING in prefix before JSON payload is detected."""
         bridge = self._make_bridge()
         line = 'WARNING server - {"status": "degraded"}'
-        assert bridge._infer_level_from_text(line) == logging.WARNING
+        assert bridge._infer_level_from_text(line) == logging.WARNING  # pylint: disable=protected-access
 
     # ---- traceback detection still works ----
 
     def test_traceback_returns_error(self):
+        """Verify Traceback line is classified as ERROR."""
         bridge = self._make_bridge()
         line = "Traceback (most recent call last):"
-        assert bridge._infer_level_from_text(line) == logging.ERROR
+        assert bridge._infer_level_from_text(line) == logging.ERROR  # pylint: disable=protected-access
 
     def test_traceback_in_payload_returns_error(self):
+        """Verify Traceback inside a payload is still classified as ERROR."""
         bridge = self._make_bridge()
         line = 'some prefix {"traceback": "Traceback (most recent call last):"}'
-        assert bridge._infer_level_from_text(line) == logging.ERROR
+        assert bridge._infer_level_from_text(line) == logging.ERROR  # pylint: disable=protected-access
 
     # ---- no false positives on normal text ----
 
     def test_plain_text_no_level_returns_default(self):
+        """Verify plain text with no level keyword returns default INFO."""
         bridge = self._make_bridge()
         line = "Server started successfully on port 8080"
-        assert bridge._infer_level_from_text(line) == logging.INFO
+        assert bridge._infer_level_from_text(line) == logging.INFO  # pylint: disable=protected-access
 
     def test_fatal_maps_to_critical(self):
+        """Verify FATAL prefix maps to CRITICAL level."""
         bridge = self._make_bridge()
         line = "FATAL: out of memory"
-        assert bridge._infer_level_from_text(line) == logging.CRITICAL
+        assert bridge._infer_level_from_text(line) == logging.CRITICAL  # pylint: disable=protected-access
 
     def test_debug_level(self):
+        """Verify DEBUG prefix is detected."""
         bridge = self._make_bridge()
         line = "DEBUG entering function foo"
-        assert bridge._infer_level_from_text(line) == logging.DEBUG
+        assert bridge._infer_level_from_text(line) == logging.DEBUG  # pylint: disable=protected-access
 
     def test_line_with_only_brace_no_prefix_level(self):
         """Line starting with '{' and no level word should return default."""
         bridge = self._make_bridge()
         line = '{"error": "something broke", "level": "info"}'
-        assert bridge._infer_level_from_text(line) == logging.INFO
+        assert bridge._infer_level_from_text(line) == logging.INFO  # pylint: disable=protected-access


### PR DESCRIPTION
## Summary

Fixes #915 - Server log messages labeled as ERROR when they should be INFO.

### Root cause

`_infer_level_from_text()` in `process_log_bridge.py` uses a regex `\b(DEBUG|INFO|WARNING|ERROR|CRITICAL|FATAL)\b` that searches the **entire line** for severity keywords. When neuro-san emits malformed JSON (due to `%(message)s` string interpolation in `logging.hocon`), the log bridge falls back to text-based level inference and incorrectly matches words like "error" that appear inside LLM-generated agent descriptions (e.g. `"handle error messages"` in `basic_helpdesk.hocon` lines 64, 73, 98, 110, 147).

### Fix

Restrict the severity-keyword search to the **log prefix** only, defined as the portion of the line before the first `{` character. This excludes JSON message payloads from the search while preserving correct detection of level words in structured log prefixes like `[2026-04-18 12:17:41 UTC] ERROR    NeuroSan - {...}`.

The change is a 3-line diff in `_infer_level_from_text()`:
```python
# Before: searched the entire line
m = self._LEVEL_WORD.search(line)

# After: search only the prefix before any JSON payload
brace_pos = line.find("{")
prefix = line[:brace_pos] if brace_pos > 0 else line
m = self._LEVEL_WORD.search(prefix)
```

### Files changed

- `plugins/log_bridge/process_log_bridge.py` - Fix in `_infer_level_from_text()`
- `tests/plugins/test_process_log_bridge.py` - 17 regression tests covering the exact #915 scenario plus edge cases

## Test plan

- [ ] `test_error_word_inside_json_payload_returns_default` - exact #915 reproduction: malformed JSON with "error" in agent description returns INFO, not ERROR
- [ ] `test_error_word_in_hocon_description_payload` - "error" after `{` in HOCON-style payload returns INFO
- [ ] `test_level_in_prefix_before_json_payload` - ERROR in prefix before `{` still detected correctly
- [ ] `test_bracketed_timestamp_with_level` - `[timestamp] ERROR` format still works
- [ ] `test_traceback_returns_error` - traceback detection unchanged
- [ ] `test_fatal_maps_to_critical` - FATAL mapping preserved
- [ ] `test_line_with_only_brace_no_prefix_level` - line starting with `{` and no prefix level returns default"