### PR TITLE
Optimize _hocon_to_config for cross-OS path handling

### DIFF
--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -46,6 +46,7 @@ from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
 from coded_tools.agent_network_editor.progress_handler import ProgressHandler
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
+from middleware.agent_network_designer.persistence.file_system_agent_network_persistor import DEFAULT_REGISTRIES_DIR
 
 AGENT_NETWORK_HOCON_FILE: str = "agent_network_hocon_file"
 AGENT_RESERVATIONS: str = "agent_reservations"
@@ -204,7 +205,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                 ">>>>>>>>>>>>>>>>>>>Reading & Parsing from Agent Network HOCON File '%s'>>>>>>>>>>>>>>>>>>>",
                 hocon_file,
             )
-            network_def = await self._hocon_to_definition(hocon_file, self.sly_data)
+            network_def = await self._hocon_to_definition(hocon_file)
             # When loading from hocon, use the file name (without extension) as the agent network name.
             # This is because the agent network name is only created when using the CreateNetwork tool.
             if network_def:
@@ -318,7 +319,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             reservation_id,
             os.getenv("AGENT_RESERVATIONS_S3_BUCKET"),
         )
-        return await self._config_to_network_def(config, reservation_id, self.sly_data)
+        return await self._config_to_network_def(config, reservation_id)
 
     def _normalize_network_def(self, network_def: dict[str, Any] | list[dict[str, Any]]) -> dict[str, Any]:
         """
@@ -382,29 +383,38 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         definition_str: str = json.dumps(network_def, indent=2)
         return f"## Current Agent Network Definition\n\n```json\n{definition_str}\n```"
 
-    async def _hocon_to_definition(
-        self, network_hocon_file: str | None, sly_data: dict[str, Any]
-    ) -> dict[str, Any] | None:
+    async def _hocon_to_definition(self, network_hocon_file: str | None) -> dict[str, Any] | None:
         """
         Convert hocon file path into agent network definition
         :param network_hocon_file: Agent network hocon file path
-        :param sly_data: A dictionary whose keys are defined by the agent hierarchy
 
         :return: Agent network definition
         """
         config: dict[str, Any] | None = await self._hocon_to_config(network_hocon_file)
         if config is None:
             return None
-        return await self._config_to_network_def(config, network_hocon_file, sly_data)
+        return await self._config_to_network_def(config, network_hocon_file)
 
-    async def _hocon_to_config(self, network_hocon_file: str | None) -> dict[str, Any] | None:
+    def _resolve_hocon_path(self, network_hocon_file: str | None) -> str | None:
         """
-        Read and parse a HOCON file into a raw config dictionary.
+        Validate and resolve a user-supplied HOCON file reference into a concrete path string.
 
-        :param network_hocon_file: Agent network hocon file path
-        :return: Parsed HOCON contents as a dict, or None if network_hocon_file is invalid or not found
+        Path resolution:
+          - Absolute paths are used as-is.
+          - Relative paths are resolved against the directory of the first entry in
+            ``AGENT_MANIFEST_FILE`` (a whitespace-separated list of manifest files), or
+            ``DEFAULT_REGISTRIES_DIR`` when the env var is empty or unset. This mirrors
+            ``FileSystemAgentNetworkPersistor`` so loads and saves agree on file location.
+
+        Backslashes in the input are normalized to forward slashes so Windows-style paths
+        work on POSIX (and vice versa).
+
+        On invalid input, sets ``self.error_message`` and returns None.
+
+        :param network_hocon_file: Agent network hocon file path (absolute or relative)
+        :return: The resolved file reference as a forward-slash path string, or None if invalid
         """
-        if not isinstance(network_hocon_file, str) or not network_hocon_file:
+        if not isinstance(network_hocon_file, str) or not network_hocon_file.strip():
             error_message: str = (
                 f"Error: Invalid network_hocon_file value: {type(network_hocon_file).__name__} "
                 "(expected non-empty string)."
@@ -413,25 +423,58 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             self.error_message = error_message
             return None
 
+        # Normalize backslashes so Windows-style input also works on POSIX.
+        normalized: str = network_hocon_file.strip().replace("\\", "/")
+        candidate: Path = Path(normalized)
+        if candidate.is_absolute():
+            return candidate.as_posix()
+
+        # Derive the base registries directory from AGENT_MANIFEST_FILE (the dirname of the
+        # first listed manifest), falling back to the default registries directory.
+        agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
+        manifest_parts: list[str] = agent_manifest_file.split()
+        base_dir: str = os.path.dirname(manifest_parts[0]) if manifest_parts else DEFAULT_REGISTRIES_DIR
+        # Strip leading separators so a user-supplied "/foo.hocon" does not silently
+        # bypass base_dir. On POSIX such input would already be caught by is_absolute()
+        # above; on Windows it is "drive-rooted" rather than absolute, so without this
+        # lstrip Path() would discard base_dir when joining.
+        return (Path(base_dir) / normalized.lstrip("/")).as_posix()
+
+    async def _hocon_to_config(self, network_hocon_file: str | None) -> dict[str, Any] | None:
+        """
+        Read and parse a HOCON file into a raw config dictionary.
+
+        :param network_hocon_file: Agent network hocon file path (absolute or relative);
+                see ``_resolve_hocon_path`` for resolution rules
+        :return: Parsed HOCON contents as a dict, or None if network_hocon_file is invalid or not found
+        """
+        file_reference: str | None = self._resolve_hocon_path(network_hocon_file)
+        if file_reference is None:
+            return None
+
         # Note we don't need to cache this because we only expect to read the file once.
         try:
             hocon = AbstractAsyncConfigRestorer(file_purpose="get_agent_network_definition", must_exist=True)
-            return await hocon.async_restore(file_reference="registries/" + network_hocon_file)
+            return await hocon.async_restore(file_reference=file_reference)
         except FileNotFoundError:
-            error_message = f"Error: Agent network HOCON file not found: registries/{network_hocon_file}"
+            error_message: str = f"Error: Agent network HOCON file not found: {file_reference}"
+            self.logger.error(error_message)
+            self.error_message = error_message
+            return None
+        except OSError as os_error:
+            # Catches PermissionError, IsADirectoryError, and other OS-level read failures
+            # whose specific subclasses differ across operating systems.
+            error_message = f"Error: Failed to read agent network HOCON file '{file_reference}'. {os_error}"
             self.logger.error(error_message)
             self.error_message = error_message
             return None
 
-    async def _config_to_network_def(
-        self, config: dict[str, Any], source: str, sly_data: dict[str, Any]
-    ) -> dict[str, Any] | None:
+    async def _config_to_network_def(self, config: dict[str, Any], source: str) -> dict[str, Any] | None:
         """
         Convert a parsed HOCON config dictionary into an agent network definition.
 
         :param config: Parsed HOCON config
         :param source: Identifier for the config source (hocon file path or reservation ID), used for error messages
-        :param sly_data: A dictionary whose keys are defined by the agent hierarchy
         :return: Agent network definition, or None on failure
         """
         agents: list[dict[str, Any]] | None = config.get("tools")
@@ -444,21 +487,18 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
         network_def: dict[str, Any] = {}
         for agent in agents:
-            name, agent_def = await self._parse_agent(agent, source, sly_data)
+            name, agent_def = await self._parse_agent(agent, source)
             if name is not None:
                 network_def[name] = agent_def
 
         return network_def
 
-    async def _parse_agent(
-        self, agent: Any, source: str, sly_data: dict[str, Any]
-    ) -> tuple[str | None, dict[str, Any]]:
+    async def _parse_agent(self, agent: Any, source: str) -> tuple[str | None, dict[str, Any]]:
         """
         Parse a single agent entry from the hocon 'tools' list.
 
         :param agent: A single entry from the 'tools' list in the hocon file
         :param source: Identifier for the config source (hocon file path or reservation ID), used for warning messages
-        :param sly_data: A dictionary whose keys are defined by the agent hierarchy
 
         :return: (agent_name, agent_def) where agent_name is None if the entry should be skipped
         """
@@ -486,7 +526,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             if instructions.strip():
                 # Extract only the unique instructions
                 # (remove aaosa instructions, instructions prefix, and demo mode)
-                agent_def["instructions"] = await self._extract_custom_instructions(instructions.strip(), sly_data)
+                agent_def["instructions"] = await self._extract_custom_instructions(instructions.strip())
 
             # Initialize description for non-function agents so the description setter
             # can distinguish them from function/toolbox agents (which have no description key).
@@ -511,11 +551,10 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
         return agent_name, agent_def
 
-    async def _extract_custom_instructions(self, instructions: str, sly_data: dict[str, Any]) -> str:
+    async def _extract_custom_instructions(self, instructions: str) -> str:
         """
         Extract the custom part of instructions, excluding aaosa instructions, instructions prefix, and demo mode.
         :param instructions: The full instructions of an agent.
-        :param sly_data: A dictionary whose keys are defined by the agent hierarchy
 
         :return: The part of instructions that is unique to the agent.
         """
@@ -532,7 +571,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             "you are actually grounded in real data or you are operating a real application API or microservice."
         )
 
-        aaosa_instructions: str = await self._get_aaosa_instructions(sly_data)
+        aaosa_instructions: str = await self._get_aaosa_instructions()
 
         # Clean and normalize the input
         custom_part: str = instructions.strip()
@@ -552,18 +591,17 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
         return custom_part
 
-    async def _get_aaosa_instructions(self, sly_data: dict[str, Any]) -> str:
+    async def _get_aaosa_instructions(self) -> str:
         """
         Get aaosa instructions potentially from cache in sly_data
-        :param sly_data: A dictionary whose keys are defined by the agent hierarchy
 
         :return: aaosa instructions
         """
         aaosa_instructions: str = ""
 
         # Try to get aaosa_instructions from sly_data cache
-        async with await SlyDataLock.get_lock(sly_data, "aaosa_instructions_lock"):
-            aaosa_instructions = sly_data.get("aaosa_instructions")
+        async with await SlyDataLock.get_lock(self.sly_data, "aaosa_instructions_lock"):
+            aaosa_instructions = self.sly_data.get("aaosa_instructions")
             if aaosa_instructions is not None:
                 # Return early with cached value
                 return aaosa_instructions
@@ -580,7 +618,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                 aaosa_instructions = ""
 
             # Cache the loaded value in sly_data for subsequent calls
-            sly_data["aaosa_instructions"] = aaosa_instructions
+            self.sly_data["aaosa_instructions"] = aaosa_instructions
 
         return aaosa_instructions
 

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -427,7 +427,13 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         # Normalize backslashes so Windows-style input also works on POSIX.
         normalized: str = network_hocon_file.strip().replace("\\", "/")
         candidate: Path = Path(normalized)
-        if candidate.is_absolute():
+        # Treat as absolute only if pathlib agrees AND, on Windows, the path has a drive
+        # letter (e.g. "C:/...") or a UNC anchor (e.g. "//server/share/..."). On Windows
+        # a bare "/foo" is "drive-rooted": Python 3.13+ reports is_absolute() == True for
+        # it, but the path is ambiguous without a drive, so we fall through to the
+        # relative branch where the leading slash is stripped — preventing the input
+        # from bypassing base_dir.
+        if candidate.is_absolute() and (os.name != "nt" or candidate.drive):
             return candidate.as_posix()
 
         # Derive the base registries directory from AGENT_MANIFEST_FILE (the dirname of the
@@ -435,10 +441,10 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
         manifest_parts: list[str] = agent_manifest_file.split()
         base_dir: str = os.path.dirname(manifest_parts[0]) if manifest_parts else DEFAULT_REGISTRIES_DIR
-        # Strip leading separators so a user-supplied "/foo.hocon" does not silently
-        # bypass base_dir. On POSIX such input would already be caught by is_absolute()
-        # above; on Windows it is "drive-rooted" rather than absolute, so without this
-        # lstrip Path() would discard base_dir when joining.
+        # Strip leading separators so a user-supplied "/foo.hocon" cannot escape base_dir.
+        # POSIX absolute paths are handled above; this catches the Windows drive-rooted
+        # case where Path() would otherwise discard base_dir when joining with a rooted
+        # right-hand side.
         return (Path(base_dir) / normalized.lstrip("/")).as_posix()
 
     async def _hocon_to_config(self, network_hocon_file: str | None) -> dict[str, Any] | None:

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -400,19 +400,23 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         """
         Validate and resolve a user-supplied HOCON file reference into a concrete path string.
 
-        Path resolution:
-          - Absolute paths are used as-is.
-          - Relative paths are resolved against the directory of the first entry in
-            ``AGENT_MANIFEST_FILE`` (a whitespace-separated list of manifest files), or
-            ``DEFAULT_REGISTRIES_DIR`` when the env var is empty or unset. This mirrors
-            ``FileSystemAgentNetworkPersistor`` so loads and saves agree on file location.
+        Resolution order:
+          1. Absolute paths (POSIX-rooted, or Windows with drive/UNC anchor) are used as-is.
+          2. Paths relative to cwd (typically the repo root) — if the input resolves to an
+             existing file under cwd, it is used as-is. This covers paths copied from the
+             repo tree such as "registries/generated/foo.hocon".
+          3. Otherwise, paths are resolved against ``base_dir`` — the directory of the
+             first entry in ``AGENT_MANIFEST_FILE`` (a whitespace-separated list of
+             manifest files), or ``DEFAULT_REGISTRIES_DIR`` when the env var is empty or
+             unset. This mirrors ``FileSystemAgentNetworkPersistor`` so loads and saves
+             agree on file location.
 
         Backslashes in the input are normalized to forward slashes so Windows-style paths
         work on POSIX (and vice versa).
 
         On invalid input, sets ``self.error_message`` and returns None.
 
-        :param network_hocon_file: Agent network hocon file path (absolute or relative)
+        :param network_hocon_file: Agent network hocon file path
         :return: The resolved file reference as a forward-slash path string, or None if invalid
         """
         if not isinstance(network_hocon_file, str) or not network_hocon_file.strip():
@@ -436,16 +440,25 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         if candidate.is_absolute() and (os.name != "nt" or candidate.drive):
             return candidate.as_posix()
 
+        # Strip leading separators so a user-supplied "/foo.hocon" cannot escape base_dir.
+        # POSIX absolute paths are handled above; this catches the Windows drive-rooted
+        # case where Path() would otherwise discard base_dir when joining with a rooted
+        # right-hand side.
+        trimmed_input: str = normalized.lstrip("/")
+
+        # If the input resolves to an existing file relative to cwd (typically the repo
+        # root when running the server from the project directory), use it as-is. This
+        # covers any repo-root-relative path, including "registries/generated/foo.hocon"
+        # or files outside the registries folder.
+        if Path(trimmed_input).is_file():
+            return trimmed_input
+
         # Derive the base registries directory from AGENT_MANIFEST_FILE (the dirname of the
         # first listed manifest), falling back to the default registries directory.
         agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
         manifest_parts: list[str] = agent_manifest_file.split()
         base_dir: str = os.path.dirname(manifest_parts[0]) if manifest_parts else DEFAULT_REGISTRIES_DIR
-        # Strip leading separators so a user-supplied "/foo.hocon" cannot escape base_dir.
-        # POSIX absolute paths are handled above; this catches the Windows drive-rooted
-        # case where Path() would otherwise discard base_dir when joining with a rooted
-        # right-hand side.
-        return (Path(base_dir) / normalized.lstrip("/")).as_posix()
+        return (Path(base_dir) / trimmed_input).as_posix()
 
     async def _hocon_to_config(self, network_hocon_file: str | None) -> dict[str, Any] | None:
         """

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -40,6 +40,7 @@ from langchain_core.messages import SystemMessage
 from neuro_san.interfaces.agent_progress_reporter import AgentProgressReporter
 from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
 from neuro_san.service.watcher.temp_networks.s3_reservations_storage import S3ReservationsStorage
+from pyparsing.exceptions import ParseException
 
 from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
@@ -442,11 +443,15 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
     async def _hocon_to_config(self, network_hocon_file: str | None) -> dict[str, Any] | None:
         """
-        Read and parse a HOCON file into a raw config dictionary.
+        Read and parse an agent network config file into a raw config dictionary.
 
-        :param network_hocon_file: Agent network hocon file path (absolute or relative);
+        ``AbstractAsyncConfigRestorer`` accepts both ``.hocon`` and ``.json`` files, so JSON
+        inputs work as well even though the surrounding API is named for HOCON.
+
+        :param network_hocon_file: Agent network config file path (absolute or relative);
                 see ``_resolve_hocon_path`` for resolution rules
-        :return: Parsed HOCON contents as a dict, or None if network_hocon_file is invalid or not found
+        :return: Parsed config contents as a dict, or None if the file is invalid, has an
+                unsupported extension, fails to parse, or cannot be read
         """
         file_reference: str | None = self._resolve_hocon_path(network_hocon_file)
         if file_reference is None:
@@ -457,14 +462,27 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             hocon = AbstractAsyncConfigRestorer(file_purpose="get_agent_network_definition", must_exist=True)
             return await hocon.async_restore(file_reference=file_reference)
         except FileNotFoundError:
-            error_message: str = f"Error: Agent network HOCON file not found: {file_reference}"
+            error_message: str = f"Error: Agent network config file not found: {file_reference}"
             self.logger.error(error_message)
             self.error_message = error_message
             return None
         except OSError as os_error:
             # Catches PermissionError, IsADirectoryError, and other OS-level read failures
             # whose specific subclasses differ across operating systems.
-            error_message = f"Error: Failed to read agent network HOCON file '{file_reference}'. {os_error}"
+            error_message = f"Error: Failed to read agent network config file '{file_reference}'. {os_error}"
+            self.logger.error(error_message)
+            self.error_message = error_message
+            return None
+        except ValueError as value_error:
+            # Raised by AbstractAsyncConfigRestorer when the file extension is not .hocon or .json.
+            error_message = f"Error: Unsupported agent network config file '{file_reference}'. {value_error}"
+            self.logger.error(error_message)
+            self.error_message = error_message
+            return None
+        except ParseException as parse_error:
+            # AbstractAsyncConfigRestorer wraps HOCON/JSON parse failures (ParseException,
+            # ParseSyntaxException, JSONDecodeError, ConfigException) into ParseException.
+            error_message = f"Error: Failed to parse agent network config file '{file_reference}'. {parse_error}"
             self.logger.error(error_message)
             self.error_message = error_message
             return None

--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -75,7 +75,10 @@
                         },
                         "agent_network_hocon_file": {
                             "type": "string",
-                            "description": "The file name (with .hocon extension) of an agent network HOCON file located in the registries folder. This is for users who want to provide the full agent network definition in HOCON format as input."
+                            "description": """
+The path of an agent network HOCON file (with .hocon extension). Use an absolute path, or a path relative to the registries folder — the directory of the first file in the AGENT_MANIFEST_FILE env var,
+falling back to 'registries' in the repo root. This is for users who want to provide the full agent network definition in HOCON format as input.
+"""
                         },
                         "agent_network_name": {
                             "type": "string",

--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -76,8 +76,10 @@
                         "agent_network_hocon_file": {
                             "type": "string",
                             "description": """
-The path of an agent network HOCON file (with .hocon extension). Use an absolute path, or a path relative to the registries folder — the directory of the first file in the AGENT_MANIFEST_FILE env var,
-falling back to 'registries' in the repo root. This is for users who want to provide the full agent network definition in HOCON format as input.
+The path of an agent network config file. HOCON (.hocon) is preferred — hence the field name — but JSON (.json) is also accepted. Accepted in order:
+(1) an absolute path; (2) a path relative to the current working directory (typically the repo root, e.g. 'registries/generated/foo.hocon');
+(3) a path relative to the registries folder — the directory of the first file in the AGENT_MANIFEST_FILE env var, falling back to 'registries' in the repo root.
+This is for users who want to provide the full agent network definition as input.
 """
                         },
                         "agent_network_name": {


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

- Resolution order is now:

1. Absolute (POSIX-rooted, or Windows with drive/UNC) → as-is.
2. Cwd-relative — if Path(trimmed_input).is_file() returns True, use as-is. Covers "registries/generated/foo.hocon", but also anything else that happens to live under cwd (test fixtures, alternate dirs, etc.).
3. Registries-relative — env-derived from AGENT_MANIFEST_FILE or default "registries".

- Normalize backslashes so Windows-style input works on POSIX, and only treat a path as absolute when pathlib agrees and, on Windows, a drive letter or UNC anchor is present — so a bare "/foo.hocon" on Windows (reported as absolute by Python 3.13+ pathlib but actually drive-rooted without a drive) is correctly routed through the relative branch where a leading-slash strip prevents it from escaping base_dir.

- Split path resolution into `_resolve_hocon_path` so it can be reasoned about and tested without async/file-system mocks. Update the schema description in `agent_network_designer.hocon` to reflect that absolute paths and the env-var-derived base directory are now supported.

- Drop the redundant `sly_data` parameter from `_hocon_to_definition`, `_config_to_network_def`, `_parse_agent`, `_extract_custom_instructions`, and `_get_aaosa_instructions` — every caller passed `self.sly_data`, so read the instance attribute directly.

Fixes #999 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
