### PR TITLE
Enable hadolint in quality gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,12 @@ jobs:
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    # 1.0.5
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@550f3d7338e598c813b9580a238141328f7baaaa
+    # build-common#25 (decouples hadolint from lint override)
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@2eebe366cf8a06faa66a032ee934818f8b09c394
     with:
       python-version: '3.13'
+      run-hadolint: true
+      dockerfile-path: 'deploy/Dockerfile'
       lint-command-override: |
         set -e
         VIRTUAL_ENV=system make lint-check


### PR DESCRIPTION
## Description

Enables hadolint for `deploy/Dockerfile` in the CI quality gate using the built-in `run-hadolint` input.

Points to [build-common#25](https://github.com/cognizant-ai-lab/build-common/pull/25) (`2eebe36`) which decouples hadolint and zizmor from `lint-command-override`, allowing repos that use the override to still opt into these tools.

## Impact

CI will now lint `deploy/Dockerfile` with hadolint on every push and PR. No functional change to the application.

## Type of Change

- [x] Refactoring / Improvement

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation

**Note:** Once build-common#25 merges and is tagged, the build-common ref in this workflow should be updated to the new tag.

Link to Devin session: https://app.devin.ai/sessions/e8478adcc09c450882c66f13dc257b29
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/1075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->