### PR TITLE
Use 'logs' as default log dir

### DIFF
--- a/neuro_san_studio/plugins/log_bridge/process_log_bridge_plugin.py
+++ b/neuro_san_studio/plugins/log_bridge/process_log_bridge_plugin.py
@@ -38,7 +38,7 @@ class ProcessLogBridgePlugin(BasePlugin, ProcessLoggerInterface):
         :param args (dict | None): Optional configuration for the logging bridge.
         """
         super().__init__("ProcessLogBridgePlugin", args)
-        self.log_file = os.path.join(self.args.get("logs_dir", "."), "runner.log")
+        self.log_file = os.path.join(self.args.get("logs_dir", "logs"), "runner.log")
         self.log_bridge = ProcessLogBridge(
             level=self.args.get("log_level", "info"),
             runner_log_file=self.log_file,


### PR DESCRIPTION
## Description

Fixes residual `runner.log` files appearing in project root directory instead of only in `logs/` directory.
Root cause: `NeuroSanServerWrapper` instantiates plugins with empty args, causing `ProcessLogBridgePlugin` to use
default `logs_dir` of `"."` (current directory).

Fixes #1060

## Impact
- All future `runner.log` files (including TimedRotatingFileHandler dated backups) will be created in `logs/` directory only

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
