### PR TITLE
Optimize agent network name handling in persistence middleware

### DIFF
--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -132,7 +132,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         # issues without being forced to produce a network definition — for example, when
         # AgentNetworkDefinitionMiddleware failed to load from a HOCON file or S3 reservation and
         # already reported the error (jumping to end), so no network definition will be present.
-        # A valid name is also required to avoid crashing in _normalize_network_name.
+        # A valid name is also required for file path and reservation name construction.
         if network_def and agent_network_name and isinstance(agent_network_name, str):
             error_list: list[str] = await self._validate_network(network_def)
             if error_list:
@@ -142,11 +142,9 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
                     "Please fix these issues to ensure the agent network can be properly assembled and executed."
                 )
 
-            the_agent_network_name: str = self._normalize_network_name(agent_network_name)
-            self.sly_data[AGENT_NETWORK_NAME] = the_agent_network_name
             sample_queries: list[str] = self.sly_data.get(AGENT_NETWORK_QUERIES, [])
 
-            await self._assemble_and_persist(network_def, the_agent_network_name, sample_queries)
+            await self._assemble_and_persist(network_def, agent_network_name, sample_queries)
             self._determine_exported_network_definition(self.sly_data)
 
             self.logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
@@ -177,28 +175,25 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         instructions_errors = await AgentNetworkInstructionsValidationMiddleware(self.sly_data).validate(network_def)
         return structure_errors + instructions_errors
 
-    def _normalize_network_name(self, name: str) -> str:
-        """Prepend SUBDIRECTORY prefix if not already present."""
-        prefix: str = SUBDIRECTORY.rstrip("/") + "/"
-        if not name.startswith(prefix):
-            # Neuro-SAN only allows '/' as path separator in agent network names.
-            return prefix + name
-        return name
-
     async def _assemble_and_persist(
         self,
         network_def: dict[str, Any],
-        the_agent_network_name: str,
+        agent_network_name: str,
         sample_queries: list[str],
     ) -> None:
         """
-        Assemble the agent network and persist it, then store HOCON text in sly_data.
+        Assemble the agent network, store HOCON text in sly_data, and persist it.
 
-        If WRITE_TO_FILE is True, the network is persisted by writing a HOCON file to disk.
-        Otherwise, it is registered as a temporary network via the reservationist interface.
+        HOCON content is always assembled first and stored in sly_data for client consumption.
+        If WRITE_TO_FILE is True, that same HOCON content is persisted to disk; the subdirectory
+        prefix is added by FileSystemAgentNetworkPersistor internally.
+        Otherwise, a deployable config is assembled and registered as a temporary network via
+        the reservationist interface using the sanitized raw name.
+
+        :param agent_network_name: The raw network name without any subdirectory prefix.
         """
-        self.logger.info(">>>>>>>>>>>>>>>>>>>Create Agent Network>>>>>>>>>>>>>>>>>>")
-        self.logger.info("Agent Network Name: %s", the_agent_network_name)
+        self.logger.info(">>>>>>>>>>>>>>>>>>>Assemble and Persist Agent Network>>>>>>>>>>>>>>>>>>")
+        self.logger.info("Agent Network Name: %s", agent_network_name)
 
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
         mcp_servers: list[str] = await GetMcpTool.get_mcp_servers(self.sly_data)
@@ -210,35 +205,34 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             subnetwork_names,
             mcp_servers,
         )
-        assembler: AgentNetworkAssembler = persistor.get_assembler()
         top_agent_name: str = UnreachableNodesNetworkValidator().find_all_top_agents(network_def).pop()
-        persisted_content: str = await assembler.assemble_agent_network(
-            network_def, top_agent_name, the_agent_network_name, sample_queries
-        )
-        self.logger.info("The resulting agent network: \n %s", persisted_content)
 
-        if WRITE_TO_FILE:
-            file_reference: str = the_agent_network_name
-        else:
-            # Reservations API forbids '/', ':', and ' ' — strip subdirectory prefix then sanitize
-            file_reference = the_agent_network_name.removeprefix(SUBDIRECTORY)
+        # Always assemble and store HOCON content for client consumption.
+        persisted_content: str = await HoconAgentNetworkAssembler(DEMO_MODE).assemble_agent_network(
+            network_def, top_agent_name, agent_network_name, sample_queries
+        )
+        self.logger.info("The resulting agent network content: \n %s", persisted_content)
+        self.sly_data[AGENT_NETWORK_HOCON_TEXT] = persisted_content
+
+        # Reservations API forbids '/', ':', and ' ' — sanitize the raw name for that case.
+        # FileSystemAgentNetworkPersistor handles its own subdirectory prefixing internally.
+        file_reference: str = agent_network_name
+        if not WRITE_TO_FILE:
             for char in ["/", ":", " "]:
                 file_reference = file_reference.replace(char, "")
-
+            # For reservations, assemble a deployable config instead of HOCON.
+            assembler: AgentNetworkAssembler = persistor.get_assembler()
+            # The persisted content for reservations is config.
+            persisted_content: dict[str | Any] = await assembler.assemble_agent_network(
+                network_def, top_agent_name, agent_network_name, sample_queries
+            )
+        # Persist the agent network
         persisted_reference: str | list[dict[str, Any]] = await persistor.async_persist(
             obj=persisted_content, file_reference=file_reference
         )
+        # Store information on reservations in the sly data
         if isinstance(persisted_reference, list):
             self.sly_data["agent_reservations"] = persisted_reference
-
-        if not isinstance(assembler, HoconAgentNetworkAssembler):
-            # We don't yet have client-consumable HOCON content, so we need to re-assemble
-            # to send that back as a parting gift.
-            assembler = HoconAgentNetworkAssembler(DEMO_MODE)
-            persisted_content = await assembler.assemble_agent_network(
-                network_def, top_agent_name, the_agent_network_name, sample_queries
-            )
-        self.sly_data[AGENT_NETWORK_HOCON_TEXT] = persisted_content
 
     def _determine_exported_network_definition(self, sly_data: dict[str, Any]):
         """

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -223,7 +223,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             # For reservations, assemble a deployable config instead of HOCON.
             assembler: AgentNetworkAssembler = persistor.get_assembler()
             # The persisted content for reservations is config.
-            persisted_content: dict[str | Any] = await assembler.assemble_agent_network(
+            persisted_content: dict[str, Any] = await assembler.assemble_agent_network(
                 network_def, top_agent_name, agent_network_name, sample_queries
             )
         # Persist the agent network

--- a/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
+++ b/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
@@ -14,8 +14,8 @@
 #
 # END COPYRIGHT
 
-# Import for asynchronous file operations
 import os
+from pathlib import Path
 
 import aiofiles
 from leaf_common.serialization.util.text_file_reader import TextFileReader
@@ -72,30 +72,32 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
         """
 
         the_agent_network_hocon_str: str = obj
-        # This agent network name already includes any subdirectory specified.
-        the_agent_network_name: str = file_reference
+        # Prepend subdirectory to form the full relative network path.
+        the_agent_network_name: str = f"{self.subdirectory}/{file_reference}"
 
-        # Write the agent network file
-        file_path: str = os.path.join(self.output_path, the_agent_network_name + ".hocon")
+        # Write the agent network file. Path() handles OS-specific separators: even though
+        # `the_agent_network_name` contains '/', pathlib recognizes it as an alt-separator on
+        # Windows and normalizes to '\' when the path is passed to the file system APIs.
+        file_path: Path = Path(self.output_path) / (the_agent_network_name + ".hocon")
         # Create parent directory automatically if necessary
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
         async with aiofiles.open(file_path, "w", encoding="utf-8", newline="\n") as file:
             await file.write(the_agent_network_hocon_str)
 
         # Update the manifest.hocon file
-        manifest_path: str = os.path.join(self.output_path, self.subdirectory, "manifest.hocon")
+        manifest_path: Path = Path(self.output_path) / self.subdirectory / "manifest.hocon"
 
         # Create the generated directory if it doesn't exist
-        os.makedirs(os.path.dirname(manifest_path), exist_ok=True)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Create the manifest file if it doesn't exist
-        if not os.path.exists(manifest_path):
+        if not manifest_path.exists():
             async with aiofiles.open(manifest_path, "w", encoding="utf-8", newline="\n") as file:
                 # Initialize with empty JSON format
                 await file.write("{\n}")
 
         # Read the current manifest content
-        manifest_content: str = await TextFileReader.async_read_text_file(manifest_path)
+        manifest_content: str = await TextFileReader.async_read_text_file(str(manifest_path))
 
         # Check if the entry already exists to avoid duplicates
         if (
@@ -133,7 +135,7 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
         if self.subdirectory != DEFAULT_SUBDIRECTORY:
             await self._async_update_main_manifest()
 
-        return file_path
+        return str(file_path)
 
     async def _async_update_main_manifest(self) -> None:
         """

--- a/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
+++ b/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
@@ -25,6 +25,8 @@ from middleware.agent_network_designer.persistence.agent_network_persistor impor
 from middleware.agent_network_designer.persistence.hocon_agent_network_assembler import HoconAgentNetworkAssembler
 
 DEFAULT_SUBDIRECTORY: str = "generated"
+DEFAULT_REGISTRIES_DIR: str = "registries"
+MANIFEST_FILENAME: str = "manifest.hocon"
 
 
 class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
@@ -39,9 +41,11 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
 
         :param demo_mode: Whether to include demo mode instructions for agents
         :param subdirectory: The subdirectory under output_path where networks are saved.
+                Leading and trailing slashes are stripped so callers can pass either
+                "generated" or "generated/" interchangeably.
         """
         self.demo_mode: bool = demo_mode
-        self.subdirectory: str = subdirectory
+        self.subdirectory: str = subdirectory.strip("/")
 
         # Derive output_path from the first file listed in AGENT_MANIFEST_FILE
         agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
@@ -50,8 +54,8 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
             self.output_path: str = os.path.dirname(parts[0])
             self.main_manifest_path: str = parts[0]
         else:
-            self.output_path = "registries"
-            self.main_manifest_path = os.path.join("registries", "manifest.hocon")
+            self.output_path = DEFAULT_REGISTRIES_DIR
+            self.main_manifest_path = os.path.join(DEFAULT_REGISTRIES_DIR, MANIFEST_FILENAME)
 
     def get_assembler(self) -> AgentNetworkAssembler:
         """
@@ -85,7 +89,7 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
             await file.write(the_agent_network_hocon_str)
 
         # Update the manifest.hocon file
-        manifest_path: Path = Path(self.output_path) / self.subdirectory / "manifest.hocon"
+        manifest_path: Path = Path(self.output_path) / self.subdirectory / MANIFEST_FILENAME
 
         # Create the generated directory if it doesn't exist
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -148,7 +152,7 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
         content: str = await TextFileReader.async_read_text_file(self.main_manifest_path)
 
         registries_name: str = os.path.basename(self.output_path)
-        include_line: str = f'include "{registries_name}/{self.subdirectory}/manifest.hocon",'
+        include_line: str = f'include "{registries_name}/{self.subdirectory}/{MANIFEST_FILENAME}",'
 
         if include_line in content:
             return None

--- a/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
+++ b/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
@@ -51,7 +51,7 @@ class TestFileSystemAgentNetworkPersistor:
             with open(manifest_path, "wb") as f:
                 f.write('{\n    "café_network.hocon": true,\n}\n'.encode("utf-8"))
 
-            asyncio.run(persistor.async_persist("agent = {}", "generated/new_net"))
+            asyncio.run(persistor.async_persist("agent = {}", "new_net"))
 
             with open(manifest_path, "rb") as f:
                 raw = f.read()
@@ -70,7 +70,7 @@ class TestFileSystemAgentNetworkPersistor:
             with open(manifest_path, "wb") as f:
                 f.write(b'{\n    "caf\xe9_network.hocon": true,\n}\n')
 
-            asyncio.run(persistor.async_persist("agent = {}", "generated/new_net"))
+            asyncio.run(persistor.async_persist("agent = {}", "new_net"))
 
             with open(manifest_path, "rb") as f:
                 content = f.read().decode("utf-8")
@@ -86,7 +86,7 @@ class TestFileSystemAgentNetworkPersistor:
             with open(manifest_path, "wb") as f:
                 f.write(b'{\n    "generated/existing.hocon": true,\n    "caf\xe9.hocon": true,\n}\n')
 
-            result = asyncio.run(persistor.async_persist("agent = {}", "generated/existing"))
+            result = asyncio.run(persistor.async_persist("agent = {}", "existing"))
 
             assert result is None
             with open(manifest_path, "rb") as f:
@@ -120,7 +120,7 @@ class TestFileSystemAgentNetworkPersistor:
             persistor = self._make_persistor(tmp_dir)
 
             hocon_content = 'description = "café network"\n'
-            asyncio.run(persistor.async_persist(hocon_content, "generated/test_net"))
+            asyncio.run(persistor.async_persist(hocon_content, "test_net"))
 
             file_path = os.path.join(tmp_dir, "generated", "test_net.hocon")
             with open(file_path, "rb") as f:
@@ -134,7 +134,7 @@ class TestFileSystemAgentNetworkPersistor:
             persistor = self._make_persistor(tmp_dir)
 
             hocon_content = "line1\nline2\nline3\n"
-            asyncio.run(persistor.async_persist(hocon_content, "generated/test_net"))
+            asyncio.run(persistor.async_persist(hocon_content, "test_net"))
 
             file_path = os.path.join(tmp_dir, "generated", "test_net.hocon")
             with open(file_path, "rb") as f:


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Previously, `agent_network_name` was prefixed with `SUBDIRECTORY` in `sly_data`, then stripped again for reservations. Now the raw name stays in `sly_data`, and `FileSystemAgentNetworkPersistor` adds the subdirectory prefix internally.

- Move subdirectory prefixing into `FileSystemAgentNetworkPersistor`
- Switch file path construction to `pathlib.Path` for Windows compatibility
- Restructure `_assemble_and_persist`: assemble HOCON first for `sly_data`, only assemble deployable config when persisting to reservations
- Remove redundant isinstance check on assembler in favor of `WRITE_TO_FILE`
- Remove unused `_normalize_network_name`

Fixes #970, #997 

## Impact

`agent_network_name` contains only the name of the agent network without the directory prefix

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
