### PR TITLE
Use lychee-ignored URL prefix in max-length test

### DIFF
--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_url.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_url.py
@@ -81,7 +81,7 @@ class TestValidateUrl(TestCase):
 
     def test_url_at_max_length_is_accepted(self):
         """Tests that a URL exactly at the maximum allowed length is accepted."""
-        prefix = "https://x.co/"
+        prefix = "https://test.co/"
         url = prefix + "a" * (MAX_URL_LENGTH - len(prefix))
         self.assertEqual(self._call({"url": url}), url)
 


### PR DESCRIPTION
## Description

The `test_url_at_max_length_is_accepted` test constructs a 250-character URL using the prefix `https://x.co/`. Lychee picks this up as a real link and tries to resolve it, causing CI failures.

This changes the prefix to `https://test.co/` which is covered by the existing `https://test` entry in `.lycheeignore`.

## Impact

Fixes the lychee CI failure while preserving identical test semantics (still constructs a URL at exactly `MAX_URL_LENGTH`).

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**