### PR TITLE
Run tools-is-list check first in structure validation

### DIFF
--- a/middleware/agent_network_designer/validation/agent_network_instructions_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_instructions_validation_middleware.py
@@ -58,7 +58,10 @@ class AgentNetworkInstructionsValidationMiddleware(AgentNetworkValidationMiddlew
                 description: str = agent_copy.pop("description")
                 agent_copy["function"] = {"description": description}
             use_network_def[agent_name] = agent_copy
-        return KeywordNetworkValidator().validate(use_network_def)
+        # Only check that "instructions" and "description" fields are present and non-empty.
+        # We do not check if "tools" field is a list of str here since that is related to structure validation and
+        # this agent network has no tools to fix this issue.
+        return KeywordNetworkValidator(keywords=["instructions", "description"]).validate(use_network_def)
 
     def format_error(self, error_list: list[str]) -> str:
         """

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -56,6 +56,15 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
         :return: A list of error strings (empty if valid)
         """
 
+        # Check that "tools" field is a list of str first since if it is not,
+        # the other validators will fail and raise an error.
+        # Note that the keywords argument restricts the check to specific keywords.
+        # Available keywords are "description", "instructions", and "tools".
+        # If keywords is not provided, all keywords will be checked.
+        tool_not_list_error: list[str] = KeywordNetworkValidator(keywords=["tools"]).validate(network_def)
+        if tool_not_list_error:
+            return tool_not_list_error
+
         # Get infos from sly_data. These should have been put there by the respective tools
         # from the agent network editor.
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
@@ -66,11 +75,6 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
             StructureNetworkValidator().validate(network_def)
             + ToolboxNetworkValidator(toolbox_tools).validate(network_def)
             + UrlNetworkValidator(subnetwork_names, mcp_servers).validate(network_def)
-            # Check that "tools" field is a list of str.
-            # Note that keywords argument is for check specific keywords.
-            # Available keywords are "description", "instructions", and "tools".
-            # If keywords is not provided, all keywords will be checked.
-            + KeywordNetworkValidator(keywords=["tools"]).validate(network_def)
         )
 
     def format_error(self, error_list: list[str]) -> str:


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Gate `StructureNetworkValidator`, `ToolboxNetworkValidator`, and `UrlNetworkValidator` behind a `KeywordNetworkValidator` check on the `"tools"` field. When an agent's `"tools"` is a string instead of a list, the downstream validators crash with `"can only concatenate str (not "list") to str"` before producing a usable error. Early-returning with the keyword error surfaces the actionable message and routes the fix to `agent_network_editor`.

Also scope the instructions validator to `["instructions", "description"]` so tools-shape errors are not misrouted to `agent_network_instructions_editor`, which cannot fix structural issues.

Fixes #1051

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
