### PR TITLE
Migrate tests.yml to build-common quality gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,106 +13,28 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     if: >
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    container:
-      image: python:3.13-slim
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Check if PR is from a fork
-        id: fork_check
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-              echo "is_fork=true" >> $GITHUB_OUTPUT
-            else
-              echo "is_fork=false" >> $GITHUB_OUTPUT
-            fi
-          else
-          # Not a PR — so it's not a fork
-            echo "is_fork=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Install dependencies
-        shell: bash
-        run: |
-          apt-get update && apt-get install -y shellcheck make curl
-          python -m venv venv
-          source venv/bin/activate
-          pip install -r requirements-build.txt
-          pip install -r requirements.txt
-
-      - name: Show installed packages
-        shell: bash
-        run: |
-          source venv/bin/activate 
-          pip freeze
-
-      - name: Run make lint-check
-        # We run this check-only step to break the build if
-        # formatting changes are needed
-        shell: bash
-        run: |
-          source venv/bin/activate 
-          make lint-check
-      
-      - name: Run dead link checker
-        shell: bash
-        run: |
-          curl --silent --location \
+    # cognizant-ai-lab/build-common 1.0.3
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a5d90457ea6e44b8f24f878755f77c00216e2947
+    with:
+      python-version: '3.13'
+      system-packages: 'curl'
+      lint-command-override: 'VIRTUAL_ENV=1 make lint-check'
+      test-command-override: |
+        curl --silent --location \
           https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.1/lychee-x86_64-unknown-linux-gnu.tar.gz \
           | tar --extract --gzip --directory /tmp --strip-components=1
-          # To prevent flaky CI failures, accept:
-          # - 401 (Unauthorized) for API endpoints that require authentication
-          # - 403 (Forbidden) if the server blocks bots or requests without a browser-like User-Agent
-          # - 405 (Method Not Allowed) for MCP/API endpoints that only accept POST, not GET
-          # - 406 (Not Acceptable) for MCP/API endpoints that serve non-HTML formats
-          # - 422 (Unprocessable Entity) for API endpoints that require query parameters
-          # - 429 (rate limit)
-          # - 502 (bad gateway) if the server is reachable but its backend momentarily failed to respond
-          # - 503 (temporary outage)
-          /tmp/lychee --max-retries 3 --retry-wait-time 3 --max-concurrency 32 --verbose --accept '200,203,204,401,403,405,406,422,429,502,503' --exclude-path venv --include-verbatim '**/*.py' '**/*.md' '**/*.rst' '**/*.hocon' '**/*.txt' '**/*.yaml' '**/*.yml' '**/*.json' '**/*.html' '**/*.sh' .
-
-      - name: Run make test
-        shell: bash
-        run: |
-          source venv/bin/activate 
-          make test
-        env:
-          AGENT_TOOL_PATH: "./neuro_san/coded_tools"
-          PYTHONPATH: ${{ env.PYTHONPATH }}:"."
-
-      - name: Check README renders correctly on PyPI
-        shell: bash
-        run: |
-          source venv/bin/activate
-          pip install readme_renderer readme_renderer[md]
-          python -m readme_renderer README.md
-
-      - name: Notify Slack on success
-        if: success() && steps.fork_check.outputs.is_fork == 'false'
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload: |
-            {
-              "text": "✅ *Tests Passed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack on failure
-        if: failure() && steps.fork_check.outputs.is_fork == 'false'
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          payload: |
-            {
-              "text": "❌ *Tests Failed* for `${{ github.repository }}` on `${{ github.ref_name }}`"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        /tmp/lychee --max-retries 3 --retry-wait-time 3 \
+          --max-concurrency 32 --verbose \
+          --accept '200,203,204,401,403,405,406,422,429,502,503' \
+          --exclude-path venv \
+          --include-verbatim \
+          '**/*.py' '**/*.md' '**/*.rst' '**/*.hocon' '**/*.txt' \
+          '**/*.yaml' '**/*.yml' '**/*.json' '**/*.html' '**/*.sh' .
+        VIRTUAL_ENV=1 AGENT_TOOL_PATH=./neuro_san/coded_tools PYTHONPATH=. make test
+      check-readme-pypi: true
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

Replaces inline workflow steps with a `workflow_call` to the shared `_python-quality-gate.yml` reusable workflow from `build-common` (pinned to SHA `a5d90457`, tag 1.0.3). All original behavior is preserved through quality gate inputs: `lint-command-override` for `make lint-check`, `test-command-override` for lychee dead-link checking and `make test`, and `check-readme-pypi` for README rendering validation.

## Impact

- **Container to ubuntu-latest**: The old workflow ran inside `python:3.13-slim`; the quality gate runs on `ubuntu-latest` with `actions/setup-python`. `VIRTUAL_ENV=1` is set for make targets that use the Makefile's `venv-guard` check.
- **Slack message format**: The old workflow used custom emoji-prefixed text payloads. The `slack-notify` composite action generates its own format via `build-payload.py`.
- **Fork detection**: The explicit fork-check step is removed; the `slack-notify` action has built-in fork detection that skips notifications for fork PRs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

## Human Review Checklist

- [ ] Verify `VIRTUAL_ENV=1` correctly bypasses `venv-guard` in the Makefile since packages are installed globally by `actions/setup-python`
- [ ] Confirm the `python:3.13-slim` container to `ubuntu-latest` runner change is acceptable
- [ ] Confirm the new Slack notification format from `slack-notify` is acceptable for your channel
- [ ] Trigger a CI run on this branch to validate the quality gate passes end-to-end

Link to Devin session: https://app.devin.ai/sessions/4ebad006218044ab80d0d2a0a5130399
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
