### PR TITLE
#1056 Fix cruse demo app and sanitize system names

### DIFF
--- a/apps/cruse/cruse_assistant.py
+++ b/apps/cruse/cruse_assistant.py
@@ -20,7 +20,7 @@ from neuro_san.client.agent_session_factory import AgentSessionFactory
 from neuro_san.client.streaming_input_processor import StreamingInputProcessor
 from pyhocon import ConfigFactory
 
-AGENT_NETWORK_NAME = "cruse_agent"
+AGENT_NETWORK_NAME = "experimental/cruse_agent"
 
 
 def set_up_cruse_assistant(selected_agent):

--- a/apps/cruse/cruse_assistant.py
+++ b/apps/cruse/cruse_assistant.py
@@ -18,7 +18,8 @@ import os
 
 from neuro_san.client.agent_session_factory import AgentSessionFactory
 from neuro_san.client.streaming_input_processor import StreamingInputProcessor
-from pyhocon import ConfigFactory
+from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
+from neuro_san.internals.interfaces.storage_class import StorageClass
 
 AGENT_NETWORK_NAME = "experimental/cruse_agent"
 
@@ -99,20 +100,26 @@ def tear_down_cruse_assistant(cruse_session):
 
 def get_available_systems():
     """
-    Parses the HOCON manifest file specified by the AGENT_MANIFEST_FILE environment variable
-    and returns a list of enabled system keys.
+    Return the list of public agent networks from the manifest.
 
-    Systems explicitly listed in the `excluded` set will be omitted, even if enabled.
+    Uses neuro-san's RegistryManifestRestorer so HOCON `include` directives
+    (e.g. `include "registries/basic/manifest.hocon"`) are resolved -- the
+    prior implementation called `ConfigFactory.parse_file()` directly and
+    silently dropped every nested entry.
 
     Returns:
-        List[str]: A list of enabled HOCON filenames (without surrounding quotes)
-                   that are not in the excluded set.
+        List[str]: Enabled, public agent network keys with a `.hocon` suffix
+                   (e.g. `basic/coffee_finder.hocon`), excluding anything in
+                   the local `excluded` set.
     """
     excluded = {"experimental/cruse_agent.hocon"}  # Add more filenames as needed
-    config = ConfigFactory.parse_file(os.environ["AGENT_MANIFEST_FILE"])
-    return [
-        key.strip('"').strip() for key, enabled in config.items() if enabled and key.strip('"').strip() not in excluded
-    ]
+
+    manifest_file = os.environ["AGENT_MANIFEST_FILE"]
+    restorer = RegistryManifestRestorer()
+    all_networks = restorer.restore_from_files([manifest_file])
+    public_networks = all_networks.get(StorageClass.PUBLIC, {})
+
+    return [f"{name}.hocon" for name in public_networks if f"{name}.hocon" not in excluded]
 
 
 def parse_response_blocks(response: str):

--- a/apps/cruse/templates/index.html
+++ b/apps/cruse/templates/index.html
@@ -183,21 +183,25 @@ END COPYRIGHT
                     select.innerHTML = ''; // Clear any existing items
 
                     const HOCON_NAME = /^[\w.\- ]+\.hocon$/; // allowlist
+                    const sanitize = (value) => DOMPurify.sanitize(String(value), {
+                        ALLOWED_TAGS: [],
+                        ALLOWED_ATTR: [],
+                    });
+
                     systems.forEach((system, index) => {
-                        system = String(system);
-                        if (!HOCON_NAME.test(system)) {
-                          console.warn('Skipping unexpected system name:', system);
-                          return;
+                        if (typeof system !== 'string' || !HOCON_NAME.test(system)) {
+                            console.warn('Skipping unexpected system name:', system);
+                            return;
                         }
-                        const option = document.createElement('option');
-                        option.value = system;
-                        option.textContent = system.replace('.hocon', '');
+                        const safeValue = sanitize(system);
+                        const safeLabel = sanitize(system.replace('.hocon', ''));
+                        const option = new Option(safeLabel, safeValue);
                         select.appendChild(option);
 
                         // Select the first item by default
                         if (index === 0) {
                             option.selected = true;
-                            selectedSystem = system;
+                            selectedSystem = safeValue;
                         }
                     });
 

--- a/apps/cruse/templates/index.html
+++ b/apps/cruse/templates/index.html
@@ -182,7 +182,9 @@ END COPYRIGHT
                     const select = document.getElementById('system-select');
                     select.innerHTML = ''; // Clear any existing items
 
-                    const HOCON_NAME = /^[\w.\- ]+\.hocon$/; // allowlist
+                    // Allow slashed paths like experimental/mdap_decomposer.hocon
+                    // but reject .. (path traversal) and leading / (absolute paths).
+                    const HOCON_NAME = /^(?!.*\.\.)[\w\- ]+(?:\/[\w\- ]+)*\.hocon$/;
                     const sanitize = (value) => DOMPurify.sanitize(String(value), {
                         ALLOWED_TAGS: [],
                         ALLOWED_ATTR: [],


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

- Fixed path to cruse_agent.hocon
- Used `RegistryManifestRestorer` to load manifest files
- Added a DOMPurify.sanitize helper (DOMPurify was already loaded at line 27)
- Tightened the type guard to typeof system !== 'string'
- And switched the option construction to new Option(safeLabel, safeValue). This breaks the taint flow Checkmarx tracks from the AJAX source to appendChild.

Fixes #1056 and #1059

## Impact

The cruse demo app works again:
```
python -m apps.cruse.interface_flask
```

## Screenshots / Logs / Examples (optional)

<img width="758" height="225" alt="image" src="https://github.com/user-attachments/assets/b004beba-f9d1-4030-8dad-86e10064ef00" />

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
