### PR TITLE
Update OpenAI docs URLs to developers.openai.com

### DIFF
--- a/docs/examples/tools/openai_code_interpreter.md
+++ b/docs/examples/tools/openai_code_interpreter.md
@@ -34,7 +34,7 @@ export OPENAI_API_KEY="your_openai_api_key_here"
 
 For more information on setting up OpenAI tools, see:
 
-- [OpenAI Tools Guide](https://platform.openai.com/docs/guides/tools?api-mode=responses)
+- [OpenAI Tools Guide](https://developers.openai.com/api/docs/guides/tools)
 
 - [LangChain OpenAI Responses API](https://python.langchain.com/docs/integrations/chat/openai/#responses-api)
 
@@ -151,7 +151,7 @@ When developing or debugging the OpenAI Code Interpreter Assistant, keep the fol
 
 ## Resources
 
-- [OpenAI Tools Guide](https://platform.openai.com/docs/guides/tools?api-mode=responses)  
+- [OpenAI Tools Guide](https://developers.openai.com/api/docs/guides/tools)  
   Complete guide to OpenAI's built-in tools and their capabilities.
 
 - [OpenAI Code Interpreter Documentation](https://developers.openai.com/api/docs/guides/tools-code-interpreter)  
@@ -160,7 +160,7 @@ When developing or debugging the OpenAI Code Interpreter Assistant, keep the fol
 - [LangChain OpenAI Responses API](https://python.langchain.com/docs/integrations/chat/openai/#responses-api)  
   Documentation on using OpenAI's Responses API within the LangChain framework.
 
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference)  
+- [OpenAI API Reference](https://developers.openai.com/docs/api-reference)  
   Complete API reference for OpenAI's services and endpoints.
 
 - [Coded Tools Implementation Guide](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#coded-tools)  

--- a/docs/examples/tools/openai_image_generation.md
+++ b/docs/examples/tools/openai_image_generation.md
@@ -34,7 +34,7 @@ export OPENAI_API_KEY="your_openai_api_key_here"
 
 For more information on setting up OpenAI tools, see:
 
-- [OpenAI Tools Guide](https://platform.openai.com/docs/guides/tools?api-mode=responses)
+- [OpenAI Tools Guide](https://developers.openai.com/api/docs/guides/tools)
 
 - [LangChain OpenAI Responses API](https://python.langchain.com/docs/integrations/chat/openai/#responses-api)
 
@@ -83,7 +83,7 @@ which leverages OpenAI's built-in image generation capabilities.
 
 - `additional_kwargs`: Optional parameters for fine-tuning image generation behavior
   - `quality`: Image quality setting (e.g., "medium", "high")
-  - Additional parameters as documented in [OpenAI's image generation guide](https://platform.openai.com/docs/guides/tools-image-generation)
+  - Additional parameters as documented in [OpenAI's image generation guide](https://developers.openai.com/api/docs/guides/tools-image-generation)
 
 ---
 
@@ -135,16 +135,16 @@ When developing or debugging the OpenAI Image Generation Assistant, keep the fol
 
 ## Resources
 
-- [OpenAI Tools Guide](https://platform.openai.com/docs/guides/tools?api-mode=responses)  
+- [OpenAI Tools Guide](https://developers.openai.com/api/docs/guides/tools)  
   Complete guide to OpenAI's built-in tools and their capabilities.
 
-- [OpenAI Image Generation Tool Documentation](https://platform.openai.com/docs/guides/tools-image-generation)  
+- [OpenAI Image Generation Tool Documentation](https://developers.openai.com/api/docs/guides/tools-image-generation)  
   Detailed specifications and parameters for OpenAI's image generation tool.
 
 - [LangChain OpenAI Responses API](https://python.langchain.com/docs/integrations/chat/openai/#responses-api)  
   Documentation on using OpenAI's Responses API within the LangChain framework.
 
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference)  
+- [OpenAI API Reference](https://developers.openai.com/docs/api-reference)  
   Complete API reference for OpenAI's services and endpoints.
 
 - [Coded Tools Implementation Guide](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#coded-tools)  

--- a/docs/examples/tools/openai_video_generation.md
+++ b/docs/examples/tools/openai_video_generation.md
@@ -43,7 +43,7 @@ export OPENAI_API_KEY="your_openai_api_key_here"
 
 For more information on setting up OpenAI tools, see:
 
-- [OpenAI Video Generation Guide](https://platform.openai.com/docs/guides/video-generation)
+- [OpenAI Video Generation Guide](https://developers.openai.com/api/docs/guides/video-generation)
 
 ---
 
@@ -189,13 +189,13 @@ videos.
 
 ## Resources
 
-- [OpenAI Video Generation Guide](https://platform.openai.com/docs/guides/video-generation)
+- [OpenAI Video Generation Guide](https://developers.openai.com/api/docs/guides/video-generation)
   Complete guide to OpenAI's video generation capabilities and best practices.
 - [OpenAI Video API Reference](https://developers.openai.com/api/reference/resources/videos)
   Detailed specifications and parameters for OpenAI's video generation API.
 - [LangChain OpenAI Integration](https://python.langchain.com/docs/integrations/chat/openai/)
   Documentation on using OpenAI's services within the LangChain framework.
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference)
+- [OpenAI API Reference](https://developers.openai.com/docs/api-reference)
   Complete API reference for OpenAI's services and endpoints.
 - [Coded Tools Implementation Guide](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#coded-tools)
   Learn how to implement and integrate custom coded tools in Neuro-SAN Studio.

--- a/docs/examples/tools/openai_web_search.md
+++ b/docs/examples/tools/openai_web_search.md
@@ -34,7 +34,7 @@ export OPENAI_API_KEY="your_openai_api_key_here"
 
 For more information on setting up OpenAI tools, see:
 
-- [OpenAI Tools Guide](https://platform.openai.com/docs/guides/tools?api-mode=responses)
+- [OpenAI Tools Guide](https://developers.openai.com/api/docs/guides/tools)
 
 - [LangChain OpenAI Responses API](https://python.langchain.com/docs/integrations/chat/openai/#responses-api)
 
@@ -131,16 +131,16 @@ When developing or debugging the OpenAI Web Search Assistant, keep the following
 
 ## Resources
 
-- [OpenAI Tools Guide](https://platform.openai.com/docs/guides/tools?api-mode=responses)  
+- [OpenAI Tools Guide](https://developers.openai.com/api/docs/guides/tools)  
   Complete guide to OpenAI's built-in tools and their capabilities.
 
-- [OpenAI Web Search Tool Documentation](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses)  
+- [OpenAI Web Search Tool Documentation](https://developers.openai.com/api/docs/guides/tools-web-search)  
   Detailed specifications and parameters for OpenAI's web search tool.
 
 - [LangChain OpenAI Responses API](https://python.langchain.com/docs/integrations/chat/openai/#responses-api)  
   Documentation on using OpenAI's Responses API within the LangChain framework.
 
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference)  
+- [OpenAI API Reference](https://developers.openai.com/docs/api-reference)  
   Complete API reference for OpenAI's services and endpoints.
 
 - [Coded Tools Implementation Guide](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#coded-tools)  


### PR DESCRIPTION
## Description

OpenAI moved their documentation from `platform.openai.com` to `developers.openai.com`. The old `/docs/api-reference` URL now returns 404, and the `/docs/guides/*` URLs redirect. This PR updates all affected URLs across four tool documentation files to point directly to the new canonical locations.

## Impact

Documentation links will resolve correctly without relying on redirects or hitting 404s.

## Type of Change

- [x] Documentation

## Checklist

- [x] Updated relevant documentation
