### PR TITLE
#991 Use timedinput to avoid hanging the process forever when prompting users

### DIFF
--- a/neuro_san_studio/commands/init.py
+++ b/neuro_san_studio/commands/init.py
@@ -24,6 +24,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from timedinput import timedinput
+
 PROVIDERS: Dict[str, Dict[str, str]] = {
     "openai": {"label": "OpenAI", "model_name": "gpt-5.2"},
     "anthropic": {"label": "Anthropic", "model_name": "claude-sonnet"},
@@ -31,6 +33,10 @@ PROVIDERS: Dict[str, Dict[str, str]] = {
 }
 
 TEMPLATES_PACKAGE = "neuro_san_studio.templates"
+
+# Long enough to never bite a real user; finite so timedinput is happy and so a
+# detached terminal can't hang the process forever.
+INPUT_TIMEOUT_SECONDS = 300
 
 
 class InitCommand:  # pylint: disable=too-few-public-methods
@@ -94,7 +100,11 @@ class InitCommand:  # pylint: disable=too-few-public-methods
             info = PROVIDERS[key]
             default_tag = "  [default]" if key == "openai" else ""
             print(f"  {idx}) {info['label']:<14} ({info['model_name']}){default_tag}")
-        raw = input("Enter numbers separated by commas (default: 1): ").strip()
+        raw = timedinput(
+            "Enter numbers separated by commas (default: 1): ",
+            timeout=INPUT_TIMEOUT_SECONDS,
+            default="1",
+        ).strip()
         if not raw:
             return ["openai"]
         selected: List[str] = []

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -28,10 +28,15 @@ from typing import Dict
 from typing import Tuple
 
 from dotenv import load_dotenv
+from timedinput import timedinput
 
 from neuro_san_studio.interfaces.process_logger_interface import ProcessLoggerInterface
 from neuro_san_studio.plugins.plugin_loader import PluginLoader
 from neuro_san_studio.runner.simple_process_logger import SimpleProcessLogger
+
+# Long enough to never bite a real user; finite so timedinput is happy and so a
+# detached terminal can't hang the process forever.
+INPUT_TIMEOUT_SECONDS = 300
 
 
 class NeuroSanRunner:
@@ -484,7 +489,7 @@ class NeuroSanRunner:
         valid_no = {"no", "n"}
         for attempt in range(max_attempts):
             try:
-                raw = input(prompt).strip().lower()
+                raw = timedinput(prompt, timeout=INPUT_TIMEOUT_SECONDS, default="").strip().lower()
             except EOFError:
                 print("No input available. Considering the answer is 'no'.")
                 return False

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -489,6 +489,8 @@ class NeuroSanRunner:
         valid_no = {"no", "n"}
         for attempt in range(max_attempts):
             try:
+                # Default to "" (empty), which is an invalid input that triggers the prompt again
+                # if there are remaining attempts or gives up otherwise with a 'no'.
                 raw = timedinput(prompt, timeout=INPUT_TIMEOUT_SECONDS, default="").strip().lower()
             except EOFError:
                 print("No input available. Considering the answer is 'no'.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,7 @@ pyvis~=0.3.2
 
 # For web search tools without needing API keys, using DuckDuckGo's search results
 ddgs>=9.4.1
+
+# For chat-based cli tools not used in deployment
+# Also used by neuro-san
+timedinput>=0.1.1

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -16,7 +16,6 @@
 
 """Tests for the `neuro-san-studio init` command."""
 
-import builtins
 import os
 import sys
 from pathlib import Path
@@ -24,6 +23,7 @@ from pathlib import Path
 import pytest
 from pytest import MonkeyPatch
 
+from neuro_san_studio.commands import init as init_module
 from neuro_san_studio.commands.init import InitCommand
 
 
@@ -142,7 +142,7 @@ class TestRunFlow:
     def test_run_interactive_multi_select(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """Interactive mode should parse numbered input into the right providers."""
         monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
-        monkeypatch.setattr(builtins, "input", lambda _prompt="": "1,2")
+        monkeypatch.setattr(init_module, "timedinput", lambda *_a, **_kw: "1,2")
         InitCommand(providers_arg=None, root_dir=str(tmp_path)).run()
         llm_config = (tmp_path / "config" / "llm_config.hocon").read_text()
         assert '"fallbacks"' in llm_config
@@ -152,7 +152,7 @@ class TestRunFlow:
     def test_run_interactive_empty_input_defaults_to_openai(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """Pressing enter at the prompt should accept the default (OpenAI)."""
         monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
-        monkeypatch.setattr(builtins, "input", lambda _prompt="": "")
+        monkeypatch.setattr(init_module, "timedinput", lambda *_a, **_kw: "")
         InitCommand(providers_arg=None, root_dir=str(tmp_path)).run()
         llm_config = (tmp_path / "config" / "llm_config.hocon").read_text()
         assert '"model_name": "gpt-5.2"' in llm_config

--- a/tests/neuro_san_studio/commands/test_run.py
+++ b/tests/neuro_san_studio/commands/test_run.py
@@ -16,12 +16,12 @@
 
 """Tests for NeuroSanRunner."""
 
-import builtins
 import os
 import sys
 from collections.abc import Callable
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pytest import CaptureFixture
@@ -42,13 +42,13 @@ class TestNeuroSanRunner:
         return NeuroSanRunner.__new__(NeuroSanRunner)
 
     @staticmethod
-    def _scripted_input(responses: Iterable[str]) -> Callable[[str], str]:
-        """Return a replacement for input() that pops successive responses."""
+    def _scripted_input(responses: Iterable[str]) -> Callable[..., str]:
+        """Return a replacement for timedinput() that pops successive responses."""
         queue: list[str] = list(responses)
 
-        def _input(_prompt: str) -> str:
+        def _input(_prompt: str = "", **_kwargs: Any) -> str:
             if not queue:
-                raise AssertionError("input() called more times than scripted responses")
+                raise AssertionError("timedinput() called more times than scripted responses")
             return queue.pop(0)
 
         return _input
@@ -58,32 +58,32 @@ class TestNeuroSanRunner:
     @pytest.mark.parametrize("response", ["yes", "y", "YES", "Y", "Yes", "  y  "])
     def test_returns_true_for_affirmative(self, monkeypatch: MonkeyPatch, response: str) -> None:
         """Test that any affirmative variant (case/whitespace) returns True."""
-        monkeypatch.setattr(builtins, "input", self._scripted_input([response]))
+        monkeypatch.setattr(run_module, "timedinput", self._scripted_input([response]))
         assert self._make_runner()._validate_yes_no_input("prompt: ") is True
 
     @pytest.mark.parametrize("response", ["no", "n", "NO", "N", "No", "  n  "])
     def test_returns_false_for_negative(self, monkeypatch: MonkeyPatch, response: str) -> None:
         """Test that any negative variant (case/whitespace) returns False."""
-        monkeypatch.setattr(builtins, "input", self._scripted_input([response]))
+        monkeypatch.setattr(run_module, "timedinput", self._scripted_input([response]))
         assert self._make_runner()._validate_yes_no_input("prompt: ") is False
 
     def test_reprompts_then_accepts_valid(self, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]) -> None:
         """Test that invalid input triggers a re-prompt before a valid one succeeds."""
-        monkeypatch.setattr(builtins, "input", self._scripted_input(["maybe", "y"]))
+        monkeypatch.setattr(run_module, "timedinput", self._scripted_input(["maybe", "y"]))
         assert self._make_runner()._validate_yes_no_input("prompt: ") is True
         captured = capsys.readouterr()
         assert "Invalid input" in captured.out
 
     def test_returns_false_after_max_attempts(self, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]) -> None:
         """Test that exhausting all attempts with invalid input returns False."""
-        monkeypatch.setattr(builtins, "input", self._scripted_input(["a", "b", "c"]))
+        monkeypatch.setattr(run_module, "timedinput", self._scripted_input(["a", "b", "c"]))
         assert self._make_runner()._validate_yes_no_input("prompt: ") is False
         captured = capsys.readouterr()
         assert "Too many invalid responses." in captured.out
 
     def test_respects_custom_max_attempts(self, monkeypatch: MonkeyPatch) -> None:
         """Test that max_attempts controls the number of allowed retries."""
-        monkeypatch.setattr(builtins, "input", self._scripted_input(["bad", "yes"]))
+        monkeypatch.setattr(run_module, "timedinput", self._scripted_input(["bad", "yes"]))
         assert self._make_runner()._validate_yes_no_input("prompt: ", max_attempts=2) is True
 
     def test_toolbox_env_var_takes_precedence(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
@@ -167,14 +167,14 @@ class TestNeuroSanRunner:
         assert os.environ["AGENT_TOOLBOX_INFO_FILE"] == "/explicit/path/toolbox.hocon"
 
     def test_passes_prompt_to_input(self, monkeypatch: MonkeyPatch) -> None:
-        """Test that the supplied prompt string is forwarded to input()."""
+        """Test that the supplied prompt string is forwarded to timedinput()."""
         seen_prompts: list[str] = []
 
-        def _capturing_input(prompt: str) -> str:
+        def _capturing_input(prompt: str = "", **_kwargs: Any) -> str:
             seen_prompts.append(prompt)
             return "y"
 
-        monkeypatch.setattr(builtins, "input", _capturing_input)
+        monkeypatch.setattr(run_module, "timedinput", _capturing_input)
         self._make_runner()._validate_yes_no_input("Kill processes? ")
         assert seen_prompts == ["Kill processes? "]
 


### PR DESCRIPTION
…

<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Used a timed input when prompting users, to avoid blocking indefinitely.

Fixes #991

## Impact

When running run.py, if a server is already running the user is prompted with a "do you want to kill it?" question. It used to block forever. The new behavior is to reprompt after 5 mins, and again after another 5 mins, and if no answer we give up and terminate the process. That avoid having processes hanging forever.

Side effect: it will probably also silence the Checkmarx false positive about unvalidated inputs.

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [X] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
