### PR TITLE
Update OpenAI Video API reference URL

### DIFF
--- a/docs/examples/tools/openai_video_generation.md
+++ b/docs/examples/tools/openai_video_generation.md
@@ -105,7 +105,7 @@ OpenAI's built-in video generation capabilities.
 "1792x1024"; defaults to "720x1280")
 
 For additional parameters, see
-[OpenAI Video Generation API Reference](https://platform.openai.com/docs/api-reference/videos)
+[OpenAI Video Generation API Reference](https://developers.openai.com/api/reference/resources/videos)
 
 Note: `input_reference` is not currently supported.
 
@@ -191,7 +191,7 @@ videos.
 
 - [OpenAI Video Generation Guide](https://platform.openai.com/docs/guides/video-generation)
   Complete guide to OpenAI's video generation capabilities and best practices.
-- [OpenAI Video API Reference](https://platform.openai.com/docs/api-reference/videos)
+- [OpenAI Video API Reference](https://developers.openai.com/api/reference/resources/videos)
   Detailed specifications and parameters for OpenAI's video generation API.
 - [LangChain OpenAI Integration](https://python.langchain.com/docs/integrations/chat/openai/)
   Documentation on using OpenAI's services within the LangChain framework.

--- a/registries/tools/openai_video_generation.hocon
+++ b/registries/tools/openai_video_generation.hocon
@@ -102,7 +102,7 @@ If the user ask you to describe a video, you MUST call your video_describer tool
                 # Output resolution formatted as width x height (allowed values: 720x1280, 1280x720, 1024x1792, 1792x1024). Defaults to 720x1280.
                 "size": "720x1280"
 
-                # For more information, please see https://platform.openai.com/docs/api-reference/videos
+                # For more information, please see https://developers.openai.com/api/reference/resources/videos
                 # Note that "input_reference" is not currently supported.
             }
         },


### PR DESCRIPTION
## Description

Replace the deprecated OpenAI Video API reference URL (`platform.openai.com/docs/api-reference/videos`) with the new URL (`developers.openai.com/api/reference/resources/videos`) in 3 places across 2 files.

## Impact

Documentation and config comments now point to the correct, up-to-date OpenAI Video API reference page.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/c22ca2cb525047ecb1a5c0f58a16abbb
Requested by: @shrushtiimehta