### PR TITLE
Disable persistent_memory_local in multiuser overlay

### DIFF
--- a/registries/manifest_multiuser_overlay.hocon
+++ b/registries/manifest_multiuser_overlay.hocon
@@ -46,6 +46,7 @@
     "tools/agent_network_html_creator.hocon": false,    # Reason #3
     "tools/agentforce.hocon": false,                    # Reason #2
     "tools/openai_image_generation.hocon": false,       # Reason #1
+    "tools/persistent_memory_local.hocon": false,       # Reason #1
 
     # Experimental and research
     "agent_network_designer.hocon": true,               # Reason #1. Needs AGENT_NETWORK_DESIGNER_USE_RESERVATIONS=true

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -132,7 +132,7 @@
     # File system-backed long-term memory tool (per-agent): CRUD + keyword search.
     # Supports two backends: JSON or Markdown.
     # See ``docs/examples/tools/persistent_memory_local.md`` for a usage example.
-    "tools/persistent_memory_local.hocon": true,
+    "tools/persistent_memory_local.hocon": false,
 
     # Cloud-backed long-term memory tool using the Mem0 API; per-user scoping via ``sly_data["user_id"]``.
     # Requirement to use this Mem0 based agent network:

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -132,7 +132,7 @@
     # File system-backed long-term memory tool (per-agent): CRUD + keyword search.
     # Supports two backends: JSON or Markdown.
     # See ``docs/examples/tools/persistent_memory_local.md`` for a usage example.
-    "tools/persistent_memory_local.hocon": false,
+    "tools/persistent_memory_local.hocon": true,
 
     # Cloud-backed long-term memory tool using the Mem0 API; per-user scoping via ``sly_data["user_id"]``.
     # Requirement to use this Mem0 based agent network:


### PR DESCRIPTION
## Description

Disable `tools/persistent_memory_local.hocon` in `manifest_multiuser_overlay.hocon` (Reason #1 — knowledge or modification of the server's local filesystem).

## Impact

The `persistent_memory_local` agent network will not be served in multi-user deployments.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**