### PR TITLE
Add langchain-google-genai install steps to Gemini guide

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -484,7 +484,21 @@ To find which models are available in your region, refer to the official AWS doc
 
 ### Gemini
 
-To use Gemini models, set the `GOOGLE_API_KEY` environment variable to your Google Gemini API key
+To use Gemini models:
+
+1. Confirm that `langchain-google-genai` is installed:
+
+    ```bash
+    pip show langchain-google-genai
+    ```
+
+2. If not installed, install it:
+
+    ```bash
+    pip install langchain-google-genai
+    ```
+
+3. Set the `GOOGLE_API_KEY` environment variable to your Google Gemini API key
 and specify which model to use in the `model_name` field of the `llm_config` section of an agent network hocon file:
 
 ```hocon


### PR DESCRIPTION
## Description

The Gemini section of the user guide now includes prerequisite steps to verify and install the `langchain-google-genai` package before configuring the model. Previously, users were only told to set `GOOGLE_API_KEY` and configure `llm_config`, but were not informed that `langchain-google-genai` must be installed separately (it is not a dependency of `neuro-san`).

Fixes #930

## Impact

Users following the Gemini setup instructions will no longer encounter an unexpected missing-module error at runtime.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**