### PR TITLE
#943 Handle cross-platform encoding consistently when reading files via leaf-common's TextFileReader

### DIFF
--- a/apps/log_analyzer/log_analyzer.py
+++ b/apps/log_analyzer/log_analyzer.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 from neuro_san.client.agent_session_factory import AgentSessionFactory
 from neuro_san.client.streaming_input_processor import StreamingInputProcessor
 
@@ -122,8 +123,7 @@ def parse_log_files(directory_path, log_analyzer, analysis_session, analysis_thr
         print(f"Processing file: {log_file}")
 
         try:
-            with open(file_path, "r", encoding="utf-8") as f:
-                content = f.read()
+            content = TextFileReader.read_text_file(file_path)
 
             # Extract system prompt
             system_prompt = extract_system_prompt(content)
@@ -139,7 +139,7 @@ def parse_log_files(directory_path, log_analyzer, analysis_session, analysis_thr
                     )
                     print(analysis)
 
-        except (FileNotFoundError, UnicodeDecodeError, IOError) as e:
+        except (FileNotFoundError, IOError) as e:
             print(f"Error processing file {file_path}: {str(e)}")
 
         except Exception as e:

--- a/coded_tools/experimental/kwik_agents/commit_to_memory.py
+++ b/coded_tools/experimental/kwik_agents/commit_to_memory.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from typing import Any
 from typing import Dict
 
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 from neuro_san.interfaces.coded_tool import CodedTool
 
 from coded_tools.experimental.kwik_agents.list_topics import LONG_TERM_MEMORY_FILE
@@ -111,9 +112,8 @@ class CommitToMemory(CodedTool):
         """
         file_path = MEMORY_FILE_PATH + MEMORY_DATA_STRUCTURE + ".json"
         if os.path.exists(file_path):
-            with open(file_path, "r", encoding="utf-8") as file:
-                content = file.read()
-                self.topic_memory = json.loads(content) if content else {}
+            content = TextFileReader.read_text_file(file_path)
+            self.topic_memory = json.loads(content) if content else {}
         else:
             self.topic_memory = {}
 

--- a/coded_tools/experimental/kwik_agents/list_topics.py
+++ b/coded_tools/experimental/kwik_agents/list_topics.py
@@ -20,6 +20,7 @@ import os
 from typing import Any
 from typing import Dict
 
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 from neuro_san.interfaces.coded_tool import CodedTool
 
 LONG_TERM_MEMORY_FILE = True  # Store and read memory from file
@@ -71,9 +72,8 @@ class ListTopics(CodedTool):
         """
         file_path = MEMORY_FILE_PATH + MEMORY_DATA_STRUCTURE + ".json"
         if os.path.exists(file_path):
-            with open(file_path, "r", encoding="utf-8") as file:
-                content = file.read()
-                self.topic_memory = json.loads(content) if content else {}
+            content = TextFileReader.read_text_file(file_path)
+            self.topic_memory = json.loads(content) if content else {}
         else:
             self.topic_memory = {}
 

--- a/coded_tools/industry/airline_policy/extract_docs.py
+++ b/coded_tools/industry/airline_policy/extract_docs.py
@@ -20,6 +20,7 @@ from typing import Any
 from typing import Dict
 from typing import Union
 
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 from neuro_san.interfaces.coded_tool import CodedTool
 from pypdf import PdfReader
 from pypdf.errors import PyPdfError
@@ -162,8 +163,7 @@ class ExtractDocs(CodedTool):
         :return: Content of the text file.
         """
         try:
-            with open(txt_path, "r", encoding="utf-8") as f:
-                return f.read()
+            return TextFileReader.read_text_file(txt_path)
         except OSError as e:
             error = f"Error reading TXT {txt_path}: {e}"
             logger.error(error)

--- a/coded_tools/industry/news_sentiment_analysis/sentiment_analysis.py
+++ b/coded_tools/industry/news_sentiment_analysis/sentiment_analysis.py
@@ -24,6 +24,7 @@ from typing import Optional
 from typing import Tuple
 
 # pylint: disable=import-error
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 from neuro_san.interfaces.coded_tool import CodedTool
 from nupunkt import sent_tokenize
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
@@ -115,9 +116,8 @@ class SentimentAnalysis(CodedTool):
 
         path = os.path.join(input_dir or self.input_dir, file_name)
         try:
-            with open(path, "r", encoding="utf-8") as f:
-                content = f.read().strip()
-        except (OSError, UnicodeDecodeError):
+            content = TextFileReader.read_text_file(path).strip()
+        except OSError:
             logger.exception("Error reading file: %s", path)
             return None
 

--- a/coded_tools/industry/news_sentiment_analysis/web_scraping_technician.py
+++ b/coded_tools/industry/news_sentiment_analysis/web_scraping_technician.py
@@ -29,6 +29,7 @@ import backoff
 import feedparser
 import requests
 from bs4 import BeautifulSoup
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 from neuro_san.interfaces.coded_tool import CodedTool
 from newspaper import Article
 from newspaper import ArticleException
@@ -343,8 +344,8 @@ class WebScrapingTechnician(CodedTool):
         for result in [nyt_result, guardian_result, aljazeera_result]:
             file_path = result.get("file")
             if file_path and os.path.exists(file_path):
-                with open(file_path, "r", encoding="utf-8") as f:
-                    all_articles.extend(line.strip() for line in f if line.strip())
+                text = TextFileReader.read_text_file(file_path)
+                all_articles.extend(line.strip() for line in text.splitlines() if line.strip())
 
         combined_filename = os.path.join(save_dir, "all_news_articles.txt")
         with open(combined_filename, "w", encoding="utf-8") as f:

--- a/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
+++ b/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
@@ -15,16 +15,14 @@
 # END COPYRIGHT
 
 # Import for asynchronous file operations
-import logging
 import os
 
 import aiofiles
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 
 from middleware.agent_network_designer.persistence.agent_network_assembler import AgentNetworkAssembler
 from middleware.agent_network_designer.persistence.agent_network_persistor import AgentNetworkPersistor
 from middleware.agent_network_designer.persistence.hocon_agent_network_assembler import HoconAgentNetworkAssembler
-
-_logger = logging.getLogger(__name__)
 
 DEFAULT_SUBDIRECTORY: str = "generated"
 
@@ -60,25 +58,6 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
         :return: An assembler instance associated with this persistor
         """
         return HoconAgentNetworkAssembler(self.demo_mode)
-
-    async def _async_read_text(self, path: str) -> str:
-        """
-        Reads a text file, trying UTF-8 first with a fallback to platform default encoding.
-
-        Writes always use UTF-8, so most files decode on the first attempt. The fallback
-        handles files created manually on Windows where the editor used the system locale
-        encoding (typically cp1252).
-        """
-        try:
-            async with aiofiles.open(path, "r", encoding="utf-8") as file:
-                return await file.read()
-        except UnicodeDecodeError:
-            _logger.warning(
-                "File '%s' is not valid UTF-8; retrying with platform default encoding.",
-                path,
-            )
-        async with aiofiles.open(path, "r", encoding="locale") as file:
-            return await file.read()
 
     async def async_persist(self, obj: str, file_reference: str = None) -> str:
         """
@@ -116,7 +95,7 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
                 await file.write("{\n}")
 
         # Read the current manifest content
-        manifest_content: str = await self._async_read_text(manifest_path)
+        manifest_content: str = await TextFileReader.async_read_text_file(manifest_path)
 
         # Check if the entry already exists to avoid duplicates
         if (
@@ -164,7 +143,7 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
         if not os.path.exists(self.main_manifest_path):
             return None
 
-        content: str = await self._async_read_text(self.main_manifest_path)
+        content: str = await TextFileReader.async_read_text_file(self.main_manifest_path)
 
         registries_name: str = os.path.basename(self.output_path)
         include_line: str = f'include "{registries_name}/{self.subdirectory}/manifest.hocon",'

--- a/middleware/agent_skills_middleware.py
+++ b/middleware/agent_skills_middleware.py
@@ -26,7 +26,6 @@ from typing import Callable
 from typing import override
 from urllib.parse import urljoin
 
-import aiofiles
 from aiohttp import ClientError
 from aiohttp import ClientSession
 from aiohttp import ClientTimeout
@@ -45,6 +44,7 @@ from langchain_core.tools import StructuredTool
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
 from langgraph.types import Command
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 from yaml import YAMLError
 from yaml import safe_load
 
@@ -316,10 +316,7 @@ class AgentSkillsMiddleware(AgentMiddleware):
             return f"Error: Resource file not found: {resource_path}"
 
         try:
-            async with aiofiles.open(path, mode="r", encoding="utf-8") as file:
-                return await file.read()
-        except UnicodeDecodeError as unicode_error:
-            return f"Error: Unable to decode file as UTF-8: {unicode_error}"
+            return await TextFileReader.async_read_text_file(str(path))
         except IOError as io_error:
             return f"Error: Failed to read file: {io_error}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Neuro SAN
-neuro-san==0.6.48
+leaf-common>=1.2.40
+neuro-san==0.6.49
 nsflow==0.6.15
 
 # For config parsing

--- a/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
+++ b/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
@@ -21,8 +21,6 @@ import os
 import tempfile
 from unittest.mock import patch
 
-from leaf_common.serialization.util.text_file_reader import TextFileReader
-
 from middleware.agent_network_designer.persistence.file_system_agent_network_persistor import (
     FileSystemAgentNetworkPersistor,
 )
@@ -32,66 +30,92 @@ class TestFileSystemAgentNetworkPersistor:
     """Tests for FileSystemAgentNetworkPersistor."""
 
     @staticmethod
-    def _make_persistor(tmp_dir: str) -> FileSystemAgentNetworkPersistor:
+    def _make_persistor(tmp_dir: str, subdirectory: str = "generated") -> FileSystemAgentNetworkPersistor:
         """Creates a persistor pointing at the given temp directory."""
         manifest_path = os.path.join(tmp_dir, "manifest.hocon")
         with patch.dict(os.environ, {"AGENT_MANIFEST_FILE": manifest_path}):
             persistor = FileSystemAgentNetworkPersistor(demo_mode=False)
         persistor.output_path = tmp_dir
-        persistor.subdirectory = "generated"
+        persistor.subdirectory = subdirectory
         return persistor
 
-    # Test cases for TextFileReader integration
+    # Tests for async_persist reading a manifest with various encodings
 
-    def test_read_utf8_file(self):
-        """Reads a UTF-8 file with non-ASCII content correctly."""
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".hocon", delete=False) as tmp:
-            tmp.write('description = "café résumé"\n'.encode("utf-8"))
-            tmp_path = tmp.name
+    def test_persist_appends_to_utf8_manifest(self):
+        """async_persist reads and updates a UTF-8 manifest with non-ASCII content."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            persistor = self._make_persistor(tmp_dir)
+            manifest_dir = os.path.join(tmp_dir, "generated")
+            os.makedirs(manifest_dir)
+            manifest_path = os.path.join(manifest_dir, "manifest.hocon")
+            with open(manifest_path, "wb") as f:
+                f.write('{\n    "café_network.hocon": true,\n}\n'.encode("utf-8"))
 
-        try:
-            result = asyncio.run(TextFileReader.async_read_text_file(tmp_path))
-            assert "café résumé" in result
-        finally:
-            os.unlink(tmp_path)
+            asyncio.run(persistor.async_persist("agent = {}", "generated/new_net"))
 
-    def test_read_ascii_file(self):
-        """Reads a pure-ASCII file (valid in both UTF-8 and cp1252)."""
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".hocon", delete=False) as tmp:
-            tmp.write(b'{\n    "network.hocon": true\n}\n')
-            tmp_path = tmp.name
+            with open(manifest_path, "rb") as f:
+                raw = f.read()
+            content = raw.decode("utf-8")
+            assert '"generated/new_net.hocon": true' in content
+            assert "café_network.hocon" in content
 
-        try:
-            result = asyncio.run(TextFileReader.async_read_text_file(tmp_path))
-            assert '"network.hocon": true' in result
-        finally:
-            os.unlink(tmp_path)
+    def test_persist_appends_to_cp1252_manifest(self):
+        """async_persist reads a cp1252-encoded manifest and appends a new entry."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            persistor = self._make_persistor(tmp_dir)
+            manifest_dir = os.path.join(tmp_dir, "generated")
+            os.makedirs(manifest_dir)
+            manifest_path = os.path.join(manifest_dir, "manifest.hocon")
+            # 0xe9 is e-acute in cp1252, invalid as a UTF-8 continuation byte
+            with open(manifest_path, "wb") as f:
+                f.write(b'{\n    "caf\xe9_network.hocon": true,\n}\n')
 
-    def test_reads_non_utf8_via_cp1252_fallback(self):
-        """Decodes a file with cp1252 content (0x80 = euro sign)."""
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".hocon", delete=False) as tmp:
-            tmp.write(b'key = "val\x80ue"\n')
-            tmp_path = tmp.name
+            asyncio.run(persistor.async_persist("agent = {}", "generated/new_net"))
 
-        try:
-            result = asyncio.run(TextFileReader.async_read_text_file(tmp_path))
-            assert "val€ue" in result
-        finally:
-            os.unlink(tmp_path)
+            with open(manifest_path, "rb") as f:
+                content = f.read().decode("utf-8")
+            assert '"generated/new_net.hocon": true' in content
 
-    def test_reads_cp1252_encoded_content(self):
-        """Decodes cp1252 bytes where e-acute = 0xe9."""
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".hocon", delete=False) as tmp:
-            tmp.write(b'description = "caf\xe9"\n')
-            tmp_path = tmp.name
+    def test_persist_detects_duplicate_in_cp1252_manifest(self):
+        """async_persist correctly finds an existing entry in a cp1252-encoded manifest."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            persistor = self._make_persistor(tmp_dir)
+            manifest_dir = os.path.join(tmp_dir, "generated")
+            os.makedirs(manifest_dir)
+            manifest_path = os.path.join(manifest_dir, "manifest.hocon")
+            with open(manifest_path, "wb") as f:
+                f.write(b'{\n    "generated/existing.hocon": true,\n    "caf\xe9.hocon": true,\n}\n')
 
-        try:
-            result = asyncio.run(TextFileReader.async_read_text_file(tmp_path))
-            assert "café" in result
-        finally:
-            os.unlink(tmp_path)
+            result = asyncio.run(persistor.async_persist("agent = {}", "generated/existing"))
 
-    # Tests for async_persist file encoding and line endings."""
+            assert result is None
+            with open(manifest_path, "rb") as f:
+                raw = f.read()
+            assert raw.count(b"existing.hocon") == 1
+
+    # Tests for _async_update_main_manifest reading non-UTF-8 content
+
+    def test_update_main_manifest_reads_cp1252(self):
+        """_async_update_main_manifest reads a cp1252-encoded main manifest."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            persistor = self._make_persistor(tmp_dir, subdirectory="custom")
+            main_manifest = os.path.join(tmp_dir, "manifest.hocon")
+            # Write main manifest with cp1252 content and an existing include line
+            with open(main_manifest, "wb") as f:
+                f.write(
+                    b'# caf\xe9 comment\n'
+                    b'    include "registries/generated/manifest.hocon",\n'
+                )
+            persistor.main_manifest_path = main_manifest
+
+            asyncio.run(persistor._async_update_main_manifest())  # pylint: disable=protected-access
+
+            with open(main_manifest, "rb") as f:
+                content = f.read().decode("utf-8")
+            base = os.path.basename(tmp_dir)
+            assert f'include "{base}/custom/manifest.hocon"' in content
+
+    # Tests for async_persist file encoding and line endings
 
     def test_persist_writes_utf8(self):
         """Persisted files are encoded as UTF-8."""

--- a/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
+++ b/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
@@ -102,10 +102,7 @@ class TestFileSystemAgentNetworkPersistor:
             main_manifest = os.path.join(tmp_dir, "manifest.hocon")
             # Write main manifest with cp1252 content and an existing include line
             with open(main_manifest, "wb") as f:
-                f.write(
-                    b'# caf\xe9 comment\n'
-                    b'    include "registries/generated/manifest.hocon",\n'
-                )
+                f.write(b'# caf\xe9 comment\n    include "registries/generated/manifest.hocon",\n')
             persistor.main_manifest_path = main_manifest
 
             asyncio.run(persistor._async_update_main_manifest())  # pylint: disable=protected-access

--- a/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
+++ b/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
@@ -17,12 +17,11 @@
 """Tests for FileSystemAgentNetworkPersistor encoding behavior."""
 
 import asyncio
-import logging
 import os
 import tempfile
 from unittest.mock import patch
 
-import aiofiles
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 
 from middleware.agent_network_designer.persistence.file_system_agent_network_persistor import (
     FileSystemAgentNetworkPersistor,
@@ -42,7 +41,7 @@ class TestFileSystemAgentNetworkPersistor:
         persistor.subdirectory = "generated"
         return persistor
 
-    # Test cases for _async_read_text
+    # Test cases for TextFileReader integration
 
     def test_read_utf8_file(self):
         """Reads a UTF-8 file with non-ASCII content correctly."""
@@ -51,8 +50,7 @@ class TestFileSystemAgentNetworkPersistor:
             tmp_path = tmp.name
 
         try:
-            persistor = self._make_persistor(os.path.dirname(tmp_path))
-            result = asyncio.run(persistor._async_read_text(tmp_path))  # pylint: disable=protected-access
+            result = asyncio.run(TextFileReader.async_read_text_file(tmp_path))
             assert "café résumé" in result
         finally:
             os.unlink(tmp_path)
@@ -64,66 +62,31 @@ class TestFileSystemAgentNetworkPersistor:
             tmp_path = tmp.name
 
         try:
-            persistor = self._make_persistor(os.path.dirname(tmp_path))
-            result = asyncio.run(persistor._async_read_text(tmp_path))  # pylint: disable=protected-access
+            result = asyncio.run(TextFileReader.async_read_text_file(tmp_path))
             assert '"network.hocon": true' in result
         finally:
             os.unlink(tmp_path)
 
-    def test_fallback_called_on_non_utf8(self, caplog):
-        """Logs a warning and falls back when file is not valid UTF-8."""
+    def test_reads_non_utf8_via_cp1252_fallback(self):
+        """Decodes a file with cp1252 content (0x80 = euro sign)."""
         with tempfile.NamedTemporaryFile(mode="wb", suffix=".hocon", delete=False) as tmp:
-            # 0x80 is invalid UTF-8 start byte but valid in cp1252 (euro sign)
             tmp.write(b'key = "val\x80ue"\n')
             tmp_path = tmp.name
 
         try:
-            persistor = self._make_persistor(os.path.dirname(tmp_path))
-
-            # Mock the fallback open to simulate a Windows platform where
-            # encoding="locale" would be cp1252
-            original_open = aiofiles.open
-
-            call_count = {"n": 0}
-
-            def mock_open(path, mode="r", **kwargs):
-                call_count["n"] += 1
-                if call_count["n"] == 2:
-                    # Second call is the fallback — force cp1252
-                    kwargs["encoding"] = "cp1252"
-                return original_open(path, mode, **kwargs)
-
-            with patch("aiofiles.open", side_effect=mock_open):
-                with caplog.at_level(logging.WARNING):
-                    result = asyncio.run(persistor._async_read_text(tmp_path))  # pylint: disable=protected-access
-
-            assert "not valid UTF-8" in caplog.text
+            result = asyncio.run(TextFileReader.async_read_text_file(tmp_path))
             assert "val€ue" in result
         finally:
             os.unlink(tmp_path)
 
-    def test_fallback_reads_cp1252_content(self):
-        """Verifies the fallback correctly decodes cp1252 bytes."""
+    def test_reads_cp1252_encoded_content(self):
+        """Decodes cp1252 bytes where e-acute = 0xe9."""
         with tempfile.NamedTemporaryFile(mode="wb", suffix=".hocon", delete=False) as tmp:
-            # Write cp1252-encoded content: café where é = 0xe9 in cp1252
             tmp.write(b'description = "caf\xe9"\n')
             tmp_path = tmp.name
 
         try:
-            persistor = self._make_persistor(os.path.dirname(tmp_path))
-
-            original_open = aiofiles.open
-            call_count = {"n": 0}
-
-            def mock_open(path, mode="r", **kwargs):
-                call_count["n"] += 1
-                if call_count["n"] == 2:
-                    kwargs["encoding"] = "cp1252"
-                return original_open(path, mode, **kwargs)
-
-            with patch("aiofiles.open", side_effect=mock_open):
-                result = asyncio.run(persistor._async_read_text(tmp_path))  # pylint: disable=protected-access
-
+            result = asyncio.run(TextFileReader.async_read_text_file(tmp_path))
             assert "café" in result
         finally:
             os.unlink(tmp_path)


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Use leaf-common's `TextFileReader` to read files to ensure consistent cross-platform file decoding.

Fixes #943 

## Impact

Should avoid any issues while reading files even if they are not UTF-8 encoded.

## Screenshots / Logs / Examples (optional)

N/A

## Type of Change

- [X] Bug fix
- [ ] New feature
- [X] Dependency upgrade
- [X] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [X] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
