### PR TITLE
Deploy langfuse plugin

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -41,7 +41,7 @@ RUN pip3 install --upgrade pip==${PIP3_VERSION} --no-cache-dir ; mkdir -p ${APP_
 
 # Having a requirements.txt file for your coded_tool dependencies is optional
 COPY ./requirements.txt ${APP_SOURCE}/requirements.txt
-COPY ./neuro_san_studio ${APP_SOURCE}/neuro_san_studio
+COPY ./neuro_san_studio/plugins/langfuse/requirements.txt ${APP_SOURCE}/neuro_san_studio/plugins/langfuse/requirements.txt
 
 # Move the work dir to the app source to find the requirements.
 WORKDIR ${APP_SOURCE}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -41,12 +41,20 @@ RUN pip3 install --upgrade pip==${PIP3_VERSION} --no-cache-dir ; mkdir -p ${APP_
 
 # Having a requirements.txt file for your coded_tool dependencies is optional
 COPY ./requirements.txt ${APP_SOURCE}/requirements.txt
+COPY ./neuro_san_studio ${APP_SOURCE}/neuro_san_studio
+
 # Move the work dir to the app source to find the requirements.
 WORKDIR ${APP_SOURCE}
 RUN if [ -f ${APP_SOURCE}/requirements.txt ]; \
     then \
         pip install --prefix=/install --no-cache-dir -r ${APP_SOURCE}/requirements.txt ; \
     fi
+
+# Install plugin dependencies.
+# To install additional plugins, add more lines following this pattern:
+#   pip install --prefix=/install --no-cache-dir -r ${APP_SOURCE}/neuro_san_studio/plugins/<plugin>/requirements.txt
+RUN pip install --prefix=/install --no-cache-dir \
+    -r ${APP_SOURCE}/neuro_san_studio/plugins/langfuse/requirements.txt
 
 # Reset to the root directory
 WORKDIR /
@@ -93,6 +101,8 @@ COPY --from=builder /install /usr/local
 #       The Agent Network Designer relies on:
 #       - its own toolbox in ./toolbox
 #       - ./middleware for validation of designed networks
+COPY ./neuro_san_studio ${APP_SOURCE}/neuro_san_studio
+COPY ./servers ${APP_SOURCE}/servers
 COPY ./registries ${APP_SOURCE}/registries
 COPY ./coded_tool[s] ${APP_SOURCE}/coded_tools
 COPY ./toolbox ${APP_SOURCE}/toolbox
@@ -254,6 +264,12 @@ ENV AGENT_TRACING_METADATA_REQUEST_KEYS=""
 # The defaults given here are standard Kubernetes environment variables for any given deployment pod.
 # Only environment variables that are set to something other than the empty string will be forwarded.
 ENV AGENT_TRACING_METADATA_ENV_VARS="POD_NAME POD_NAMESPACE POD_IP NODE_NAME"
+
+# Langfuse observability
+ENV LANGFUSE_ENABLED=""
+ENV LANGFUSE_SECRET_KEY=""
+ENV LANGFUSE_PUBLIC_KEY=""
+ENV LANGFUSE_HOST=""
 
 # Size of backlog for TCP connections to http server.
 # Sets the maximum number of pending TCP connections waiting to be accepted by the server.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -265,10 +265,17 @@ ENV AGENT_TRACING_METADATA_REQUEST_KEYS=""
 # Only environment variables that are set to something other than the empty string will be forwarded.
 ENV AGENT_TRACING_METADATA_ENV_VARS="POD_NAME POD_NAMESPACE POD_IP NODE_NAME"
 
-# Langfuse observability
+# Langfuse observability plugin.
+# See https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/neuro_san_studio/plugins/langfuse/README.md
+# for more details.
+
+# "true" or "false" to turn on/off the Langfuse plugin.
 ENV LANGFUSE_ENABLED=""
+# The secrect and public keys for the Langfuse plugin.
+# These can be found in your Langfuse account settings.
 ENV LANGFUSE_SECRET_KEY=""
 ENV LANGFUSE_PUBLIC_KEY=""
+# Langfuse instance URL, e.g. "https://us.cloud.langfuse.com".
 ENV LANGFUSE_HOST=""
 
 # Size of backlog for TCP connections to http server.

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -45,6 +45,6 @@ echo "DIAGNOSTIC: Dumping sys.path and PYTHONPATH before server start..."
 ${PYTHON} -c "import sys, os; print('DIAGNOSTIC sys.path:', sys.path); print('DIAGNOSTIC PYTHONPATH:', os.environ.get('PYTHONPATH'))"
 
 echo "Starting service with args '$1'..."
-${PYTHON} "${PACKAGE_INSTALL}"/neuro_san/service/main_loop/server_main_loop.py "$@"
+${PYTHON} "${APP_SOURCE}"/servers/neuro_san/neuro_san_server_wrapper.py "$@"
 
 echo "Done."

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -26,7 +26,9 @@ echo "Using python ${PYTHON}"
 PIP=pip3
 echo "Using pip ${PIP}"
 
-# Disable the log bridge plugin: we only start the neuro SAN server here.
+# The Log Bridge plugin aggregates logs from server and client subprocesses, and pretty-prints them.
+# But we only deploy the neuro-san server here, and it has its own logging configuration.
+# So we forcibly disable the log bridge plugin to avoid conflicts.
 export LOGBRIDGE_ENABLED=false
 
 echo "Preparing app..."

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -26,6 +26,9 @@ echo "Using python ${PYTHON}"
 PIP=pip3
 echo "Using pip ${PIP}"
 
+# Disable the log bridge plugin: we only start the neuro SAN server here.
+export LOGBRIDGE_ENABLED=false
+
 echo "Preparing app..."
 if [ -z "${PYTHONPATH}" ]
 then

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -70,6 +70,10 @@ function run() {
         --network=$network \
         -e OPENAI_API_KEY \
         -e ANTHROPIC_API_KEY \
+        -e LANGFUSE_ENABLED \
+        -e LANGFUSE_SECRET_KEY \
+        -e LANGFUSE_PUBLIC_KEY \
+        -e LANGFUSE_HOST \
         -e AGENT_RESERVATIONS_S3_BUCKET \
         -e AGENT_EXTERNAL_RESERVATIONS_STORAGE \
         -e TOOL_REGISTRY_FILE=$1 \

--- a/neuro_san_studio/plugins/plugin_loader.py
+++ b/neuro_san_studio/plugins/plugin_loader.py
@@ -41,6 +41,14 @@ class PluginLoader:  # pylint: disable=too-few-public-methods
     """Loads plugin classes from a HOCON configuration file."""
 
     @staticmethod
+    def _is_enabled(plugin_entry: Dict[str, Any]) -> bool:
+        """Determine whether a plugin entry is enabled, handling string env var substitutions."""
+        value = plugin_entry.get("enabled", True)
+        if isinstance(value, str):
+            return value.lower() in ("true", "1", "yes")
+        return bool(value)
+
+    @staticmethod
     def load_plugin_classes(plugins_file: str) -> List[Type]:
         """Load plugin classes from a HOCON configuration file.
 
@@ -71,7 +79,7 @@ class PluginLoader:  # pylint: disable=too-few-public-methods
         plugin_entry: Dict[str, Any]
         for plugin_entry in config.get("plugins", []):
             class_path: Optional[str] = plugin_entry.get("class")
-            enabled: bool = plugin_entry.get("enabled", True)
+            enabled: bool = PluginLoader._is_enabled(plugin_entry)
 
             if not enabled:
                 _logger.info("Plugin %s is disabled. Skipping.", class_path)

--- a/tests/neuro_san_studio/plugins/test_plugin_loader.py
+++ b/tests/neuro_san_studio/plugins/test_plugin_loader.py
@@ -19,6 +19,8 @@
 import os
 import tempfile
 
+import pytest
+
 from neuro_san_studio.interfaces.base_plugin import BasePlugin
 from neuro_san_studio.plugins.plugin_loader import PluginLoader
 
@@ -256,20 +258,12 @@ class TestIsEnabled:  # pylint: disable=protected-access
         """Test that a missing 'enabled' key defaults to True."""
         assert PluginLoader._is_enabled({}) is True
 
-    def test_string_true_variants(self):
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes", "Yes"])
+    def test_string_true_variants(self, value):
         """Test that string truthy values are recognized."""
-        assert PluginLoader._is_enabled({"enabled": "true"}) is True
-        assert PluginLoader._is_enabled({"enabled": "True"}) is True
-        assert PluginLoader._is_enabled({"enabled": "TRUE"}) is True
-        assert PluginLoader._is_enabled({"enabled": "1"}) is True
-        assert PluginLoader._is_enabled({"enabled": "yes"}) is True
-        assert PluginLoader._is_enabled({"enabled": "Yes"}) is True
+        assert PluginLoader._is_enabled({"enabled": value}) is True
 
-    def test_string_false_variants(self):
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", "0", "no", ""])
+    def test_string_false_variants(self, value):
         """Test that string falsy values are recognized."""
-        assert PluginLoader._is_enabled({"enabled": "false"}) is False
-        assert PluginLoader._is_enabled({"enabled": "False"}) is False
-        assert PluginLoader._is_enabled({"enabled": "FALSE"}) is False
-        assert PluginLoader._is_enabled({"enabled": "0"}) is False
-        assert PluginLoader._is_enabled({"enabled": "no"}) is False
-        assert PluginLoader._is_enabled({"enabled": ""}) is False
+        assert PluginLoader._is_enabled({"enabled": value}) is False

--- a/tests/neuro_san_studio/plugins/test_plugin_loader.py
+++ b/tests/neuro_san_studio/plugins/test_plugin_loader.py
@@ -198,3 +198,78 @@ plugins = [
             assert len(classes) == 1
         finally:
             os.unlink(tmp_path)
+
+    def test_string_false_disables_plugin(self):
+        """Test that a string 'False' (from env var substitution) disables the plugin."""
+        hocon = """
+plugins = [
+    {
+        class = "neuro_san_studio.interfaces.base_plugin.BasePlugin"
+        enabled = "False"
+    }
+]
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".hocon", delete=False) as tmp:
+            tmp.write(hocon)
+            tmp_path = tmp.name
+
+        try:
+            classes = PluginLoader.load_plugin_classes(tmp_path)
+            assert not classes
+        finally:
+            os.unlink(tmp_path)
+
+    def test_string_true_enables_plugin(self):
+        """Test that a string 'true' (from env var substitution) enables the plugin."""
+        hocon = """
+plugins = [
+    {
+        class = "neuro_san_studio.interfaces.base_plugin.BasePlugin"
+        enabled = "true"
+    }
+]
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".hocon", delete=False) as tmp:
+            tmp.write(hocon)
+            tmp_path = tmp.name
+
+        try:
+            classes = PluginLoader.load_plugin_classes(tmp_path)
+            assert len(classes) == 1
+            assert classes[0] is BasePlugin
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestIsEnabled:  # pylint: disable=protected-access
+    """Tests for PluginLoader._is_enabled."""
+
+    def test_bool_true(self):
+        """Test that boolean True returns True."""
+        assert PluginLoader._is_enabled({"enabled": True}) is True
+
+    def test_bool_false(self):
+        """Test that boolean False returns False."""
+        assert PluginLoader._is_enabled({"enabled": False}) is False
+
+    def test_missing_key_defaults_to_true(self):
+        """Test that a missing 'enabled' key defaults to True."""
+        assert PluginLoader._is_enabled({}) is True
+
+    def test_string_true_variants(self):
+        """Test that string truthy values are recognized."""
+        assert PluginLoader._is_enabled({"enabled": "true"}) is True
+        assert PluginLoader._is_enabled({"enabled": "True"}) is True
+        assert PluginLoader._is_enabled({"enabled": "TRUE"}) is True
+        assert PluginLoader._is_enabled({"enabled": "1"}) is True
+        assert PluginLoader._is_enabled({"enabled": "yes"}) is True
+        assert PluginLoader._is_enabled({"enabled": "Yes"}) is True
+
+    def test_string_false_variants(self):
+        """Test that string falsy values are recognized."""
+        assert PluginLoader._is_enabled({"enabled": "false"}) is False
+        assert PluginLoader._is_enabled({"enabled": "False"}) is False
+        assert PluginLoader._is_enabled({"enabled": "FALSE"}) is False
+        assert PluginLoader._is_enabled({"enabled": "0"}) is False
+        assert PluginLoader._is_enabled({"enabled": "no"}) is False
+        assert PluginLoader._is_enabled({"enabled": ""}) is False


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

This PR makes it possible to activate the Langfuse plugin in the deployed Docker image:
- Installs the Langfuse plugin requirements
-  Exposes the Langfuse env variables to turn the plugin on and off and configure it.

Fixes #980 

## Impact

It's now possible to activate the Langfuse plugin in the Neuro SAN server Docker image.

## Screenshots / Logs / Examples (optional)

NA

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
