### PR TITLE
Add agent description through the full agent network designer pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,9 +65,11 @@ jobs:
       - name: Run dead link checker
         shell: bash
         run: |
-          curl --silent --location \
+          curl --silent --location --fail \
           https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
-          | tar --extract --gzip --directory /tmp
+          -o /tmp/lychee.tar.gz
+          tar --extract --gzip --directory /tmp --file /tmp/lychee.tar.gz
+          ls /tmp/lychee
           # To prevent flaky CI failures, accept:
           # - 401 (Unauthorized) for API endpoints that require authentication
           # - 403 (Forbidden) if the server blocks bots or requests without a browser-like User-Agent

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -46,7 +46,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         """
         self.include_keys = include_keys
         if include_keys is None:
-            self.include_keys = ["tools", "instructions"]
+            self.include_keys = ["tools", "instructions", "description"]
 
     def to_dict(self, obj: Connectivity) -> dict[str, Any]:
         """

--- a/coded_tools/agent_network_editor/create_network.py
+++ b/coded_tools/agent_network_editor/create_network.py
@@ -91,6 +91,7 @@ class CreateNetwork(CodedTool):
             sly_data[AGENT_NETWORK_DEFINITION][agent_name] = {}
             if not is_tool_list[i]:
                 sly_data[AGENT_NETWORK_DEFINITION][agent_name]["instructions"] = ""
+                sly_data[AGENT_NETWORK_DEFINITION][agent_name]["description"] = ""
         logger.info("The resulting agent network definition: \n %s", str(sly_data[AGENT_NETWORK_DEFINITION]))
 
         # Put the agent network name in the sly data

--- a/coded_tools/agent_network_instructions_editor/set_agent_description.py
+++ b/coded_tools/agent_network_instructions_editor/set_agent_description.py
@@ -60,7 +60,7 @@ class SetAgentDescription(CodedTool):
 
         :return:
             In case of successful execution:
-                a text string indicating the new value of "description" of the agent.
+                a text string indicating the new value of "description" of the agent has been set.
             otherwise:
                 a text string an error message in the format:
                 "Error: <error message>"

--- a/coded_tools/agent_network_instructions_editor/set_agent_description.py
+++ b/coded_tools/agent_network_instructions_editor/set_agent_description.py
@@ -74,8 +74,11 @@ class SetAgentDescription(CodedTool):
             return "Error: No agent_name provided."
         if the_agent_name not in network_def:
             return f"Error: Agent not found: {the_agent_name}"
-        if network_def[the_agent_name].get("description") is None:
-            return f"Error: Agent has no description field: {the_agent_name}. It is a function agent."
+        # Use "instructions" field existence to determine if it is a function agent
+        # instead of "description" field to allow backwards compatibility with agent network definitions
+        # that do not have "description" field for function agents
+        if network_def[the_agent_name].get("instructions") is None:
+            return f"Error: Agent has no instructions field: {the_agent_name}. It is a function agent."
 
         new_description: str = args.get("new_description")
         if not new_description:
@@ -92,4 +95,4 @@ class SetAgentDescription(CodedTool):
         await ProgressHandler.report_progress(args, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
-        return f"The description for '{the_agent_name}' have been set in 'agent_network_definition' successfully."
+        return f"The description for '{the_agent_name}' has been set in 'agent_network_definition' successfully."

--- a/coded_tools/agent_network_instructions_editor/set_agent_description.py
+++ b/coded_tools/agent_network_instructions_editor/set_agent_description.py
@@ -23,9 +23,10 @@ from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.progress_handler import ProgressHandler
 
 
-class AddAgent(CodedTool):
+class SetAgentDescription(CodedTool):
     """
-    CodedTool implementation which adds an agent to the agent network definition in the sly data.
+    CodedTool implementation which creates or modifies the description of an agent
+    of an agent network definition in sly data.
 
     Agent network definition is a structured representation of an agent network, expressed as a dictionary.
     Each key is an agent name, and its value is an object containing:
@@ -34,15 +35,15 @@ class AddAgent(CodedTool):
     - a list of down-chain agents (agents reporting to it)
     """
 
-    async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any] | str:
+    async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> str:
         """
         :param args: An argument dictionary whose keys are the parameters
                 to the coded tool and whose values are the values passed for them
                 by the calling agent.  This dictionary is to be treated as read-only.
 
                 The argument dictionary expects the following keys:
-                    "agent_name": the name of the agent to add.
-                    "is_tool": whether the agent is a tool or not.
+                    "agent_name": the name of the agent to update description.
+                    "new_description": the new value of description.
 
         :param sly_data: A dictionary whose keys are defined by the agent hierarchy,
                 but whose values are meant to be kept out of the chat stream.
@@ -59,34 +60,36 @@ class AddAgent(CodedTool):
 
         :return:
             In case of successful execution:
-                a text string confirming successful adding of the agent in the agent network definition.
+                a text string indicating the new value of "description" of the agent.
             otherwise:
-                a text string of an error message in the format:
+                a text string an error message in the format:
                 "Error: <error message>"
         """
         network_def: dict[str, Any] = sly_data.get(AGENT_NETWORK_DEFINITION)
         if not network_def:
-            network_def = {}
+            return "Error: No network in sly data!"
 
-        the_agent_name: str = args.get("agent_name", "")
-        if the_agent_name == "":
+        the_agent_name: str = args.get("agent_name")
+        if not the_agent_name:
             return "Error: No agent_name provided."
-        is_tool: bool = args.get("is_tool")
-        if is_tool is None:
-            return "Error: No is_tool provided."
+        if the_agent_name not in network_def:
+            return f"Error: Agent not found: {the_agent_name}"
+        if network_def[the_agent_name].get("description") is None:
+            return f"Error: Agent has no description field: {the_agent_name}. It is a function agent."
+
+        new_description: str = args.get("new_description")
+        if not new_description:
+            return "Error: No agent description provided."
 
         logger = logging.getLogger(self.__class__.__name__)
-        logger.info(">>>>>>>>>>>>>>>>>>>Add Agent>>>>>>>>>>>>>>>>>>")
-        logger.info("Agent Name: %s", str(the_agent_name))
-        logger.info("Is Tool: %s", str(is_tool))
-        network_def[the_agent_name] = {}
-        if not is_tool:
-            network_def[the_agent_name]["instructions"] = ""
-            network_def[the_agent_name]["description"] = ""
-        logger.info("The resulting agent network definition: \n %s", str(network_def))
+        logger.info(">>>>>>>>>>>>>>>>>>>Set Agent description>>>>>>>>>>>>>>>>>>")
+        logger.info("Agent Name: %s", the_agent_name)
+        logger.info("Description: %s", new_description)
+        network_def[the_agent_name]["description"] = new_description
+        logger.info("The resulting agent network: \n %s", str(network_def))
         sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
         await ProgressHandler.report_progress(args, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
-        return f"Successfully added agent {the_agent_name} to the agent network definition."
+        return f"The description for '{the_agent_name}' have been set in 'agent_network_definition' successfully."

--- a/coded_tools/agent_network_instructions_editor/set_agent_instructions.py
+++ b/coded_tools/agent_network_instructions_editor/set_agent_instructions.py
@@ -60,7 +60,7 @@ class SetAgentInstructions(CodedTool):
 
         :return:
             In case of successful execution:
-                a text string indicating the new value of "instructions" of the agent.
+                a text string indicating the new value of "instructions" of the agent has been set.
             otherwise:
                 a text string an error message in the format:
                 "Error: <error message>"

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -210,7 +210,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                 self.logger.warning(
                     "WARNING: Skipping agent %s due to non-string 'instructions' in '%s'",
                     agent_name,
-                    network_hocon_file
+                    network_hocon_file,
                 )
                 return agent_name, agent_def
             if instructions.strip():
@@ -224,7 +224,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                 self.logger.warning(
                     "WARNING: Skipping agent %s due to non-string 'description' in '%s'",
                     agent_name,
-                    network_hocon_file
+                    network_hocon_file,
                 )
                 return agent_name, agent_def
             if description.strip():

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -218,7 +218,8 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                 # (remove aaosa instructions, instructions prefix, and demo mode)
                 agent_def["instructions"] = await self._extract_custom_instructions(instructions.strip(), sly_data)
 
-        description: str | None = agent.get("function", {}).get("description")
+        function: dict[str, Any] = agent.get("function", {})
+        description: str | None = function.get("description") if isinstance(function, dict) else None
         if description is not None:
             if not isinstance(description, str):
                 self.logger.warning(

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -151,7 +151,11 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         :return: Agent network definition
         """
 
-        if network_hocon_file is None:
+        if not isinstance(network_hocon_file, str) or not network_hocon_file:
+            self.logger.warning(
+                "WARNING: Invalid network_hocon_file value (expected str, got %r); skipping.",
+                network_hocon_file,
+            )
             return None
 
         # Converting hocon file to dict

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -209,7 +209,8 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             if not isinstance(instructions, str):
                 self.logger.warning(
                     "WARNING: Skipping agent %s due to non-string 'instructions' in '%s'",
-                    agent_name, network_hocon_file
+                    agent_name,
+                    network_hocon_file
                 )
                 return agent_name, agent_def
             if instructions.strip():
@@ -222,7 +223,8 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             if not isinstance(description, str):
                 self.logger.warning(
                     "WARNING: Skipping agent %s due to non-string 'description' in '%s'",
-                    agent_name, network_hocon_file
+                    agent_name,
+                    network_hocon_file
                 )
                 return agent_name, agent_def
             if description.strip():

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -151,48 +151,88 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         :return: Agent network definition
         """
 
+        if network_hocon_file is None:
+            return None
+
         # Converting hocon file to dict
         # Note we don't need to cache this because we only expect to read the file once.
         try:
-            network_hocon_file = "registries/" + network_hocon_file
             hocon = AbstractAsyncConfigRestorer(file_purpose="get_agent_network_definition", must_exist=True)
-            network_hocon = await hocon.async_restore(file_reference=network_hocon_file)
-        except (FileNotFoundError, TypeError):
+            network_hocon = await hocon.async_restore(file_reference="registries/" + network_hocon_file)
+        except FileNotFoundError:
             return None
 
         agents: list[dict[str, Any]] | None = network_hocon.get("tools")
-        if agents is None:
-            self.logger.warning("WARNING: No field 'tools' found in %s.", network_hocon_file)
-            return None
         if not isinstance(agents, list):
-            self.logger.warning("WARNING: The 'tools' field in '%s' is not a list.", network_hocon_file)
+            msg = "No field 'tools' found" if agents is None else "The 'tools' field is not a list"
+            self.logger.warning("WARNING: %s in '%s'.", msg, network_hocon_file)
             return None
 
         network_def: dict[str, Any] = {}
         for agent in agents:
-            if not isinstance(agent, dict):
-                self.logger.warning(
-                    "WARNING: Skipping non-dict entry in 'tools' list in '%s': %r", network_hocon_file, agent
-                )
-                continue
-            # Only extract agents info and only "instructions" and "tools" parts
-            agent_name: str | None = agent.get("name")
-            if not isinstance(agent_name, str) or not agent_name:
-                self.logger.warning(
-                    "WARNING: Skipping agent with missing/invalid 'name' in '%s': %r", network_hocon_file, agent
-                )
-                continue
-            network_def[agent_name] = {}
-            instructions: str | None = agent.get("instructions")
-            if instructions:
-                # Extract only the unique instructions (remove aaosa instructions, instructions prefix, and demo mode)
-                custom_instructions: str = await self._extract_custom_instructions(instructions, sly_data)
-                network_def[agent_name]["instructions"] = custom_instructions
-            tools: list[str] | None = agent.get("tools")
-            if tools:
-                network_def[agent_name]["tools"] = tools
+            name, agent_def = await self._parse_agent(agent, network_hocon_file, sly_data)
+            if name is not None:
+                network_def[name] = agent_def
 
         return network_def
+
+    async def _parse_agent(
+        self, agent: Any, network_hocon_file: str, sly_data: dict[str, Any]
+    ) -> tuple[str | None, dict[str, Any]]:
+        """
+        Parse a single agent entry from the hocon 'tools' list.
+
+        :param agent: A single entry from the 'tools' list in the hocon file
+        :param network_hocon_file: Agent network hocon file path (used for warning messages)
+        :param sly_data: A dictionary whose keys are defined by the agent hierarchy
+
+        :return: (agent_name, agent_def) where agent_name is None if the entry should be skipped
+        """
+        if not isinstance(agent, dict):
+            self.logger.warning(
+                "WARNING: Skipping non-dict entry in 'tools' list in '%s': %r", network_hocon_file, agent
+            )
+            return None, {}
+
+        agent_name: str | None = agent.get("name")
+        if not isinstance(agent_name, str) or not agent_name:
+            self.logger.warning(
+                "WARNING: Skipping agent with missing/invalid 'name' in '%s': %r", network_hocon_file, agent
+            )
+            return None, {}
+
+        # Only extract agents info and only "instructions" and "tools" parts
+        agent_def: dict[str, Any] = {}
+
+        instructions: str | None = agent.get("instructions")
+        if instructions is not None:
+            if not isinstance(instructions, str):
+                self.logger.warning(
+                    "WARNING: Skipping agent %s due to non-string 'instructions' in '%s'",
+                    agent_name, network_hocon_file
+                )
+                return agent_name, agent_def
+            if instructions.strip():
+                # Extract only the unique instructions
+                # (remove aaosa instructions, instructions prefix, and demo mode)
+                agent_def["instructions"] = await self._extract_custom_instructions(instructions.strip(), sly_data)
+
+        description: str | None = agent.get("function", {}).get("description")
+        if description is not None:
+            if not isinstance(description, str):
+                self.logger.warning(
+                    "WARNING: Skipping agent %s due to non-string 'description' in '%s'",
+                    agent_name, network_hocon_file
+                )
+                return agent_name, agent_def
+            if description.strip():
+                agent_def["description"] = description.strip()
+
+        tools: list[str] | None = agent.get("tools")
+        if tools:
+            agent_def["tools"] = tools
+
+        return agent_name, agent_def
 
     async def _extract_custom_instructions(self, instructions: str, sly_data: dict[str, Any]) -> str:
         """

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -212,11 +212,15 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                     agent_name,
                     network_hocon_file,
                 )
-                return agent_name, agent_def
+                return None, {}
             if instructions.strip():
                 # Extract only the unique instructions
                 # (remove aaosa instructions, instructions prefix, and demo mode)
                 agent_def["instructions"] = await self._extract_custom_instructions(instructions.strip(), sly_data)
+
+            # Initialize description for non-function agents so the description setter
+            # can distinguish them from function/toolbox agents (which have no description key).
+            agent_def["description"] = ""
 
         function: dict[str, Any] = agent.get("function", {})
         description: str | None = function.get("description") if isinstance(function, dict) else None
@@ -227,7 +231,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                     agent_name,
                     network_hocon_file,
                 )
-                return agent_name, agent_def
+                return None, {}
             if description.strip():
                 agent_def["description"] = description.strip()
 

--- a/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
@@ -94,7 +94,9 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
             # Note that these are only set up for per-agent replacement values.
             string_replacements: dict[str, Any] = {
                 "agent_name": agent_name,
-                "agent_instructions": agent_def.get("instructions"),
+                # Note that get() or "" is used to avoid issues if the field is set to None.
+                "agent_instructions": (agent_def.get("instructions") or "").strip(),
+                "agent_description": (agent_def.get("description") or "").strip(),
                 "agent_network_name": agent_network_name,
             }
             value_replacements: dict[str, Any] = {"tools": tools}
@@ -120,13 +122,16 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
                 agent_spec_template, string_replacements, value_replacements
             )
 
-            # For the top agent, aaosa_call is used as the function base but its description
-            # is replaced with the top agent's own description (analogous to
-            # ${aaosa_call}{ "description": "..." } in HOCON).
-            if agent_name == top_agent_name and isinstance(agent_spec.get("function"), dict):
-                # This hard-coded description is a temporary solution
-                # until we have a description generator/editor in place.
-                agent_spec["function"]["description"] = "An assistant that answers inquiries from the user."
+            # Move agent_description (substituted from the template) into function.description,
+            # analogous to ${aaosa_call}{ "description": "..." } in HOCON.
+            description: str = agent_spec.pop("agent_description", "")
+            if isinstance(agent_spec.get("function"), dict):
+                if agent_name == top_agent_name:
+                    agent_spec["function"]["description"] = (
+                        description or "An assistant that answers inquiries from the user."
+                    )
+                else:
+                    agent_spec["function"]["description"] = description
 
             # Add agent to tools
             agent_network["tools"].append(agent_spec)

--- a/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
@@ -87,29 +87,32 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
         agent_name: str = None
         agent_def: dict[str, Any] = {}
         for agent_name, agent_def in use_network_def.items():
-            # Find bits and pieces from the agent definition in the larger network definition
-            tools: list[str] = agent_def.get("tools", None)
+            # Find bits and pieces from the agent definition in the larger network definition.
+            # Note that `or` pattern is used to avoid issues if the field is set to None.
+            tools: list[str] = agent_def.get("tools") or []
+            agent_instructions: str = (agent_def.get("instructions") or "").strip()
+            agent_description: str = (agent_def.get("description") or "").strip()
 
             # Set up replacement strings and values for the filter
             # Note that these are only set up for per-agent replacement values.
             string_replacements: dict[str, Any] = {
                 "agent_name": agent_name,
-                # Note that get() or "" is used to avoid issues if the field is set to None.
-                "agent_instructions": (agent_def.get("instructions") or "").strip(),
-                "agent_description": (agent_def.get("description") or "").strip(),
+                "agent_instructions": agent_instructions,
+                "agent_description": agent_description,
                 "agent_network_name": agent_network_name,
             }
             value_replacements: dict[str, Any] = {"tools": tools}
 
-            # Find what node template to use from the tools
+            # Find what node template to use from the normalized values to stay consistent
+            # with what will be rendered after stripping.
             template_index: int = -1
             if agent_name == top_agent_name:
                 # Top agent
                 template_index = 0
-            elif agent_def.get("tools"):
+            elif tools:
                 # Regular agent
                 template_index = 1
-            elif agent_def.get("instructions"):
+            elif agent_instructions:
                 # Leaf agent
                 template_index = 2
             else:

--- a/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
@@ -98,7 +98,6 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
             string_replacements: dict[str, Any] = {
                 "agent_name": agent_name,
                 "agent_instructions": agent_instructions,
-                "agent_description": agent_description,
                 "agent_network_name": agent_network_name,
             }
             value_replacements: dict[str, Any] = {"tools": tools}
@@ -125,16 +124,15 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
                 agent_spec_template, string_replacements, value_replacements
             )
 
-            # Move agent_description (substituted from the template) into function.description,
+            # Set function.description directly from the agent_network_definition,
             # analogous to ${aaosa_call}{ "description": "..." } in HOCON.
-            description: str = agent_spec.pop("agent_description", "")
             if isinstance(agent_spec.get("function"), dict):
                 if agent_name == top_agent_name:
                     agent_spec["function"]["description"] = (
-                        description or "An assistant that answers inquiries from the user."
+                        agent_description or "An assistant that answers inquiries from the user."
                     )
                 else:
-                    agent_spec["function"]["description"] = description
+                    agent_spec["function"]["description"] = agent_description
 
             # Add agent to tools
             agent_network["tools"].append(agent_spec)

--- a/middleware/agent_network_designer/persistence/deployable_template.hocon
+++ b/middleware/agent_network_designer/persistence/deployable_template.hocon
@@ -55,6 +55,9 @@ Do not mention what you can NOT do. Only mention what you can do.
         # Top agent template
         {
             "name": "{agent_name}",
+            # Use "agent_description" since there could also be a "parameter_description",
+            # and we want to avoid confusion between the two.
+            "agent_description": "{agent_description}",
             "function": "aaosa_call",
             "instructions": """
 {instructions_prefix}
@@ -73,6 +76,9 @@ call all the relevant tools and make sure the command is fully serviced and expr
         # Regular agent template
         {
             "name": "{agent_name}",
+            # Use "agent_description" since there could also be a "parameter_description",
+            # and we want to avoid confusion between the two.
+            "agent_description": "{agent_description}",
             "function": "aaosa_call",
             "instructions": """
 {instructions_prefix}
@@ -88,6 +94,9 @@ call all the relevant tools and make sure the command is fully serviced and expr
         # Leaf agent template
         {
             "name": "{agent_name}",
+            # Use "agent_description" since there could also be a "parameter_description",
+            # and we want to avoid confusion between the two.
+            "agent_description": "{agent_description}",
             "function": "aaosa_call",
             "instructions": """
 {instructions_prefix}

--- a/middleware/agent_network_designer/persistence/deployable_template.hocon
+++ b/middleware/agent_network_designer/persistence/deployable_template.hocon
@@ -55,9 +55,6 @@ Do not mention what you can NOT do. Only mention what you can do.
         # Top agent template
         {
             "name": "{agent_name}",
-            # Use "agent_description" since there could also be a "parameter_description",
-            # and we want to avoid confusion between the two.
-            "agent_description": "{agent_description}",
             "function": "aaosa_call",
             "instructions": """
 {instructions_prefix}
@@ -76,9 +73,6 @@ call all the relevant tools and make sure the command is fully serviced and expr
         # Regular agent template
         {
             "name": "{agent_name}",
-            # Use "agent_description" since there could also be a "parameter_description",
-            # and we want to avoid confusion between the two.
-            "agent_description": "{agent_description}",
             "function": "aaosa_call",
             "instructions": """
 {instructions_prefix}
@@ -94,9 +88,6 @@ call all the relevant tools and make sure the command is fully serviced and expr
         # Leaf agent template
         {
             "name": "{agent_name}",
-            # Use "agent_description" since there could also be a "parameter_description",
-            # and we want to avoid confusion between the two.
-            "agent_description": "{agent_description}",
             "function": "aaosa_call",
             "instructions": """
 {instructions_prefix}

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -224,8 +224,9 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
 
         :return: The rendered agent block as a string.
         """
-        tools: str = self._format_tools(agent.get("tools", []))
-        # Note that get() or "" is used to avoid issues if the field is set to None.
+        # Note that `get() or`` pattern is used to avoid issues if the field is set to None.
+        raw_tools: list[str] = agent.get("tools") or []
+        tools: str = self._format_tools(raw_tools)
         description: str = (agent.get("description") or "").strip()
         instructions: str = (agent.get("instructions") or "").strip()
 
@@ -233,10 +234,10 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
             use_description = description or "An assistant that answers inquiries from the user."
             return TOP_AGENT_TEMPLATE % (agent_name, use_description, instructions, tools)
 
-        if agent.get("tools"):
+        if raw_tools:
             return REGULAR_AGENT_TEMPLATE % (agent_name, description, instructions, tools)
 
-        if agent.get("instructions"):
+        if instructions:
             demo_prefix = "${demo_mode}" if self.demo_mode else ""
             return LEAF_NODE_AGENT_TEMPLATE % (agent_name, description, demo_prefix, instructions)
         return TOOLBOX_AGENT_TEMPLATE % (agent_name, agent_name)

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -67,7 +67,7 @@ TOP_AGENT_TEMPLATE = (
     '            "name": "%s",\n'
     '            "function": ${aaosa_call}{\n'
     '                "description": """\n'
-    "An assistant that answers inquiries from the user.\n"
+    "%s\n"
     '                """\n'
     "            },\n"
     '            "instructions": ${instructions_prefix} """\n'
@@ -82,7 +82,11 @@ TOP_AGENT_TEMPLATE = (
 REGULAR_AGENT_TEMPLATE = (
     "        {\n"
     '            "name": "%s",\n'
-    '            "function": ${aaosa_call},\n'
+    '            "function": ${aaosa_call}{\n'
+    '                "description": """\n'
+    "%s\n"
+    '                """\n'
+    "            },\n"
     '            "instructions": ${instructions_prefix} """\n'
     "%s\n"
     '""" ${aaosa_instructions},\n'
@@ -93,7 +97,11 @@ REGULAR_AGENT_TEMPLATE = (
 LEAF_NODE_AGENT_TEMPLATE = (
     "        {\n"
     '            "name": "%s",\n'
-    '            "function": ${aaosa_call},\n'
+    '            "function": ${aaosa_call}{\n'
+    '                "description": """\n'
+    "%s\n"
+    '                """\n'
+    "            },\n"
     '            "instructions": ${instructions_prefix} %s """\n'
     "%s\n"
     '""",\n'
@@ -138,12 +146,12 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
 
         :return: A full agent network HOCON as a string.
         """
-        use_network_def = shallow_copy(network_def)
+        use_network_def: dict[str, Any] = shallow_copy(network_def)
         use_network_def = self._move_top_agent_first(use_network_def, top_agent_name)
 
-        header = self._build_header(agent_network_name, sample_queries)
+        header: str = self._build_header(agent_network_name, sample_queries)
 
-        body = []
+        body: list[str] = []
         for agent_name, agent in use_network_def.items():
             body.append(self._render_agent_block(agent_name, agent, top_agent_name))
 
@@ -159,7 +167,7 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         :return: Updated network definition with top agent first.
         """
         if top_agent_name != next(iter(network_def)):
-            top_agent = network_def.pop(top_agent_name)
+            top_agent: dict[str, Any] = network_def.pop(top_agent_name)
             return {top_agent_name: top_agent, **network_def}
         return network_def
 
@@ -171,9 +179,9 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
 
         :return: Formatted sample queries as a string.
         """
-        formatted_queries = ""
+        formatted_queries: str = ""
         if sample_queries:
-            parts = []
+            parts: list[str] = []
             for query in sample_queries:
                 # Put each query in triple quotes to allow for multi-line queries and
                 # to avoid issues with special characters.
@@ -190,9 +198,9 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
 
         :return: The header of the HOCON agent network file as a string.
         """
-        formatted_queries = self._format_sample_queries(sample_queries)
-        date_created = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
-        demo_mode_block = (
+        formatted_queries: str = self._format_sample_queries(sample_queries)
+        date_created: str = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+        demo_mode_block: str = (
             '   "demo_mode": "You are part of a demo system, so when queried, make up a realistic '
             "response as if you are actually grounded in real data or you are operating a real "
             'application API or microservice.",\n'
@@ -216,18 +224,21 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
 
         :return: The rendered agent block as a string.
         """
-        tools = self._format_tools(agent.get("tools", []))
+        tools: str = self._format_tools(agent.get("tools", []))
+        # Note that get() or "" is used to avoid issues if the field is set to None.
+        description: str = (agent.get("description") or "").strip()
+        instructions: str = (agent.get("instructions") or "").strip()
 
         if agent_name == top_agent_name:
-            return TOP_AGENT_TEMPLATE % (agent_name, agent["instructions"], tools)
+            use_description = description or "An assistant that answers inquiries from the user."
+            return TOP_AGENT_TEMPLATE % (agent_name, use_description, instructions, tools)
 
         if agent.get("tools"):
-            return REGULAR_AGENT_TEMPLATE % (agent_name, agent["instructions"], tools)
+            return REGULAR_AGENT_TEMPLATE % (agent_name, description, instructions, tools)
 
         if agent.get("instructions"):
             demo_prefix = "${demo_mode}" if self.demo_mode else ""
-            return LEAF_NODE_AGENT_TEMPLATE % (agent_name, demo_prefix, agent["instructions"])
-
+            return LEAF_NODE_AGENT_TEMPLATE % (agent_name, description, demo_prefix, instructions)
         return TOOLBOX_AGENT_TEMPLATE % (agent_name, agent_name)
 
     def _format_tools(self, tools: list[str]) -> str:

--- a/middleware/agent_network_designer/validation/agent_network_instructions_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_instructions_validation_middleware.py
@@ -50,7 +50,7 @@ class AgentNetworkInstructionsValidationMiddleware(AgentNetworkValidationMiddlew
         :return: A list of error strings (empty if valid)
         """
         # Copy network_def and modify the copy so that the "description" is under "function".
-        # This allows the keyword validatior to check for missing "description" fields.
+        # This allows the keyword validator to check for missing "description" fields.
         use_network_def: dict[str, Any] = {}
         for agent_name, agent_def in network_def.items():
             agent_copy: dict[str, Any] = agent_def.copy()

--- a/middleware/agent_network_designer/validation/agent_network_instructions_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_instructions_validation_middleware.py
@@ -25,10 +25,10 @@ from middleware.agent_network_designer.validation.agent_network_validation_middl
 
 class AgentNetworkInstructionsValidationMiddleware(AgentNetworkValidationMiddleware):
     """
-    Middleware that validates agent instructions after each agent turn.
+    Middleware that validates agent instructions and descriptions after each agent turn.
 
     Runs keyword validation against the current network definition stored
-    in sly_data to detect missing or incomplete agent instructions.
+    in sly_data to detect missing or incomplete agent instructions and descriptions.
     If validation errors are found, a `HumanMessage` containing the errors
     is injected into the conversation and control returns to the model so it can self-correct.
     """
@@ -36,20 +36,29 @@ class AgentNetworkInstructionsValidationMiddleware(AgentNetworkValidationMiddlew
     def no_network_error_message(self) -> str:
         """Return the error message when no agent network definition is found."""
 
-        return "Error: No agent network found. Cannot edit or create instructions."
+        return "Error: No agent network found. Cannot edit or create instructions or description."
 
     def validation_label(self) -> str:
-        """Return a label for log messages (e.g. 'Structure', 'Instructions')."""
-        return "Instructions"
+        """Return a label for log messages (e.g. 'Structure', 'Instructions/Description')."""
+        return "Instructions/Description"
 
     async def validate(self, network_def: dict[str, Any]) -> list[str]:
         """
-        Run validators against the network definition.
+        Run validators against the network definition to check for missing "instructions" and "description" fields.
 
         :param network_def: The agent network definition to validate
         :return: A list of error strings (empty if valid)
         """
-        return KeywordNetworkValidator().validate(network_def)
+        # Copy network_def and modify the copy so that the "description" is under "function".
+        # This allows the keyword validatior to check for missing "description" fields.
+        use_network_def: dict[str, Any] = {}
+        for agent_name, agent_def in network_def.items():
+            agent_copy: dict[str, Any] = agent_def.copy()
+            if "description" in agent_copy:
+                description: str = agent_copy.pop("description")
+                agent_copy["function"] = {"description": description}
+            use_network_def[agent_name] = agent_copy
+        return KeywordNetworkValidator().validate(use_network_def)
 
     def format_error(self, error_list: list[str]) -> str:
         """

--- a/registries/agent_network_editor.hocon
+++ b/registries/agent_network_editor.hocon
@@ -132,28 +132,33 @@ Think of this as building or refining a hierarchical organizational chart. Each 
   (
     "customer_support_rep": (
       "instructions": "",
+      "description": "",
       "tools": ["network_engineer", "account_manager", "project_manager", "https://example.com/mcp"],
     )
   ),
   (
     "network_engineer": (
       "instructions": "",
+      "description": "",
       "tools": ["network_ops_center_specialist", "field_technician"],
     )
   ),
   (
     "field_technician": (
       "instructions": "",
+      "description": "",
     )
   ),
   (
     "network_ops_center_specialist": (
       "instructions": "",
+      "description": "",
     )
   ),
   (
     "account_manager": (
       "instructions": "",
+      "description": "",
       "tools": ["billing_tool", "/banking_ops"],
     )
   ),
@@ -163,12 +168,14 @@ Think of this as building or refining a hierarchical organizational chart. Each 
   (
     "project_manager": (
       "instructions": "",
+      "description": "",
       "tools": ["logistics_coordinator"],
     )
   ),
   (
     "logistics_coordinator": (
       "instructions": "",
+      "description": "",
     )
   )
 ]

--- a/registries/agent_network_instructions_editor.hocon
+++ b/registries/agent_network_instructions_editor.hocon
@@ -38,7 +38,7 @@
         {
             "name": "instructions_editor",
             "function": {
-                "description": "Create or modify instructions of agents in the agent network.",
+                "description": "Create or modify instructions and descriptions of agents in the agent network.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -55,22 +55,22 @@
                 }
             },
             "instructions": """
-You are responsible for generating and editing instructions of agents based on the agent network description and definition.
+You are responsible for coordinating the writing of instructions and descriptions for agents based on the agent network description and definition.
 Only answer inquiries that are directly within your area of expertise. Do not try to help for other matters. Do not mention what you can NOT do. Only mention what you can do.
 
-**Only create or edit `instructions` for agents that have an `instructions` field in the network definition. These are non-function agents.**
+**Only coordinate writing of `instructions` and `description` for agents that have these fields in the network definition. These are non-function agents.**
 
 Behavior by mode:
-- `create`: Generate initial instructions for every non-function agent in the network. Call `instructions_writer` once for each of these agents.
+- `create`: Call `instructions_writer` once for each non-function agent in the network to set both its instructions and description.
 - `modify`: Read `agent_network_description` and identify the impacted agents (explicitly named agents, newly added agents, and agents whose responsibilities changed).
-            Call `instructions_writer` to update instructions for these impacted agents.
-            Do not edit unaffected agents except when they lack instructions or the user explicitly requests broader edits. Call `instructions_writer` once per impacted agent.
+            Call `instructions_writer` to update instructions and description for these impacted agents.
+            Do not involve unaffected agents except when they lack instructions/description or the user explicitly requests broader edits. Call `instructions_writer` once per impacted agent.
 
 Guardrails:
-- Only create or edit `instructions` for agents that have an `instructions` field in the network definition.
-- Ensure that each and every agent with `instructions` field has the instructions.
+- Only coordinate writing of `instructions` and `description` for agents that have these fields in the network definition.
+- Ensure that each and every non-function agent has both instructions and description set.
 - Skip agents that are not referenced/affected by the current request.
-- Do not modify instructions if they are semantically unchanged.
+- Do not trigger rewrites if instructions and description are semantically unchanged.
 - Be surgical: avoid network-wide rewrites during `modify`; touch only what the request necessitates.
 """,
             "allow": {
@@ -98,19 +98,20 @@ Guardrails:
         {
             "name": "instructions_writer",
             "instructions": """
-You are an instructions writer for agents in an agent network.
-Your job is to create clear, concise, and actionable instructions for agents based on the agent network definition and description provided to you.
-Generate new instructions based on the following guidelines:
+You are an instructions and description writer for agents in an agent network.
+Your job is to write both the instructions and description for a specified agent based on the agent network definition and description provided to you.
+For each agent, call `set_agent_instructions_tool` and `set_agent_description_tool`.
 
 **Writing requirements**
-- Only write instructions for the specified agent. Do not write instructions for any other agents, even if they are mentioned in the description or network definition.
+- Only write instructions and description for the specified agent. Do not write for any other agents, even if they are mentioned in the description or network definition.
 - Make instructions clear, concise, and specific to the agent’s scope of responsibilities.
+- Write the description as a short summary of what the agent does, suitable for its callers to understand when to invoke it.
 - Do NOT mention other agents, up-chains, or down-chains; keep the text scoped to this agent only.
 - Align with the company’s cultural values and business objectives.
 - Output plain text (no formatting characters) and wrap lines at ~120 characters.
 
 **Response format**
-Always respond with "Instructions for <agent_name> have been set." after successfully setting the instructions for the agent.
+Always respond with "Instructions/description for <agent_name> have been set." after successfully setting the instructions and description for the agent.
 """
             "function": {
                 "description": "Write the instructions for a specified agent in an agent network."
@@ -129,7 +130,7 @@ Always respond with "Instructions for <agent_name> have been set." after success
                     "required": ["agent_name", "agent_network_description"]
                 }
             },
-            "tools": ["set_agent_instructions_tool"],
+            "tools": ["set_agent_instructions_tool", "set_agent_description_tool"],
             "middleware": [
                 {
                     "class": "middleware.agent_network_designer.agent_network_definition_middleware.AgentNetworkDefinitionMiddleware",
@@ -158,6 +159,28 @@ Always respond with "Instructions for <agent_name> have been set." after success
                         },
                     },
                     "required": ["agent_name", "new_instructions"]
+                }
+            },
+        },
+
+        {
+            "name": "set_agent_description_tool",
+            "class": "coded_tools.agent_network_instructions_editor.set_agent_description.SetAgentDescription"
+            "function": {
+                "description": "Set the description for an agent in an agent network."
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "agent_name": {
+                            "type": "string",
+                            "description": "the name of the agent whose description is being set."
+                        },
+                        "new_description": {
+                            "type": "string",
+                            "description": "the new description for the agent."
+                        },
+                    },
+                    "required": ["agent_name", "new_description"]
                 }
             },
         }


### PR DESCRIPTION

<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

- `instructions_editor`/`instructions_writer`: coordinate and write both `instructions` and `description` for non-function agents; add `set_agent_description_tool` to `instructions_writer`'s tools. This is because there is a high correlation between `instructions`(what this agent does) and `description`(what other agents see this agent).
- `create_network`/`add_agent`: initialize `description=""` for non-function agents at creation time
- `ConnectivityDictionaryConverter`: include `description` in default include_keys so it survives connectivity-style round-trips
- `HoconAgentNetworkAssembler`: add `description` placeholder to all three agent templates (top/regular/leaf) and pass it through `_render_agent_block`
- `deployable_template.hocon` / `DeployableAgentNetworkAssembler`: add `agent_description` placeholder and populate `function.description`
- `AgentNetworkDefinitionMiddleware`: extract `function.description` when loading an existing hocon back into `network_def`
- `AgentNetworkInstructionsValidationMiddleware`: validate `description` field alongside instructions
- `agent_network_editor.hocon`: add `description` field to example network

Fixes #699, #712 

**Note:** with optimized prompt on `instructions_editor` the runtime of `AND` is a bit faster even with addition of `description`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
