### PR TITLE
Address reviewer feedback on persistent memory PR

### DIFF
--- a/middleware/persistent_memory/json_file_store.py
+++ b/middleware/persistent_memory/json_file_store.py
@@ -219,10 +219,10 @@ class JsonFileStore(TopicStore):
                 type(parsed).__name__,
             )
             return {}
-        normalised: TopicStore.AgentMemory = {}
+        normalized: TopicStore.AgentMemory = {}
         for topic, value in parsed.items():
-            normalised[str(topic)] = JsonFileStore._coerce_value(value)
-        return normalised
+            normalized[str(topic)] = JsonFileStore._coerce_value(value)
+        return normalized
 
     @staticmethod
     def _coerce_value(value: Any) -> str:

--- a/middleware/persistent_memory/persistent_memory_middleware.py
+++ b/middleware/persistent_memory/persistent_memory_middleware.py
@@ -90,7 +90,7 @@ class PersistentMemoryMiddleware(AgentMiddleware):
 
         max_topic_size, summarization_model, personalization = self._parse_summarization_config(summarization_config)
 
-        # ``JsonFileStore`` defaults + sanitises ``file_name`` on its own;
+        # ``JsonFileStore`` defaults + sanitizes ``file_name`` on its own;
         # the markdown backend ignores it. See ``JsonFileStore.__init__``.
         self._store: TopicStore = TopicStoreFactory.create(store_config)
         self._summarizer: TopicSummarizer = TopicSummarizer(
@@ -111,7 +111,7 @@ class PersistentMemoryMiddleware(AgentMiddleware):
         self.tools: list[BaseTool] = [self._build_dispatcher_tool()]
 
         self.logger.info(
-            "Initialised for %s. Enabled operations: %s",
+            "Initialized for %s. Enabled operations: %s",
             namespace_key,
             sorted(self.persistent_memory_tool.enabled_operations),
         )
@@ -233,7 +233,7 @@ class PersistentMemoryMiddleware(AgentMiddleware):
         unknown: set[str] = set(config) - self._MEMORY_CONFIG_KEYS
         if unknown:
             self.logger.warning(
-                "Ignoring unknown memory_config keys: %s. Recognised keys: %s.",
+                "Ignoring unknown memory_config keys: %s. Recognized keys: %s.",
                 sorted(unknown),
                 sorted(self._MEMORY_CONFIG_KEYS),
             )
@@ -251,7 +251,7 @@ class PersistentMemoryMiddleware(AgentMiddleware):
         namespace_key: str,
     ) -> frozenset[str]:
         """
-        Normalise the HOCON whitelist, drop unknown ops, warn on typos.
+        Normalize the HOCON whitelist, drop unknown ops, warn on typos.
 
         Omitting ``enabled_operations`` or passing an empty list enables every
         operation. Unknown entries are dropped with a warning. If every entry
@@ -294,7 +294,7 @@ class PersistentMemoryMiddleware(AgentMiddleware):
         unknown: set[str] = set(config) - self._SUMMARIZATION_CONFIG_KEYS
         if unknown:
             self.logger.warning(
-                "Ignoring unknown summarization keys: %s. Recognised keys: %s.",
+                "Ignoring unknown summarization keys: %s. Recognized keys: %s.",
                 sorted(unknown),
                 sorted(self._SUMMARIZATION_CONFIG_KEYS),
             )

--- a/middleware/persistent_memory/persistent_memory_tool.py
+++ b/middleware/persistent_memory/persistent_memory_tool.py
@@ -77,7 +77,7 @@ class PersistentMemoryTool:
         self._handlers: dict[str, Any] = self._build_handlers()
 
         self.logger.info(
-            "Initialised for %s with operations: %s",
+            "Initialized for %s with operations: %s",
             self._namespace_key,
             sorted(self._enabled_operations),
         )

--- a/middleware/persistent_memory/topic_store.py
+++ b/middleware/persistent_memory/topic_store.py
@@ -53,7 +53,7 @@ class TopicStore(ABC):
         self._root: Path = Path(folder_name).expanduser().resolve()
         self._locks: OrderedDict[tuple[str, ...], asyncio.Lock] = OrderedDict()
         self._locks_guard: asyncio.Lock = asyncio.Lock()
-        self.logger.info("Initialised. Root path: %s", self._root)
+        self.logger.info("Initialized. Root path: %s", self._root)
 
     async def get_topic(
         self,
@@ -344,7 +344,7 @@ class TopicStore(ABC):
         """
         Split ``"<network>.<agent>"``; missing halves fall back to ``"unknown"``.
 
-        The middleware sanitises both halves before building this key, so
+        The middleware sanitizes both halves before building this key, so
         the store trusts the input to be filesystem-safe.
 
         :param namespace: ``"<network>.<agent>"`` key.

--- a/middleware/persistent_memory/topic_store_factory.py
+++ b/middleware/persistent_memory/topic_store_factory.py
@@ -83,7 +83,7 @@ class TopicStoreFactory:  # pylint: disable=too-few-public-methods
         cls._logger.info("Creating memory store backend: %s (folder_name=%s)", backend, folder_name)
 
         if backend == "json_file":
-            # ``JsonFileStore`` applies the default and sanitises the stem itself;
+            # ``JsonFileStore`` applies the default and sanitizes the stem itself;
             # an empty string here collapses to ``DEFAULT_FILE_NAME`` inside.
             return JsonFileStore(folder_name=folder_name, file_name=file_name or "")
         if backend == "markdown_file":

--- a/tests/middleware/persistent_memory/test_persistent_memory_middleware.py
+++ b/tests/middleware/persistent_memory/test_persistent_memory_middleware.py
@@ -27,8 +27,8 @@ from middleware.persistent_memory.persistent_memory_middleware import Persistent
 from tests.middleware.persistent_memory.base import MemoryTestBase
 
 
-class PersistentMemoryMiddlewareRegistrationTests(MemoryTestBase):
-    """Middleware registers exactly one tool, named ``persistent_memory``."""
+class PersistentMemoryMiddlewareTests(MemoryTestBase):
+    """Registration, origin parsing, dispatch, and summarizer tests."""
 
     def test_registers_single_named_tool(self) -> None:
         """One dispatcher tool is exposed with the right name and tag."""
@@ -37,10 +37,6 @@ class PersistentMemoryMiddlewareRegistrationTests(MemoryTestBase):
         self.assertEqual(mw.tools[0].name, PersistentMemoryMiddleware.MEMORY_TOOL_NAME)
         self.assertIn("langchain_tool", mw.tools[0].tags or [])
 
-
-class PersistentMemoryMiddlewareOriginParsingTests(MemoryTestBase):
-    """``origin_str`` is parsed into ``(network, agent)`` with index suffixes stripped."""
-
     def test_parses_network_and_agent_stripping_index_suffix(self) -> None:
         """Numeric ``-N`` suffixes are stripped from both segments."""
         network, agent = PersistentMemoryMiddleware._parse_origin_str(  # pylint: disable=protected-access
@@ -48,10 +44,6 @@ class PersistentMemoryMiddlewareOriginParsingTests(MemoryTestBase):
         )
         self.assertEqual(network, "persistent_memory")
         self.assertEqual(agent, "MemoryAssistant")
-
-
-class PersistentMemoryMiddlewareDispatchTests(MemoryTestBase):
-    """Dispatch forwards to ``PersistentMemoryTool`` and the result hits disk."""
 
     # pylint: disable=not-callable
     def test_end_to_end_create_then_search(self) -> None:
@@ -63,10 +55,6 @@ class PersistentMemoryMiddlewareDispatchTests(MemoryTestBase):
         search_result = asyncio.run(tool_fn.coroutine(operation="search", query="black"))
         topics = [r.get("topic") for r in search_result.get("result", {}).get("results", [])]
         self.assertIn("coffee", topics)
-
-
-class PersistentMemoryMiddlewareSummarizerTests(MemoryTestBase):
-    """Summarizer fires from the tool after oversized writes."""
 
     def test_summarizes_when_topic_exceeds_max_size(self) -> None:
         """A topic larger than ``max_topic_size`` is replaced with its summary."""

--- a/tests/middleware/persistent_memory/test_persistent_memory_tool.py
+++ b/tests/middleware/persistent_memory/test_persistent_memory_tool.py
@@ -25,8 +25,8 @@ from middleware.persistent_memory.json_file_store import JsonFileStore
 from tests.middleware.persistent_memory.base import MemoryTestBase
 
 
-class PersistentMemoryToolDispatchTests(MemoryTestBase):
-    """The six operations persist to disk on every call."""
+class PersistentMemoryToolTests(MemoryTestBase):
+    """Dispatch, enabled-operations, and summarizer tests."""
 
     def setUp(self) -> None:
         super().setUp()
@@ -83,20 +83,12 @@ class PersistentMemoryToolDispatchTests(MemoryTestBase):
         result = self._invoke({"operation": "list"})
         self.assertEqual(result.get("result", {}).get("topics"), ["a", "b"])
 
-
-class PersistentMemoryToolEnabledOperationsTests(MemoryTestBase):
-    """The ``enabled_operations`` whitelist constrains the LLM."""
-
     def test_disabled_operation_returns_error(self) -> None:
         """Calling a disabled operation surfaces a ``not enabled`` error."""
         tool = self.make_tool(enabled_operations=["read", "search"])
         result = asyncio.run(tool.async_invoke({"operation": "create", "topic": "x", "content": "v"}))
         self.assertIn("error", result)
         self.assertIn("not enabled", result.get("error", "").lower())
-
-
-class PersistentMemoryToolSummarizerTests(MemoryTestBase):
-    """Summarizer fires from the tool after oversized writes."""
 
     def test_summarizer_fires_after_oversized_write(self) -> None:
         """A write past ``max_topic_size`` triggers the summarizer and rewrites disk."""

--- a/tests/middleware/persistent_memory/test_topic_store_factory.py
+++ b/tests/middleware/persistent_memory/test_topic_store_factory.py
@@ -38,7 +38,7 @@ class TopicStoreFactoryTests(MemoryTestBase):
         self.assertIsInstance(store, MarkdownFileStore)
 
     def test_unknown_backend_raises(self) -> None:
-        """An unrecognised backend name raises ``ValueError``."""
+        """An unrecognized backend name raises ``ValueError``."""
         with self.assertRaises(ValueError):
             TopicStoreFactory.create({"backend": "no_such_backend"})
 
@@ -50,7 +50,7 @@ class TopicStoreFactoryTests(MemoryTestBase):
         path = store._path_for("net.agent")  # pylint: disable=protected-access
         self.assertTrue(str(path).endswith("notes.json"))
 
-    def test_backend_name_normalised(self) -> None:
+    def test_backend_name_normalized(self) -> None:
         """Backend names are lower-cased and stripped before dispatch."""
         store = TopicStoreFactory.create({"backend": "  MARKDOWN_FILE  ", "folder_name": self._tmp})
         self.assertIsInstance(store, MarkdownFileStore)


### PR DESCRIPTION
## Description

Addresses Olivier's review feedback from PR #896:

1. **US English spelling** — replaced all British English spellings with US English across the persistent memory middleware, tool, store, factory, and test files (`sanitises` → `sanitizes`, `Initialised` → `Initialized`, `Recognised` → `Recognized`, `Normalise` → `Normalize`, `normalised` → `normalized`, `unrecognised` → `unrecognized`).

2. **Consolidate test classes** — merged the multiple small test classes into a single class per file in `test_persistent_memory_middleware.py` (4 → 1) and `test_persistent_memory_tool.py` (3 → 1). No test logic changed.

## Impact

No functional changes. Spelling and test organization only.

## Type of Change

- [x] Refactoring / Improvement

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/cd351ab63ea647ca820d52bf995da08a
Requested by: @shrushtiimehta