### PR TITLE
AND: Speed up external agent/subnetwork-name lookup

### DIFF
--- a/coded_tools/agent_network_editor/constants.py
+++ b/coded_tools/agent_network_editor/constants.py
@@ -14,10 +14,28 @@
 #
 # END COPYRIGHT
 
-# Common dictionary key constants. These key may be used by the agent network designer.
+# Common sly_data dictionary key constants used by the agent network designer.
+
+# Agent network structure — dict mapping agent name to its definition (instructions, description, tools),
+# or the connectivity-list form used by the native Neuro-San representation.
 AGENT_NETWORK_DEFINITION: str = "agent_network_definition"
+
+# Assembled HOCON file content of the agent network, produced for client consumption.
 AGENT_NETWORK_HOCON_TEXT: str = "agent_network_hocon_text"
+
+# Name of the agent network, used as the persistence file path or reservation identifier.
 AGENT_NETWORK_NAME: str = "agent_network_name"
+
+# Cached list of MCP server URLs available to the designer.
 MCP_SERVERS: str = "mcp_servers"
+
+# Cached list of external agent / subnetwork names (each in "/<name>" form). Populated by a lightweight
+# manifest-only parse so validators can check tool references without loading each subnetwork's full HOCON.
+SUBNETWORK_NAMES: str = "subnetwork_names"
+
+# Cached dict mapping external agent / subnetwork name to its front-man's description. Used when the editor needs to
+# surface available subnetworks (with descriptions) to the LLM.
 SUBNETWORKS: str = "subnetworks"
+
+# Cached dict mapping toolbox tool name to its description.
 TOOLBOX_INFO: str = "toolbox_info"

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -23,10 +23,10 @@ from neuro_san.interfaces.coded_tool import CodedTool
 from neuro_san.internals.graph.persistence.agent_filetree_mapper import AgentFileTreeMapper
 from neuro_san.internals.graph.persistence.manifest_dict_config_filter import ManifestDictConfigFilter
 from neuro_san.internals.graph.persistence.manifest_key_config_filter import ManifestKeyConfigFilter
+from neuro_san.internals.graph.persistence.raw_manifest_restorer import RawManifestRestorer
 from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
 from neuro_san.internals.graph.persistence.served_manifest_config_filter import ServedManifestConfigFilter
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
-from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
 from pyparsing.exceptions import ParseException
 
 from coded_tools.agent_network_editor.constants import SUBNETWORK_NAMES
@@ -72,18 +72,20 @@ class GetSubnetwork(CodedTool):
             logger.info(">>>>>>>>>>>>>>>>>>>Getting Subnetwork Names from Manifest>>>>>>>>>>>>>>>>>>>")
             logger.info("Manifest file: %s", manifest_file)
 
-            # Parse the manifest HOCON directly. pyhocon resolves `include` statements,
-            # so composed manifests (e.g. manifest_and.hocon) flatten into a single
-            # mapping of "path/to/file.hocon" -> enabled-bool-or-dict entries.
+            # Parse the manifest HOCON. pyhocon resolves `include` statements, so composed manifests
+            # (e.g. manifest_and.hocon) flatten into a single mapping of
+            # "path/to/file.hocon" -> enabled-bool-or-dict entries. RawManifestRestorer returns None
+            # if the file is missing — treated as an empty manifest (no subnetworks available).
             names: list[str] = []
             try:
-                # We use AbstractAsyncConfigRestorer rather than RawManifestRestorer (the neuro-san subclass
-                # used internally to read manifests) because RawManifestRestorer hardcodes must_exist=False
-                # and file_purpose="agent network manifest". With must_exist=True we get an explicit
-                # FileNotFoundError on a missing file (caught below) plus an informative error message;
-                # the custom file_purpose makes those messages reflect this caller.
-                restorer = AbstractAsyncConfigRestorer(file_purpose="get_subnetwork_names", must_exist=True)
-                raw_manifest: dict[str, Any] = await restorer.async_restore(file_reference=manifest_file)
+                raw_manifest: dict[str, Any] = await RawManifestRestorer().async_restore(file_reference=manifest_file)
+                if raw_manifest is None:
+                    logger.warning(
+                        "Manifest file '%s' not found, no external agents/subnetworks will be available "
+                        "in the generated network",
+                        manifest_file,
+                    )
+                    raw_manifest = {}
 
                 # Use neuro-san's canonical manifest filters so we don't reimplement manifest semantics:
                 #   - ManifestKeyConfigFilter:    strips quote chars from quoted HOCON keys
@@ -108,12 +110,6 @@ class GetSubnetwork(CodedTool):
                     agent_filepath: str = agent_mapper.agent_name_to_filepath(manifest_key)
                     network_name: str = agent_mapper.filepath_to_agent_network_name(agent_filepath)
                     names.append(f"/{network_name}")
-            except FileNotFoundError as file_error:
-                logger.warning(
-                    "Manifest file not found, no external agents/subnetworks will be available "
-                    "in the generated network: %s",
-                    file_error,
-                )
             except ParseException as parse_error:
                 logger.warning(
                     "Failed to parse manifest '%s', no subnetwork names will be available: %s",

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -18,8 +18,13 @@ import logging
 import os
 from typing import Any
 
+from leaf_common.config.config_filter_chain import ConfigFilterChain
 from neuro_san.interfaces.coded_tool import CodedTool
+from neuro_san.internals.graph.persistence.agent_filetree_mapper import AgentFileTreeMapper
+from neuro_san.internals.graph.persistence.manifest_dict_config_filter import ManifestDictConfigFilter
+from neuro_san.internals.graph.persistence.manifest_key_config_filter import ManifestKeyConfigFilter
 from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
+from neuro_san.internals.graph.persistence.served_manifest_config_filter import ServedManifestConfigFilter
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
 from pyparsing.exceptions import ParseException
@@ -57,6 +62,11 @@ class GetSubnetwork(CodedTool):
             if SUBNETWORK_NAMES in sly_data:
                 return sly_data.get(SUBNETWORK_NAMES)
 
+            # We use a designer-specific env var (rather than AGENT_MANIFEST_FILE) so the designer's
+            # subnetwork pool can be a narrow, curated subset of what the server hosts — e.g. only
+            # industry/ + generated/ networks, not basic/, tools/, experimental/, or the
+            # designer-family agents themselves. Default points at manifest_and.hocon which composes
+            # just those two via `include`.
             manifest_file: str = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE") or DEFAULT_MANIFEST_FILE
 
             logger.info(">>>>>>>>>>>>>>>>>>>Getting Subnetwork Names from Manifest>>>>>>>>>>>>>>>>>>>")
@@ -64,8 +74,7 @@ class GetSubnetwork(CodedTool):
 
             # Parse the manifest HOCON directly. pyhocon resolves `include` statements,
             # so composed manifests (e.g. manifest_and.hocon) flatten into a single
-            # mapping of "path/to/file.hocon" -> enabled-bool entries. Only enabled
-            # entries are exposed, matching the semantics used elsewhere.
+            # mapping of "path/to/file.hocon" -> enabled-bool-or-dict entries.
             names: list[str] = []
             try:
                 # We use AbstractAsyncConfigRestorer rather than RawManifestRestorer (the neuro-san subclass
@@ -74,20 +83,31 @@ class GetSubnetwork(CodedTool):
                 # FileNotFoundError on a missing file (caught below) plus an informative error message;
                 # the custom file_purpose makes those messages reflect this caller.
                 restorer = AbstractAsyncConfigRestorer(file_purpose="get_subnetwork_names", must_exist=True)
-                manifest: dict[str, Any] = await restorer.async_restore(file_reference=manifest_file)
-                for agent_name, enabled in manifest.items():
-                    # Manifest entries are either `path: true/false` or `path: { "serve": true, ... }`.
-                    # Both forms are documented; the dict form is the canonical one used post-filter
-                    # by RegistryManifestRestorer.
-                    if enabled is True or (isinstance(enabled, dict) and enabled.get("serve") is True):
-                        # External network names follow neuro-san's convention of "/<network_name>",
-                        # where network_name is the manifest path without its file extension
-                        # (matching AgentFileTreeMapper.filepath_to_agent_network_name).
-                        # pyhocon keeps the literal quote characters in dict keys when the original
-                        # HOCON key was quoted — and manifest keys are always quoted because they
-                        # contain "/" — so we strip those quote chars before deriving the name.
-                        clean_name: str = agent_name.replace('"', "").removesuffix(".hocon").removesuffix(".json")
-                        names.append("/" + clean_name)
+                raw_manifest: dict[str, Any] = await restorer.async_restore(file_reference=manifest_file)
+
+                # Use neuro-san's canonical manifest filters so we don't reimplement manifest semantics:
+                #   - ManifestKeyConfigFilter:    strips quote chars from quoted HOCON keys
+                #   - ManifestDictConfigFilter:   normalizes bool values to {"serve": ..., ...}
+                #   - ServedManifestConfigFilter: drops non-served entries
+                # We assemble our own chain rather than using ManifestFilterChain because the latter
+                # registers ServedManifestConfigFilter with warn_on_skip=True/entry_for_skipped=True,
+                # which would log a warning per disabled entry and keep them in the result. Here we
+                # want unserved entries silently dropped.
+                filter_chain = ConfigFilterChain()
+                filter_chain.register(ManifestKeyConfigFilter(manifest_file))
+                filter_chain.register(ManifestDictConfigFilter(manifest_file))
+                filter_chain.register(
+                    ServedManifestConfigFilter(manifest_file, warn_on_skip=False, entry_for_skipped=False)
+                )
+                one_manifest: dict[str, Any] = filter_chain.filter_config(raw_manifest)
+
+                # Derive external network names ("/<network_name>") via the canonical mapper used by
+                # neuro-san (matches RegistryManifestRestorer.find_external_network_names).
+                agent_mapper = AgentFileTreeMapper()
+                for manifest_key in one_manifest.keys():
+                    agent_filepath: str = agent_mapper.agent_name_to_filepath(manifest_key)
+                    network_name: str = agent_mapper.filepath_to_agent_network_name(agent_filepath)
+                    names.append(f"/{network_name}")
             except FileNotFoundError as file_error:
                 logger.warning(
                     "Manifest file not found, no external agents/subnetworks will be available "
@@ -124,7 +144,11 @@ class GetSubnetwork(CodedTool):
                 # Exit early, including for an explicitly cached empty mapping
                 return sly_data.get(SUBNETWORKS)
 
-            # Check manifest file from env var. Use a default if no value provided.
+            # We use a designer-specific env var (rather than AGENT_MANIFEST_FILE) so the designer's
+            # subnetwork pool can be a narrow, curated subset of what the server hosts — e.g. only
+            # industry/ + generated/ networks, not basic/, tools/, experimental/, or the
+            # designer-family agents themselves. Default points at manifest_and.hocon which composes
+            # just those two via `include`.
             manifest_file: str = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE") or DEFAULT_MANIFEST_FILE
 
             empty: dict[str, AgentNetwork] = {}

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -21,7 +21,10 @@ from typing import Any
 from neuro_san.interfaces.coded_tool import CodedTool
 from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
+from pyparsing.exceptions import ParseException
 
+from coded_tools.agent_network_editor.constants import SUBNETWORK_NAMES
 from coded_tools.agent_network_editor.constants import SUBNETWORKS
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
@@ -37,14 +40,66 @@ class GetSubnetwork(CodedTool):
     @staticmethod
     async def get_subnetwork_names(sly_data: dict[str, Any]) -> list[str]:
         """
-        Get the list of subnetwork names, loading from the manifest file via
-        get_subnetworks() if not already cached on sly_data.
+        Get the list of subnetwork names. Reads only the manifest HOCON file rather
+        than each individual subnetwork's HOCON, since callers only need names
+        (no descriptions). Results are cached in sly_data.
 
         :param sly_data: The sly_data dictionary from the agent hierarchy.
         :return: List of subnetwork name strings, or empty list if none / on error.
         """
-        subnetworks = await GetSubnetwork.get_subnetworks(sly_data)
-        return list(subnetworks.keys())
+        # If the full subnetwork dict was already loaded by get_subnetworks(),
+        # reuse its keys instead of re-reading the manifest.
+        if SUBNETWORKS in sly_data:
+            return list(sly_data[SUBNETWORKS].keys())
+
+        async with await SlyDataLock.get_lock(sly_data, "subnetwork_names_lock"):
+            # Re-check caches after acquiring the lock.
+            if SUBNETWORK_NAMES in sly_data:
+                return sly_data.get(SUBNETWORK_NAMES)
+
+            manifest_file: str = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE") or DEFAULT_MANIFEST_FILE
+
+            logger.info(">>>>>>>>>>>>>>>>>>>Getting Subnetwork Names from Manifest>>>>>>>>>>>>>>>>>>>")
+            logger.info("Manifest file: %s", manifest_file)
+
+            # Parse the manifest HOCON directly. pyhocon resolves `include` statements,
+            # so composed manifests (e.g. manifest_and.hocon) flatten into a single
+            # mapping of "path/to/file.hocon" -> enabled-bool entries. Only enabled
+            # entries are exposed, matching the semantics used elsewhere.
+            names: list[str] = []
+            try:
+                restorer = AbstractAsyncConfigRestorer(file_purpose="get_subnetwork_names", must_exist=True)
+                manifest: dict[str, Any] = await restorer.async_restore(file_reference=manifest_file)
+                for agent_name, enabled in manifest.items():
+                    # Manifest entries are either `path: true/false` or `path: { "serve": true, ... }`.
+                    # Both forms are documented; the dict form is the canonical one used post-filter
+                    # by RegistryManifestRestorer.
+                    if enabled is True or (isinstance(enabled, dict) and enabled.get("serve") is True):
+                        # External network names follow neuro-san's convention of "/<network_name>",
+                        # where network_name is the manifest path without its file extension
+                        # (matching AgentFileTreeMapper.filepath_to_agent_network_name).
+                        # pyhocon keeps the literal quote characters in dict keys when the original
+                        # HOCON key was quoted — and manifest keys are always quoted because they
+                        # contain "/" — so we strip those quote chars before deriving the name.
+                        clean_name: str = agent_name.replace('"', "").removesuffix(".hocon").removesuffix(".json")
+                        names.append("/" + clean_name)
+            except FileNotFoundError as file_error:
+                logger.warning(
+                    "Manifest file not found, no external agents/subnetworks will be available "
+                    "in the generated network: %s",
+                    file_error
+                )
+            except ParseException as parse_error:
+                logger.warning(
+                    "Failed to parse manifest '%s', no subnetwork names will be available: %s",
+                    manifest_file,
+                    parse_error,
+                )
+
+            # Cache whatever we found, including an empty list on failure, to avoid reloading.
+            sly_data[SUBNETWORK_NAMES] = names
+
+        return names
 
     # pylint: disable=too-many-locals
     @staticmethod
@@ -64,11 +119,8 @@ class GetSubnetwork(CodedTool):
                 # Exit early, including for an explicitly cached empty mapping
                 return sly_data.get(SUBNETWORKS)
 
-            # Check manifest file from env var
-            manifest_file: str | list[str] = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE")
-            if not manifest_file:
-                # Use a default if no value provided
-                manifest_file = DEFAULT_MANIFEST_FILE
+            # Check manifest file from env var. Use a default if no value provided.
+            manifest_file: str = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE") or DEFAULT_MANIFEST_FILE
 
             empty: dict[str, AgentNetwork] = {}
             networks: dict[str, AgentNetwork] = {}
@@ -94,8 +146,12 @@ class GetSubnetwork(CodedTool):
                     if desc is not None and len(desc) > 0:
                         subnetworks["/" + name] = desc
 
-            except FileNotFoundError:
-                logger.warning("Error: Failed to load agent networks info from %s.", manifest_file)
+            except FileNotFoundError as file_error:
+                logger.warning(
+                    "Manifest file not found, no external agents/subnetworks will be available "
+                    "in the generated network: %s",
+                    file_error
+                )
 
             # Cache whatever we found, including an empty mapping on failure, to avoid reloading.
             sly_data[SUBNETWORKS] = subnetworks

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -87,7 +87,7 @@ class GetSubnetwork(CodedTool):
                 logger.warning(
                     "Manifest file not found, no external agents/subnetworks will be available "
                     "in the generated network: %s",
-                    file_error
+                    file_error,
                 )
             except ParseException as parse_error:
                 logger.warning(
@@ -150,7 +150,7 @@ class GetSubnetwork(CodedTool):
                 logger.warning(
                     "Manifest file not found, no external agents/subnetworks will be available "
                     "in the generated network: %s",
-                    file_error
+                    file_error,
                 )
 
             # Cache whatever we found, including an empty mapping on failure, to avoid reloading.

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -68,6 +68,11 @@ class GetSubnetwork(CodedTool):
             # entries are exposed, matching the semantics used elsewhere.
             names: list[str] = []
             try:
+                # We use AbstractAsyncConfigRestorer rather than RawManifestRestorer (the neuro-san subclass
+                # used internally to read manifests) because RawManifestRestorer hardcodes must_exist=False
+                # and file_purpose="agent network manifest". With must_exist=True we get an explicit
+                # FileNotFoundError on a missing file (caught below) plus an informative error message;
+                # the custom file_purpose makes those messages reflect this caller.
                 restorer = AbstractAsyncConfigRestorer(file_purpose="get_subnetwork_names", must_exist=True)
                 manifest: dict[str, Any] = await restorer.async_restore(file_reference=manifest_file)
                 for agent_name, enabled in manifest.items():


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

- `get_subnetwork_names` now parses only the manifest and derives names from it, reusing neuro-san's own building blocks rather than reimplementing manifest semantics:

    - `RawManifestRestorer` reads the manifest HOCON (missing file → None → warn + treat as empty pool).
    - `ConfigFilterChain` assembled from `ManifestKeyConfigFilter` + `ManifestDictConfigFilter` + `ServedManifestConfigFilter` handles quote-stripping, `bool→dict` normalization, and serve-key filtering. (assemble the chain ourselves rather than using `ManifestFilterChain` because its default `ServedManifestConfigFilter(warn_on_skip=True, entry_for_skipped=True)` would log a warning per disabled entry and keep them in the result; want unserved entries silently dropped.)
    - `AgentFileTreeMapper.filepath_to_agent_network_name` derives canonical /<network_name> strings, matching `RegistryManifestRestorer.find_external_network_names`.
   
- Results are cached under a new `subnetwork_names` sly_data key. The existing `subnetworks` cache (populated by `get_subnetworks()`) is still honored — if descriptions were already loaded, `get_subnetwork_names()` short-circuits to its keys.

- Cuts skip-designer latency by ~1.2s on a local server.

- Clarify `constants.py` comments and tighten the warning messages in `get_subnetwork.py` .

Fixes #1013 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
