### PR TITLE
Fix connectivity converter not converting MCP tools correctly

### DIFF
--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -74,7 +74,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
             value: dict[str, Any] = {}
             self.copy_keys_not_found(connectivity_entry, value)
 
-            # Don't include agent that start with "/", "http://", or "https://" since those are external agents.
+            # Don't include agents starting with "/", "http://", or "https://" since those are external agents.
             if not UrlNetworkValidator.is_url_or_path(name):
                 result_dict[name] = value
 

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -22,6 +22,7 @@ from leaf_common.serialization.interface.dictionary_converter import DictionaryC
 # we are building agent networks.  This is not normally a recommended practice.
 from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.run_context.interfaces.agent_network_inspector import AgentNetworkInspector
+from neuro_san.internals.validation.network.url_network_validator import UrlNetworkValidator
 
 from coded_tools.agent_network_editor.designer_network_inspector import DesignerNetworkInspector
 
@@ -73,8 +74,8 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
             value: dict[str, Any] = {}
             self.copy_keys_not_found(connectivity_entry, value)
 
-            # Don't include agent that start with "/" since those are external agents.
-            if not name.startswith("/"):
+            # Don't include agent that start with "/", "http://", or "https://" since those are external agents.
+            if not UrlNetworkValidator.is_url_or_path(name):
                 result_dict[name] = value
 
         return result_dict


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

`ConnectivityDictionaryConverter.to_dict()` convert MCP tools incorrectly from `connectivity` to `AND` internal dictionary.

Fixes #982 

## Impact

<!-- Brief description of what the consequences of this PR are -->

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
