### PR TITLE
Set skip designer if validation fails

### DIFF
--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -34,6 +34,7 @@ from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
 from coded_tools.agent_network_editor.constants import MCP_SERVERS
 from coded_tools.agent_network_editor.get_subnetwork import GetSubnetwork
 from coded_tools.agent_network_query_generator.set_sample_queries import AGENT_NETWORK_QUERIES
+from middleware.agent_network_designer.agent_network_definition_middleware import SKIP_DESIGNER
 from middleware.agent_network_designer.persistence.agent_network_assembler import AgentNetworkAssembler
 from middleware.agent_network_designer.persistence.agent_network_persistor import AgentNetworkPersistor
 from middleware.agent_network_designer.persistence.agent_network_persistor_factory import AgentNetworkPersistorFactory
@@ -154,6 +155,12 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
 
     def _error_response(self, content: str) -> dict[str, Any]:
         """Return a jump-to-model response with the given error content."""
+        # Set the skip designer value to False to prevent infinite loop since jumping to model actually jump to the
+        # before model method in AgentNetworkDefinitionMiddleware, which jumps back to here if skip designer is True.
+        # This is also an indicator for client that there are issues with input agent_network_definition and that the
+        # designer has made changes to the definition.
+        if self.sly_data.get(SKIP_DESIGNER) is True:
+            self.sly_data[SKIP_DESIGNER] = False
         return {
             # Use human message to ensure that the model follows the instructions
             "messages": [HumanMessage(content)],


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

`AND` gets stuck in infinite loop since if we have skip_designer it will jump to persistence middleware, do validation which will jump back to the before model and repeat.

The solution is to change skip_designer from `True` to `False` if validation fails so when it jumps back to the before model the LLM can fix it.

Fixes #966 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
