### PR TITLE
Load toolbox, mcp, and subnetwork info on demand during validation

### DIFF
--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -26,23 +26,18 @@ from neuro_san.internals.run_context.langchain.mcp.mcp_servers_info_restorer imp
 from coded_tools.agent_network_editor.constants import MCP_SERVERS
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
+# Use deepwiki MCP server as default since it is free and does not require authorization.
+DEFAULT_MCP_INFO_FILE = os.path.join("mcp", "mcp_info.hocon")
+logger = logging.getLogger(__name__)
+
 
 class GetMcpTool(CodedTool):
     """
     CodedTool implementation which provides a way to get tool definition from given MCP servers
     """
 
-    # Use deepwiki MCP server as default since it is free and does not require authorization.
-    DEFAULT_MCP_INFO_FILE = os.path.join("mcp", "mcp_info.hocon")
-
-    def __init__(self):
-        """
-        Constructor
-        """
-        # Initialize a logger
-        self.logger = logging.getLogger(self.__class__.__name__)
-
-    async def get_mcp_servers(self, sly_data: dict[str, Any]) -> list[str]:
+    @staticmethod
+    async def get_mcp_servers(sly_data: dict[str, Any]) -> list[str]:
         """
         Read the MCP servers associated with this instance
         either from a cache on sly_data or from a file.
@@ -50,12 +45,12 @@ class GetMcpTool(CodedTool):
         :param sly_data: sly_data possibly containing cached mcp_servers info
         :return: list of MCP servers
         """
-        mcp_servers: list[str] = None
+        mcp_servers: list[str] = []
 
         async with await SlyDataLock.get_lock(sly_data, "mcp_servers_lock"):
             # Try getting from sly_data
-            mcp_servers = sly_data.get(MCP_SERVERS)
-            if mcp_servers is not None:
+            mcp_servers = sly_data.get(MCP_SERVERS, {})
+            if mcp_servers:
                 # Exit early
                 return mcp_servers
 
@@ -63,7 +58,7 @@ class GetMcpTool(CodedTool):
             use_mcp_info_file: str = os.getenv("MCP_SERVERS_INFO_FILE")
             if not use_mcp_info_file:
                 # Use a default if no value specified
-                use_mcp_info_file = self.DEFAULT_MCP_INFO_FILE
+                use_mcp_info_file = DEFAULT_MCP_INFO_FILE
 
             # Try to restore
             mcp_servers_from_file: dict[str, Any] = {}
@@ -71,7 +66,7 @@ class GetMcpTool(CodedTool):
                 restorer = McpServersInfoRestorer()
                 mcp_servers_from_file = await restorer.async_restore(file_reference=use_mcp_info_file)
             except FileNotFoundError:
-                self.logger.warning(
+                logger.warning(
                     "MCP servers info file not found at %s. No MCP Servers will be used.", use_mcp_info_file
                 )
 
@@ -111,7 +106,7 @@ class GetMcpTool(CodedTool):
         """
 
         # Get tool list from MCP servers
-        self.logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from MCP Servers>>>>>>>>>>>>>>>>>>>")
+        logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from MCP Servers>>>>>>>>>>>>>>>>>>>")
 
         async with await SlyDataLock.get_lock(sly_data, "tool_dict_lock"):
             if "tool_dict" not in sly_data:
@@ -120,9 +115,9 @@ class GetMcpTool(CodedTool):
                 mcp_servers: list[str] = await self.get_mcp_servers(sly_data)
                 for mcp_server in mcp_servers:
                     try:
-                        self.logger.info("MCP Server: %s", mcp_server)
+                        logger.info("MCP Server: %s", mcp_server)
                         tools: list[BaseTool] = await LangChainMcpAdapter().get_mcp_tools(mcp_server)
-                        self.logger.info("Successfully loaded the following tools: %s", str(tools))
+                        logger.info("Successfully loaded the following tools: %s", str(tools))
 
                         # Gather each tool's description into one string.
                         tool_dict[mcp_server] = ""
@@ -131,7 +126,7 @@ class GetMcpTool(CodedTool):
 
                     except ExceptionGroup as exception:
                         error_msg = f"Error: Failed to load tools from {mcp_server}. {str(exception)}"
-                        self.logger.warning(error_msg)
+                        logger.warning(error_msg)
 
                 # Stash a string representation of the tool_dict
                 sly_data["tool_dict"] = str(tool_dict)

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -49,9 +49,9 @@ class GetMcpTool(CodedTool):
 
         async with await SlyDataLock.get_lock(sly_data, "mcp_servers_lock"):
             # Try getting from sly_data
-            mcp_servers = sly_data.get(MCP_SERVERS, {})
-            if mcp_servers:
-                # Exit early
+            if MCP_SERVERS in sly_data:
+                mcp_servers = sly_data.get(MCP_SERVERS, [])
+                # Exit early, including when the cached value is an empty list
                 return mcp_servers
 
             # Check for MCP servers info file in env var

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -50,9 +50,8 @@ class GetMcpTool(CodedTool):
         async with await SlyDataLock.get_lock(sly_data, "mcp_servers_lock"):
             # Try getting from sly_data
             if MCP_SERVERS in sly_data:
-                mcp_servers = sly_data.get(MCP_SERVERS, [])
                 # Exit early, including when the cached value is an empty list
-                return mcp_servers
+                return sly_data.get(MCP_SERVERS)
 
             # Check for MCP servers info file in env var
             use_mcp_info_file: str = os.getenv("MCP_SERVERS_INFO_FILE")

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -97,7 +97,7 @@ class GetSubnetwork(CodedTool):
             except FileNotFoundError:
                 logger.warning("Error: Failed to load agent networks info from %s.", manifest_file)
 
-            # Cache whatever we found, including an error - no need to do this more than once.
+            # Cache whatever we found, including an empty mapping on failure, to avoid reloading.
             sly_data[SUBNETWORKS] = subnetworks
 
         return subnetworks

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -25,32 +25,86 @@ from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from coded_tools.agent_network_editor.constants import SUBNETWORKS
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
+DEFAULT_MANIFEST_FILE = os.path.join("registries", "manifest_and.hocon")
+logger = logging.getLogger(__name__)
+
 
 class GetSubnetwork(CodedTool):
     """
     CodedTool implementation which provides a way to get subnetwork names and descriptions from the manifest file
     """
 
-    DEFAULT_MANIFEST_FILE = os.path.join("registries", "manifest_and.hocon")
-
     @staticmethod
-    def get_subnetwork_names(sly_data: dict) -> list[str]:
+    async def get_subnetwork_names(sly_data: dict[str, Any]) -> list[str]:
         """
-        Extract subnetwork names from sly_data.
-
-        The SUBNETWORKS entry may be a dict (name -> definition) populated by the
-        agent network editor tools, or absent/non-dict if no subnetworks were set.
+        Get the list of subnetwork names, loading from the manifest file via
+        get_subnetworks() if not already cached on sly_data.
 
         :param sly_data: The sly_data dictionary from the agent hierarchy.
-        :return: List of subnetwork name strings, or empty list if none.
+        :return: List of subnetwork name strings, or empty list if none / on error.
         """
-        subnetworks_from_tool = sly_data.get(SUBNETWORKS)
-        if isinstance(subnetworks_from_tool, dict):
-            return list(subnetworks_from_tool.keys())
-        return []
+        subnetworks = await GetSubnetwork.get_subnetworks(sly_data)
+        return list(subnetworks.keys())
+
 
     # pylint: disable=too-many-locals
-    async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any] | str:
+    @staticmethod
+    async def get_subnetworks(sly_data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Read the subnetwork name -> description mapping
+        either from a cache on sly_data or from the manifest file.
+
+        :param sly_data: sly_data possibly containing cached subnetworks info
+        :return: dict of subnetwork name to description
+        """
+        subnetworks: dict[str, str] = {}
+
+        async with await SlyDataLock.get_lock(sly_data, "subnetworks_lock"):
+            # Try getting from sly_data
+            subnetworks = sly_data.get(SUBNETWORKS, {})
+            if subnetworks:
+                # Exit early
+                return subnetworks
+
+            # Check manifest file from env var
+            manifest_file: str | list[str] = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE")
+            if not manifest_file:
+                # Use a default if no value provided
+                manifest_file = DEFAULT_MANIFEST_FILE
+
+            empty: dict[str, AgentNetwork] = {}
+            networks: dict[str, AgentNetwork] = {}
+            logger.info(">>>>>>>>>>>>>>>>>>>Getting Subnetwork Descriptions from Manifest>>>>>>>>>>>>>>>>>>>")
+            logger.info("Manifest file: %s", str(manifest_file))
+
+            # What is returned is mapping from storage type -> (name -> AgentNetwork mapping)
+            restorer = RegistryManifestRestorer(manifest_file)
+            try:
+                # Note that any hocon includes will be done synchronously
+                networks_by_storage: dict[str, dict[str, AgentNetwork]] = await restorer.async_restore()
+                logger.info("Successfully loaded agent networks info from %s", str(manifest_file))
+
+                # Put all name -> AgentNetwork mappings into a single dictionary,
+                # as is expected by the rest of this tool.
+                for storage_type in ["public", "protected"]:
+                    one_storage_dict: dict[str, AgentNetwork] = networks_by_storage.get(storage_type, empty)
+                    networks.update(one_storage_dict)
+
+                for name, network in networks.items():
+                    front_man: str = network.find_front_man()
+                    desc: str = network.get_agent_tool_spec(front_man).get("function", {}).get("description")
+                    if desc is not None and len(desc) > 0:
+                        subnetworks["/" + name] = desc
+
+            except FileNotFoundError:
+                logger.warning("Error: Failed to load agent networks info from %s.", manifest_file)
+
+            # Cache whatever we found, including an error - no need to do this more than once.
+            sly_data[SUBNETWORKS] = subnetworks
+
+        return subnetworks
+
+    async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any]:
         """
         :param args: An argument dictionary whose keys are the parameters
                 to the coded tool and whose values are the values passed for them
@@ -76,55 +130,6 @@ class GetSubnetwork(CodedTool):
             In case of successful execution:
                 the names and descriptions as keys and values of a dictionary.
             otherwise:
-                a text string of an error message in the format:
-                "Error: <error message>"
+                an empty dictionary.
         """
-        logger = logging.getLogger(self.__class__.__name__)
-
-        # Check manifest file from env var
-        manifest_file: str | list[str] = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE")
-        if not manifest_file:
-            # Use a default if no value provided
-            manifest_file = self.DEFAULT_MANIFEST_FILE
-
-        subnetworks: dict[str, str] | str = {}
-        async with await SlyDataLock.get_lock(sly_data, "subnetworks_lock"):
-            # Try getting from sly_data
-            subnetworks = sly_data.get(SUBNETWORKS)
-            if subnetworks is not None:
-                # Exit early
-                return subnetworks
-
-            subnetworks = {}
-            empty: dict[str, AgentNetwork] = {}
-            networks: dict[str, AgentNetwork] = {}
-            logger.info(">>>>>>>>>>>>>>>>>>>Getting Subnetwork Descriptions from Manifest>>>>>>>>>>>>>>>>>>>")
-            logger.info("Manifest file: %s", str(manifest_file))
-
-            # What is returned is mapping from storage type -> (name -> AgentNetwork mapping)
-            restorer = RegistryManifestRestorer(manifest_file)
-            try:
-                # Note that any hocon includes will be done synchronously
-                networks_by_storage: dict[str, dict[str, AgentNetwork]] = await restorer.async_restore()
-                logger.info("Successfully loaded agent networks info from %s", str(manifest_file))
-
-                # Put all name -> AgentNetwork mappings into a single dictionary,
-                # as is expected by the rest of this tool.
-                for storage_type in ["public", "protected"]:
-                    one_storage_dict: dict[str, AgentNetwork] = networks_by_storage.get(storage_type, empty)
-                    networks.update(one_storage_dict)
-
-                for name, network in networks.items():
-                    front_man: str = network.find_front_man()
-                    desc: str = network.get_agent_tool_spec(front_man).get("function", {}).get("description")
-                    if desc is not None and len(desc) > 0:
-                        subnetworks["/" + name] = desc
-
-            except FileNotFoundError as not_found_err:
-                subnetworks = f"Error: Failed to load agent networks info from {manifest_file}. {str(not_found_err)}"
-                logger.warning(subnetworks)
-
-            # Cache whatever we found, including an error - no need to do this more than once.
-            sly_data[SUBNETWORKS] = subnetworks
-
-        return subnetworks
+        return await self.get_subnetworks(sly_data)

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -60,10 +60,9 @@ class GetSubnetwork(CodedTool):
 
         async with await SlyDataLock.get_lock(sly_data, "subnetworks_lock"):
             # Try getting from sly_data
-            subnetworks = sly_data.get(SUBNETWORKS, {})
-            if subnetworks:
-                # Exit early
-                return subnetworks
+            if SUBNETWORKS in sly_data:
+                # Exit early, including for an explicitly cached empty mapping
+                return sly_data[SUBNETWORKS]
 
             # Check manifest file from env var
             manifest_file: str | list[str] = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE")

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -62,7 +62,7 @@ class GetSubnetwork(CodedTool):
             # Try getting from sly_data
             if SUBNETWORKS in sly_data:
                 # Exit early, including for an explicitly cached empty mapping
-                return sly_data[SUBNETWORKS]
+                return sly_data.get(SUBNETWORKS)
 
             # Check manifest file from env var
             manifest_file: str | list[str] = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE")

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -46,7 +46,6 @@ class GetSubnetwork(CodedTool):
         subnetworks = await GetSubnetwork.get_subnetworks(sly_data)
         return list(subnetworks.keys())
 
-
     # pylint: disable=too-many-locals
     @staticmethod
     async def get_subnetworks(sly_data: dict[str, Any]) -> dict[str, Any]:

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -36,8 +36,8 @@ class GetToolbox(CodedTool):
     @staticmethod
     async def get_toolbox_info(sly_data: dict[str, Any]) -> dict[str, Any]:
         """
-        Read the toolbox info associated with this instance
-        either from a cache on sly_data or from a file.
+        Read toolbox info from a cache in sly_data
+        or load it from a file.
 
         :param sly_data: sly_data possibly containing cached toolbox info
         :return: dict mapping tool names to descriptions; empty if loading fails

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -48,7 +48,7 @@ class GetToolbox(CodedTool):
             # Try getting from sly_data
             if TOOLBOX_INFO in sly_data:
                 # Return whatever we had cached before, including an empty dict
-                return sly_data[TOOLBOX_INFO]
+                return sly_data.get(TOOLBOX_INFO)
 
             # Check for toolbox info file in env var
             toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE")

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -25,6 +25,7 @@ from coded_tools.agent_network_editor.constants import TOOLBOX_INFO
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 DEFAULT_TOOLBOX_INFO_FILE = os.path.join("toolbox", "agent_network_designer_toolbox_info.hocon")
+logger = logging.getLogger(__name__)
 
 
 class GetToolbox(CodedTool):
@@ -32,7 +33,51 @@ class GetToolbox(CodedTool):
     CodedTool implementation which provides a way to get tool definition from toolbox info file
     """
 
-    async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any] | str:
+    @staticmethod
+    async def get_toolbox_info(sly_data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Read the toolbox info associated with this instance
+        either from a cache on sly_data or from a file.
+
+        :param sly_data: sly_data possibly containing cached toolbox info
+        :return: dict of tool name to description, or an error string
+        """
+        tools: dict[str, Any] = {}
+
+        async with await SlyDataLock.get_lock(sly_data, "toolbox_info_lock"):
+            # Try getting from sly_data
+            tools = sly_data.get(TOOLBOX_INFO, {})
+            if tools:
+                # Return whatever we had cached before
+                return tools
+
+            # Check for toolbox info file in env var
+            toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE")
+            if not toolbox_info_file:
+                # Use a default if no value specified
+                toolbox_info_file = DEFAULT_TOOLBOX_INFO_FILE
+
+            # Go fish, but only once.
+            logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from Toolbox>>>>>>>>>>>>>>>>>>>")
+            logger.info("Toolbox info file: %s", toolbox_info_file)
+            try:
+                # Need to do the load
+                tools = await ToolboxInfoRestorer().async_restore(toolbox_info_file)
+                logger.info("Successfully loaded the following toolbox: %s", str(tools))
+
+                # Clean up the dict so that it only contains "description" key.
+                for tool_name, tool_info in tools.items():
+                    tools[tool_name] = tool_info.get("description", "")
+
+            except FileNotFoundError:
+                logger.warning("Error: Failed to load toolbox info from %s.", toolbox_info_file)
+
+            # Cache the results in sly_data - success or failure.
+            sly_data[TOOLBOX_INFO] = tools
+
+        return tools
+
+    async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any]:
         """
         :param args: An argument dictionary whose keys are the parameters
                 to the coded tool and whose values are the values passed for them
@@ -58,37 +103,6 @@ class GetToolbox(CodedTool):
             In case of successful execution:
                 the tool definition from toolbox as a dictionary.
             otherwise:
-                a text string of an error message in the format:
-                "Error: <error message>"
+                an empty dictionary.
         """
-        logger = logging.getLogger(self.__class__.__name__)
-        toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE", DEFAULT_TOOLBOX_INFO_FILE)
-
-        tools: dict[str, Any] | str = None
-        async with await SlyDataLock.get_lock(sly_data, "toolbox_info_lock"):
-            # Try getting from sly_data
-            tools = sly_data.get(TOOLBOX_INFO)
-            if tools is not None:
-                # Return whatever we had cached before
-                return tools
-
-            # Go fish, but only once.
-            logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from Toolbox>>>>>>>>>>>>>>>>>>>")
-            logger.info("Toolbox info file: %s", toolbox_info_file)
-            try:
-                # Need to do the load
-                tools = await ToolboxInfoRestorer().async_restore(toolbox_info_file)
-                logger.info("Successfully loaded the following toolbox: %s", str(tools))
-
-                # Clean up the dict so that it only contains "description" key.
-                for tool_name, tool_info in tools.items():
-                    tools[tool_name] = tool_info.get("description", "")
-
-            except FileNotFoundError as not_found_err:
-                tools = f"Error: Failed to load toolbox info from {toolbox_info_file}. {str(not_found_err)}"
-                logger.warning(tools)
-
-            # Cache the results in sly_data - success or failure.
-            sly_data[TOOLBOX_INFO] = tools
-
-        return tools
+        return await self.get_toolbox_info(sly_data)

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -40,7 +40,7 @@ class GetToolbox(CodedTool):
         either from a cache on sly_data or from a file.
 
         :param sly_data: sly_data possibly containing cached toolbox info
-        :return: dict of tool name to description, or an error string
+        :return: dict mapping tool names to descriptions; empty if loading fails
         """
         tools: dict[str, Any] = {}
 

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -46,10 +46,9 @@ class GetToolbox(CodedTool):
 
         async with await SlyDataLock.get_lock(sly_data, "toolbox_info_lock"):
             # Try getting from sly_data
-            tools = sly_data.get(TOOLBOX_INFO, {})
-            if tools:
-                # Return whatever we had cached before
-                return tools
+            if TOOLBOX_INFO in sly_data:
+                # Return whatever we had cached before, including an empty dict
+                return sly_data[TOOLBOX_INFO]
 
             # Check for toolbox info file in env var
             toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE")

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -31,7 +31,7 @@ from coded_tools.agent_network_editor.connectivity_dictionary_converter import C
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_HOCON_TEXT
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
-from coded_tools.agent_network_editor.constants import MCP_SERVERS
+from coded_tools.agent_network_editor.get_mcp_tool import GetMcpTool
 from coded_tools.agent_network_editor.get_subnetwork import GetSubnetwork
 from coded_tools.agent_network_query_generator.set_sample_queries import AGENT_NETWORK_QUERIES
 from middleware.agent_network_designer.persistence.agent_network_assembler import AgentNetworkAssembler
@@ -193,8 +193,8 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.logger.info(">>>>>>>>>>>>>>>>>>>Create Agent Network>>>>>>>>>>>>>>>>>>")
         self.logger.info("Agent Network Name: %s", the_agent_network_name)
 
-        subnetwork_names: list[str] = GetSubnetwork.get_subnetwork_names(self.sly_data)
-        mcp_servers: list[str] = self.sly_data.get(MCP_SERVERS, [])
+        subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
+        mcp_servers: list[str] = GetMcpTool.get_mcp_servers(self.sly_data)
         persistor: AgentNetworkPersistor = AgentNetworkPersistorFactory.create_persistor(
             {"reservationist": self.reservationist},
             WRITE_TO_FILE,

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -194,7 +194,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.logger.info("Agent Network Name: %s", the_agent_network_name)
 
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
-        mcp_servers: list[str] = GetMcpTool.get_mcp_servers(self.sly_data)
+        mcp_servers: list[str] = await GetMcpTool.get_mcp_servers(self.sly_data)
         persistor: AgentNetworkPersistor = AgentNetworkPersistorFactory.create_persistor(
             {"reservationist": self.reservationist},
             WRITE_TO_FILE,

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -59,8 +59,8 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
         # Get infos from sly_data. These should have been put there by the respective tools
         # from the agent network editor.
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
-        mcp_servers: list[str] = GetMcpTool.get_mcp_servers(self.sly_data)
-        toolbox_tools: dict[str, Any] = GetToolbox.get_toolbox_info(self.sly_data)
+        mcp_servers: list[str] = await GetMcpTool.get_mcp_servers(self.sly_data)
+        toolbox_tools: dict[str, Any] = await GetToolbox.get_toolbox_info(self.sly_data)
 
         return (
             StructureNetworkValidator().validate(network_def)

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -21,8 +21,6 @@ from neuro_san.internals.validation.network.structure_network_validator import S
 from neuro_san.internals.validation.network.toolbox_network_validator import ToolboxNetworkValidator
 from neuro_san.internals.validation.network.url_network_validator import UrlNetworkValidator
 
-from coded_tools.agent_network_editor.constants import MCP_SERVERS
-from coded_tools.agent_network_editor.constants import TOOLBOX_INFO
 from coded_tools.agent_network_editor.get_mcp_tool import GetMcpTool
 from coded_tools.agent_network_editor.get_subnetwork import GetSubnetwork
 from coded_tools.agent_network_editor.get_toolbox import GetToolbox

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -23,7 +23,9 @@ from neuro_san.internals.validation.network.url_network_validator import UrlNetw
 
 from coded_tools.agent_network_editor.constants import MCP_SERVERS
 from coded_tools.agent_network_editor.constants import TOOLBOX_INFO
+from coded_tools.agent_network_editor.get_mcp_tool import GetMcpTool
 from coded_tools.agent_network_editor.get_subnetwork import GetSubnetwork
+from coded_tools.agent_network_editor.get_toolbox import GetToolbox
 from middleware.agent_network_designer.validation.agent_network_validation_middleware import (
     AgentNetworkValidationMiddleware,
 )
@@ -58,9 +60,9 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
 
         # Get infos from sly_data. These should have been put there by the respective tools
         # from the agent network editor.
-        subnetwork_names: list[str] = GetSubnetwork.get_subnetwork_names(self.sly_data)
-        mcp_servers: list[str] = self.sly_data.get(MCP_SERVERS, [])
-        toolbox_tools: dict[str, Any] = self.sly_data.get(TOOLBOX_INFO, {})
+        subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
+        mcp_servers: list[str] = GetMcpTool.get_mcp_servers(self.sly_data)
+        toolbox_tools: dict[str, Any] = GetToolbox.get_toolbox_info(self.sly_data)
 
         return (
             StructureNetworkValidator().validate(network_def)


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Structure validation read `toolbox_info`, `mcp_servers`, and `subnetworks` directly from `sly_data`, so when those tools hadn't been invoked yet the validators ran against empty inputs and the validation fails.

Extract cache-and-load helpers `get_toolbox_info` and `get_subnetworks` that mirror the existing `get_mcp_servers` pattern: check `sly_data`, otherwise read the info file under a `SlyDataLock` and cache the result. Make `get_subnetwork_names` async and delegate to `get_subnetworks` so callers get manifest-backed names on a cold cache. Update the persistence and structure-validation middlewares to await the new async call.

Also normalize the three Get coded tools onto a shared shape: module-level default-file constant and logger, `@staticmethod` helpers, and a thin `async_invoke` that delegates.

**Note:**
The logic of `get_toolbox_info`,`get_subnetworks`, and `get_mcp_servers` coded tool should be changed to middleware of `agent_network_designer` since we also need these info on the designer level to do the validation persisting the network, and then these sly data can be passed down to the `agent_network_editor`.
See #983 

Fixes #978

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
