### PR TITLE
Allow PYTHONPATH to not be completely overriden in run.py

### DIFF
--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -219,6 +219,7 @@ class NeuroSanRunner:
         existing: str = os.environ.get("PYTHONPATH", "")
 
         # Check to see if the root_dir is already in PYTHONPATH. If so, don't add it again.
+        # This block below was suggested by Copilot.
         normalized_root_dir = os.path.normcase(os.path.abspath(self.root_dir))
         existing_paths = [path for path in existing.split(os.pathsep) if path]
         if any(
@@ -227,6 +228,7 @@ class NeuroSanRunner:
         ):
             return
 
+        # Add the root_dir to PYTHONPATH differently depending on existing value
         new_path: str = self.root_dir
         if existing:
             new_path = existing + os.pathsep + self.root_dir

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -217,9 +217,10 @@ class NeuroSanRunner:
         Sets the PYTHONPATH environment variable to include the project root directory.
         """
         existing: str = os.environ.get("PYTHONPATH", "")
+
+        # Check to see if the root_dir is already in PYTHONPATH. If so, don't add it again.
         normalized_root_dir = os.path.normcase(os.path.abspath(self.root_dir))
         existing_paths = [path for path in existing.split(os.pathsep) if path]
-
         if any(
             os.path.normcase(os.path.abspath(path)) == normalized_root_dir
             for path in existing_paths

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -216,11 +216,17 @@ class NeuroSanRunner:
         """
         Sets the PYTHONPATH environment variable to include the project root directory.
         """
-        if self.root_dir in os.environ.get("PYTHONPATH", ""):
+        existing: str = os.environ.get("PYTHONPATH", "")
+        normalized_root_dir = os.path.normcase(os.path.abspath(self.root_dir))
+        existing_paths = [path for path in existing.split(os.pathsep) if path]
+
+        if any(
+            os.path.normcase(os.path.abspath(path)) == normalized_root_dir
+            for path in existing_paths
+        ):
             return
 
         new_path: str = self.root_dir
-        existing: str = os.environ.get("PYTHONPATH", "")
         if existing:
             new_path = existing + os.pathsep + self.root_dir
         os.environ["PYTHONPATH"] = new_path

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -217,7 +217,12 @@ class NeuroSanRunner:
         print("\n" + "=" * 50 + "\n")
         print("Setting environment variables...\n")
         # Common env variables
-        os.environ["PYTHONPATH"] = self.root_dir
+        if self.root_dir not in os.environ.get("PYTHONPATH", ""):
+            if os.environ.get("PYTHONPATH", ""):
+                os.environ["PYTHONPATH"] += os.pathsep
+                os.environ["PYTHONPATH"] += self.root_dir
+            else:
+                os.environ["PYTHONPATH"] = self.root_dir
         os.environ["AGENT_MANIFEST_FILE"] = self.args["agent_manifest_file"]
         os.environ["AGENT_TOOL_PATH"] = self.args["agent_tool_path"]
         self._apply_toolbox_env()

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -222,10 +222,7 @@ class NeuroSanRunner:
         # This block below was suggested by Copilot.
         normalized_root_dir = os.path.normcase(os.path.abspath(self.root_dir))
         existing_paths = [path for path in existing.split(os.pathsep) if path]
-        if any(
-            os.path.normcase(os.path.abspath(path)) == normalized_root_dir
-            for path in existing_paths
-        ):
+        if any(os.path.normcase(os.path.abspath(path)) == normalized_root_dir for path in existing_paths):
             return
 
         # Add the root_dir to PYTHONPATH differently depending on existing value

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -212,17 +212,25 @@ class NeuroSanRunner:
 
         return vars(args)
 
+    def set_pythonpath(self):
+        """
+        Sets the PYTHONPATH environment variable to include the project root directory.
+        """
+        if self.root_dir in os.environ.get("PYTHONPATH", ""):
+            return
+
+        new_path: str = self.root_dir
+        existing: str = os.environ.get("PYTHONPATH", "")
+        if existing:
+            new_path = existing + os.pathsep + self.root_dir
+        os.environ["PYTHONPATH"] = new_path
+
     def set_environment_variables(self):
         """Set required environment variables, optionally using neuro-san defaults."""
         print("\n" + "=" * 50 + "\n")
         print("Setting environment variables...\n")
         # Common env variables
-        if self.root_dir not in os.environ.get("PYTHONPATH", ""):
-            if os.environ.get("PYTHONPATH", ""):
-                os.environ["PYTHONPATH"] += os.pathsep
-                os.environ["PYTHONPATH"] += self.root_dir
-            else:
-                os.environ["PYTHONPATH"] = self.root_dir
+        self.set_pythonpath()
         os.environ["AGENT_MANIFEST_FILE"] = self.args["agent_manifest_file"]
         os.environ["AGENT_TOOL_PATH"] = self.args["agent_tool_path"]
         self._apply_toolbox_env()


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

When PYTHONPATH was already set, the studio run command would override other dependencies in there.
Now we add to the PYTHONPATH if the root_dir is not already in there.

Fixes # <!-- Issue number, if applicable -->

## Impact

<!-- Brief description of what the consequences of this PR are -->

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [X] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
