### PR TITLE
Fix connectivity converter

### DIFF
--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 # END COPYRIGHT
+from copy import deepcopy
 from typing import Any
 
 from leaf_common.serialization.interface.dictionary_converter import DictionaryConverter
@@ -72,7 +73,9 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
             value: dict[str, Any] = {}
             self.copy_keys_not_found(connectivity_entry, value)
 
-            result_dict[name] = value
+            # Don't include agent that start with "/" since those are external agents.
+            if not name.startswith("/"):
+                result_dict[name] = value
 
         return result_dict
 
@@ -87,15 +90,21 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         if obj_dict is None:
             return None
 
+        # Add toolbox key for toolbox agents so that connectivity reporter can set display correctly.
+        obj_dict_copy: dict[str, Any] = deepcopy(obj_dict)
+        for name, entry in obj_dict_copy.items():
+            if not entry:
+                entry["toolbox"] = name
+
         connectivity: Connectivity = []
 
-        inspector: AgentNetworkInspector = DesignerNetworkInspector(obj_dict)
+        inspector: AgentNetworkInspector = DesignerNetworkInspector(obj_dict_copy)
 
         reporter: ConnectivityReporter = ConnectivityReporter(inspector)
         connectivity = reporter.report_network_connectivity()
 
         # Add any keys that are not already in the connectivity report
-        for name, internal_entry in obj_dict.items():
+        for name, internal_entry in obj_dict_copy.items():
             # Find the corresponding entry in the connectivity list.
             found_entry: dict[str, Any] = None
             for connectivity_entry in connectivity:
@@ -119,4 +128,6 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         for key in self.include_keys:
             # Don't add stuff that doesn't exist in source or stuff that already exists in dest.
             if key in source and key not in dest:
-                dest[key] = source.get(key)
+                # Only put the key in dest if it has a value in source.  Don't put keys with None or empty values.
+                if source.get(key):
+                    dest[key] = source.get(key)

--- a/coded_tools/tools/agentic_rag/rag.py
+++ b/coded_tools/tools/agentic_rag/rag.py
@@ -28,7 +28,7 @@ from langchain_openai import OpenAIEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from neuro_san.interfaces.coded_tool import CodedTool
 
-PDF_FILE_URL = "https://www.replicon.com/wp-content/uploads/2016/06/RFP-Template_Replicon.pdf"
+PDF_FILE_URL = "https://www.usac.org/wp-content/uploads/rural-health-care/documents/samples/LargeProjectScopeRFP.pdf"
 
 
 class Rag(CodedTool):


### PR DESCRIPTION


<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Issues:
When converts `agent_network_definition` to connectivity, toolbox agents are displayed as `llm_agent`.
When converts connectivity to `agent_network_definition`, external agents have theirs own config.

Fixs:
- from dict to connectivity: add `toolbox` field before converstion so display as langchain tool correctly
- from connectivity to dict: only create node in `agent_network_designer` if not external agents.

Fixes # <!-- Issue number, if applicable -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
