### PR TITLE
Use config/llm_config.hocon in memory HOCONs

### DIFF
--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -157,12 +157,13 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
 
 def main() -> None:
     """Entry point for the `neuro-san-studio` console script."""
-    # Typer/click exit with SystemExit(0) on success; let clean exits return normally
-    # so main() can be driven from tests and embedded callers.
+    # Typer/click exit with SystemExit(0) on success and SystemExit(2) for
+    # no-args-is-help; let clean exits return normally so main() can be
+    # driven from tests and embedded callers.
     try:
         NeuroSanStudioCli.app()
     except SystemExit as exc:
-        if exc.code not in (None, 0):
+        if exc.code not in (None, 0, 2):
             raise
 
 

--- a/registries/tools/persistent_memory_local.hocon
+++ b/registries/tools/persistent_memory_local.hocon
@@ -48,7 +48,7 @@
 # enable it by adding the ``summarization`` block below.
 
 {
-    include "registries/llm_config.hocon",
+    include "config/llm_config.hocon",
 
     "metadata": {
         "description": "Remembers facts you share (preferences, role, personal details) and recalls them in later conversations.",

--- a/registries/tools/persistent_memory_mem0.hocon
+++ b/registries/tools/persistent_memory_mem0.hocon
@@ -54,7 +54,7 @@
 # is off by default; enable it by adding the ``summarization`` block below.
 
 {
-    include "registries/llm_config.hocon",
+    include "config/llm_config.hocon",
 
     "metadata": {
         "description": "Cloud-backed long-term memory (Mem0). Remembers facts you share across sessions and scopes them per user.",


### PR DESCRIPTION
## Description

Two fixes:

1. **HOCON config path:** The `persistent_memory_local` and `persistent_memory_mem0` agent networks use `include "registries/llm_config.hocon"` instead of `include "config/llm_config.hocon"`. This breaks these tools in a new project setup because `ns init` only creates `config/llm_config.hocon`. All other HOCON files already use the correct path.

2. **Typer no-args help exit code:** Typer 0.26.x raises `SystemExit(2)` via `NoArgsIsHelpError` when `no_args_is_help=True` and no arguments are given. `main()` only swallowed `SystemExit(0)`, so bare `neuro-san-studio` raised instead of printing help and returning cleanly.

Fixes #1070

## Impact

- New project setups using `ns init` can now use `persistent_memory_local` and `persistent_memory_mem0` without the deprecated `registries/llm_config.hocon` shim.
- `test_main_with_no_args_shows_help` passes again with Typer 0.26.x.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/8c15377424494a759898667a493b9fcd
Requested by: @shrushtiimehta