### PR TITLE
Enable hadolint in quality gate lint override

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,11 @@ jobs:
         set -e
         VIRTUAL_ENV=system make lint-check
         curl --silent --location \
+          https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 \
+          --output /tmp/hadolint
+        chmod +x /tmp/hadolint
+        /tmp/hadolint deploy/Dockerfile
+        curl --silent --location \
           https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.1/lychee-x86_64-unknown-linux-gnu.tar.gz \
           | tar --extract --gzip --directory /tmp --strip-components=1
         # To prevent flaky CI failures, accept:


### PR DESCRIPTION
## Description

Adds hadolint v2.12.0 to the `lint-command-override` in the Test workflow. This downloads the hadolint binary and runs it against `deploy/Dockerfile` as part of the CI quality gate.

The quality gate's `run-hadolint` input is gated behind `lint-command-override` being empty, so hadolint is invoked directly within the override script instead.

## Impact

CI will now lint `deploy/Dockerfile` with hadolint on every push and PR. No functional change to the application.

## Type of Change

- [x] Refactoring / Improvement

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation

Link to Devin session: https://app.devin.ai/sessions/e8478adcc09c450882c66f13dc257b29
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/1073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->