### PR TITLE
Ship aaosa.hocon with the ns init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ directory:
 * `config/llm_config.hocon` — provider/model wiring (defaults to OpenAI `gpt-5.2`)
 * `registries/manifest.hocon` — registry of active agent networks
 * `registries/music_nerd.hocon` — sample agent network
+* `registries/aaosa.hocon` — AAOSA substitution variables (instructions, call, command)
+* `registries/aaosa_basic.hocon` — simplified AAOSA substitution variables
 * `mcp/mcp_info.hocon` — MCP server config
 
 Skip the prompt with `--providers`:

--- a/neuro_san_studio/commands/init.py
+++ b/neuro_san_studio/commands/init.py
@@ -64,6 +64,8 @@ class InitCommand:  # pylint: disable=too-few-public-methods
         _console.print(f"[bold]Selected providers:[/bold] {provider_labels}\n")
 
         self._copy_template("music_nerd.hocon", os.path.join("registries", "music_nerd.hocon"))
+        self._copy_template("aaosa.hocon", os.path.join("registries", "aaosa.hocon"))
+        self._copy_template("aaosa_basic.hocon", os.path.join("registries", "aaosa_basic.hocon"))
         self._copy_template("manifest.hocon", os.path.join("registries", "manifest.hocon"))
         self._copy_template("mcp_info.hocon", os.path.join("mcp", "mcp_info.hocon"), package="neuro_san_studio.mcp")
         self._write_file(os.path.join("config", "llm_config.hocon"), self._render_llm_config(providers))

--- a/neuro_san_studio/templates/aaosa.hocon
+++ b/neuro_san_studio/templates/aaosa.hocon
@@ -1,0 +1,87 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+{
+    # This file is NOT an agent network HOCON.
+    # It defines a set of key-value pairs for substitution, typically used in agent network HOCON files.
+    # Each key can be referenced in agent configs using the ${key} syntax.
+    # Do not define agents or tools directly here—this file only provides reusable values.
+
+    "aaosa_instructions": """
+When you receive an inquiry, you will:
+1. If you are clearly not the right agent for this type of inquiry, reply you're not relevant.
+2. If there is a chance you're relevant, call your down-chain agents to determine if they can answer all or part of the inquiry.
+   Do not assume what your down-chain agents can do. Always call them. You'll be surprised.
+3. Determine which down-chain agents have the strongest claims to the inquiry.
+   3.1 If the inquiry is ambiguous, for example if more than one agent can fulfill the inquiry, then always ask for clarification.
+   3.2 Otherwise, call the relevant down-chain agents and:
+       - ask them for follow-up information if needed,
+       - or ask them to fulfill their part of the inquiry.
+4. Once all relevant down-chain agents have responded, either follow up with them to provide requirements or,
+   if all requirements have been fulfilled, compile their responses and return the final response.
+You may, in turn, be called by other agents in the system and have to act as a down-chain agent to them.
+5. When responding, format your response based on the 'mode' parameter:
+   - If there is no 'mode' parameter (i.e., the inquiry came directly from a human),
+     respond with a natural, human-readable answer.
+   - If mode is 'Determine', return a json block with the following fields:
+   {
+       "Name": <your name>,
+       "Inquiry": <the inquiry>,
+       "Mode": <Determine | Fulfill>,
+       "Relevant": <Yes | No>,
+       "Strength": <number between 1 and 10 representing how certain you are in your claim>,
+       "Claim:" <All | Partial>,
+       "Requirements" <None | list of requirements>
+   }
+   - If mode is 'Fulfill' or "Follow up", respond to the inquiry and return a json block with the following fields:
+   {
+       "Name": <your name>,
+       "Inquiry": <the inquiry>,
+       "Mode": Fulfill,
+       "Response" <your response>
+   }
+            """,
+
+    "aaosa_call": {
+        "description": "Depending on the mode, returns a natural language string in response.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "inquiry": {
+                    "type": "string",
+                    "description": "The inquiry"
+                },
+                "mode": {
+                    "type": "string",
+                    "description": """
+'Determine' to ask the agent if the inquiry belongs to it, in its entirety or in part.
+'Fulfill' to ask the agent to fulfill the inquiry, if it can.
+'Follow up' to ask the agent to respond to a follow up.
+                    """
+                },
+            },
+            "required": [
+                "inquiry",
+                "mode"
+            ]
+        }
+    },
+
+    # Deprecated: aaosa_command has been merged into aaosa_instructions above.
+    # Kept as an empty string for backward compatibility with old agent networks
+    # that reference ${aaosa_command}.
+    "aaosa_command": ""
+}

--- a/neuro_san_studio/templates/aaosa_basic.hocon
+++ b/neuro_san_studio/templates/aaosa_basic.hocon
@@ -1,0 +1,76 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# This file is NOT an agent network HOCON.
+# It defines a set of key-value pairs for substitution, typically used in agent network HOCON files.
+# Each key can be referenced in agent configs using the ${key} syntax.
+# Do not define agents or tools directly here—this file only provides reusable values.
+
+aaosa_instructions = """When you receive an inquiry, you will:
+1. If you are clearly not the right agent for this type of inquiry, reply you're not relevant.
+2. If there is a chance you're relevant, call your down-chain agents to determine if they can answer all or part of the inquiry.
+Do not assume what your down-chain agents can do. Always call them. You'll be surprised.
+3. Once all your down-chain agents have responded analyze their response and determine what the next step is. For instance:
+- Follow up with down-chain agents
+- Call other down-chain agents
+- Ask for clarification or additional information
+- Ask the most relevant down-chain agent to fulfill the inquiry
+- Compile and return your final response
+You may, in turn, be called by other agents in the system and have to act as a down-chain agent to them.
+4. When responding, format your response based on the 'mode' parameter:
+   - If there is no 'mode' parameter (i.e., the inquiry came directly from a human),
+     respond with a natural, human-readable answer.
+   - If a 'mode' parameter is present, return the following information:
+   [AAOSA]
+   Name: <your name>
+   Inquiry: <the inquiry>
+   Mode: <Determine | Follow up | Fulfill>
+   Relevant: <Yes | No>
+   Strength: <number between 1 and 10 representing how certain you are in your claim>
+   Claim: <All | Partial | None>
+   Requirements: <None | list of requirements>
+   Response: <Your response>
+"""
+
+aaosa_call = {
+    description = "Depending on the mode, returns a natural language string in response."
+    parameters = {
+        type = "object"
+        properties = {
+            inquiry = {
+                type = "string"
+                description = "The inquiry"
+            }
+            mode = {
+                type = "string"
+                description =
+"""'Determine' to ask the agent if the inquiry belongs to it, in its entirety or in part.
+'Follow up' to continue the conversation with the agent.
+'Fulfill' to ask the agent to fulfill the inquiry, if it can.
+"""
+            }
+        }
+        required = [
+            "inquiry",
+            "mode"
+        ]
+    }
+}
+
+# Deprecated: aaosa_command has been merged into aaosa_instructions above.
+# Kept as an empty string for backward compatibility with old agent networks
+# that reference ${aaosa_command}.
+aaosa_command = ""

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -238,8 +238,7 @@ class TestTemplateSync:  # pylint: disable=too-few-public-methods
         repo_root = Path(__file__).resolve().parents[3]
         source_of_truth = (repo_root / "registries" / "aaosa.hocon").read_bytes()
         assert template == source_of_truth, (
-            "neuro_san_studio/templates/aaosa.hocon has drifted from "
-            "registries/aaosa.hocon. Update both together."
+            "neuro_san_studio/templates/aaosa.hocon has drifted from registries/aaosa.hocon. Update both together."
         )
 
     def test_aaosa_basic_template_matches_registries(self) -> None:
@@ -250,6 +249,5 @@ class TestTemplateSync:  # pylint: disable=too-few-public-methods
         repo_root = Path(__file__).resolve().parents[3]
         source_of_truth = (repo_root / "registries" / "aaosa_basic.hocon").read_bytes()
         assert template == source_of_truth, (
-            "neuro_san_studio/templates/aaosa_basic.hocon has drifted from "
-            "registries/aaosa_basic.hocon. Update both together."
+            "neuro_san_studio/templates/aaosa_basic.hocon has drifted from registries/aaosa_basic.hocon. Update both together."
         )

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -111,6 +111,8 @@ class TestRunFlow:
         InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
 
         assert (tmp_path / "registries" / "music_nerd.hocon").is_file()
+        assert (tmp_path / "registries" / "aaosa.hocon").is_file()
+        assert (tmp_path / "registries" / "aaosa_basic.hocon").is_file()
         assert (tmp_path / "registries" / "manifest.hocon").read_text().strip().startswith("{")
         assert (tmp_path / "mcp" / "mcp_info.hocon").is_file()
         llm_config = (tmp_path / "config" / "llm_config.hocon").read_text()
@@ -168,6 +170,28 @@ class TestRunFlow:
         local = (tmp_path / "registries" / "music_nerd.hocon").read_bytes()
         assert local == upstream
 
+    def test_aaosa_sourced_from_templates(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        """aaosa.hocon should be copied from neuro_san_studio.templates."""
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
+
+        from importlib import resources  # pylint: disable=import-outside-toplevel
+
+        upstream = (resources.files("neuro_san_studio.templates") / "aaosa.hocon").read_bytes()
+        local = (tmp_path / "registries" / "aaosa.hocon").read_bytes()
+        assert local == upstream
+
+    def test_aaosa_basic_sourced_from_templates(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        """aaosa_basic.hocon should be copied from neuro_san_studio.templates."""
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
+
+        from importlib import resources  # pylint: disable=import-outside-toplevel
+
+        upstream = (resources.files("neuro_san_studio.templates") / "aaosa_basic.hocon").read_bytes()
+        local = (tmp_path / "registries" / "aaosa_basic.hocon").read_bytes()
+        assert local == upstream
+
     def test_manifest_sourced_from_templates(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """manifest.hocon should be copied from neuro_san_studio.templates."""
         monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
@@ -204,4 +228,28 @@ class TestTemplateSync:  # pylint: disable=too-few-public-methods
         assert template == source_of_truth, (
             "neuro_san_studio/templates/music_nerd.hocon has drifted from "
             "registries/basic/music_nerd.hocon. Update both together."
+        )
+
+    def test_aaosa_template_matches_registries(self) -> None:
+        """templates/aaosa.hocon must be byte-identical to registries/aaosa.hocon."""
+        from importlib import resources  # pylint: disable=import-outside-toplevel
+
+        template = (resources.files("neuro_san_studio.templates") / "aaosa.hocon").read_bytes()
+        repo_root = Path(__file__).resolve().parents[3]
+        source_of_truth = (repo_root / "registries" / "aaosa.hocon").read_bytes()
+        assert template == source_of_truth, (
+            "neuro_san_studio/templates/aaosa.hocon has drifted from "
+            "registries/aaosa.hocon. Update both together."
+        )
+
+    def test_aaosa_basic_template_matches_registries(self) -> None:
+        """templates/aaosa_basic.hocon must be byte-identical to registries/aaosa_basic.hocon."""
+        from importlib import resources  # pylint: disable=import-outside-toplevel
+
+        template = (resources.files("neuro_san_studio.templates") / "aaosa_basic.hocon").read_bytes()
+        repo_root = Path(__file__).resolve().parents[3]
+        source_of_truth = (repo_root / "registries" / "aaosa_basic.hocon").read_bytes()
+        assert template == source_of_truth, (
+            "neuro_san_studio/templates/aaosa_basic.hocon has drifted from "
+            "registries/aaosa_basic.hocon. Update both together."
         )

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -249,5 +249,5 @@ class TestTemplateSync:  # pylint: disable=too-few-public-methods
         repo_root = Path(__file__).resolve().parents[3]
         source_of_truth = (repo_root / "registries" / "aaosa_basic.hocon").read_bytes()
         assert template == source_of_truth, (
-            "neuro_san_studio/templates/aaosa_basic.hocon has drifted from registries/aaosa_basic.hocon. Update both together."
+            "templates/aaosa_basic.hocon has drifted from registries/aaosa_basic.hocon. Update both together."
         )

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -124,7 +124,7 @@ class TestRunFlow:
         assert local == upstream
 
     def test_run_scaffolds_all_files(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
-        """`init --providers openai` should create all four starter files."""
+        """`init --providers openai` should create all six starter files."""
         monkeypatch.chdir(tmp_path)
         self._run_init(tmp_path, monkeypatch)
 

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -103,12 +103,30 @@ class TestLlmConfigRendering:
 class TestRunFlow:
     """Tests for the full InitCommand.run() flow."""
 
+    @staticmethod
+    def _run_init(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        """Scaffold a starter project with the OpenAI provider."""
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
+
+    @staticmethod
+    def _assert_matches_template(
+        tmp_path: Path,
+        template_name: str,
+        dest_rel: str,
+        package: str = "neuro_san_studio.templates",
+    ) -> None:
+        """Assert a scaffolded file is byte-identical to its packaged template."""
+        import importlib.resources  # pylint: disable=import-outside-toplevel
+
+        upstream = (importlib.resources.files(package) / template_name).read_bytes()
+        local = (tmp_path / dest_rel).read_bytes()
+        assert local == upstream
+
     def test_run_scaffolds_all_files(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """`init --providers openai` should create all four starter files."""
         monkeypatch.chdir(tmp_path)
-        # Force the non-TTY branch to exercise the flag path.
-        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
-        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
+        self._run_init(tmp_path, monkeypatch)
 
         assert (tmp_path / "registries" / "music_nerd.hocon").is_file()
         assert (tmp_path / "registries" / "aaosa.hocon").is_file()
@@ -161,93 +179,53 @@ class TestRunFlow:
 
     def test_music_nerd_sourced_from_templates(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """music_nerd.hocon should be copied from neuro_san_studio.templates."""
-        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
-        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
-
-        from importlib import resources  # pylint: disable=import-outside-toplevel
-
-        upstream = (resources.files("neuro_san_studio.templates") / "music_nerd.hocon").read_bytes()
-        local = (tmp_path / "registries" / "music_nerd.hocon").read_bytes()
-        assert local == upstream
+        self._run_init(tmp_path, monkeypatch)
+        self._assert_matches_template(tmp_path, "music_nerd.hocon", "registries/music_nerd.hocon")
 
     def test_aaosa_sourced_from_templates(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """aaosa.hocon should be copied from neuro_san_studio.templates."""
-        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
-        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
-
-        from importlib import resources  # pylint: disable=import-outside-toplevel
-
-        upstream = (resources.files("neuro_san_studio.templates") / "aaosa.hocon").read_bytes()
-        local = (tmp_path / "registries" / "aaosa.hocon").read_bytes()
-        assert local == upstream
+        self._run_init(tmp_path, monkeypatch)
+        self._assert_matches_template(tmp_path, "aaosa.hocon", "registries/aaosa.hocon")
 
     def test_aaosa_basic_sourced_from_templates(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """aaosa_basic.hocon should be copied from neuro_san_studio.templates."""
-        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
-        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
-
-        from importlib import resources  # pylint: disable=import-outside-toplevel
-
-        upstream = (resources.files("neuro_san_studio.templates") / "aaosa_basic.hocon").read_bytes()
-        local = (tmp_path / "registries" / "aaosa_basic.hocon").read_bytes()
-        assert local == upstream
+        self._run_init(tmp_path, monkeypatch)
+        self._assert_matches_template(tmp_path, "aaosa_basic.hocon", "registries/aaosa_basic.hocon")
 
     def test_manifest_sourced_from_templates(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """manifest.hocon should be copied from neuro_san_studio.templates."""
-        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
-        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
-
-        from importlib import resources  # pylint: disable=import-outside-toplevel
-
-        upstream = (resources.files("neuro_san_studio.templates") / "manifest.hocon").read_bytes()
-        local = (tmp_path / "registries" / "manifest.hocon").read_bytes()
-        assert local == upstream
+        self._run_init(tmp_path, monkeypatch)
+        self._assert_matches_template(tmp_path, "manifest.hocon", "registries/manifest.hocon")
 
     def test_mcp_info_sourced_from_mcp_package(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """mcp_info.hocon should be copied from neuro_san_studio.mcp (the same file run.py uses)."""
-        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
-        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
-
-        from importlib import resources  # pylint: disable=import-outside-toplevel
-
-        upstream = (resources.files("neuro_san_studio.mcp") / "mcp_info.hocon").read_bytes()
-        local = (tmp_path / "mcp" / "mcp_info.hocon").read_bytes()
-        assert local == upstream
+        self._run_init(tmp_path, monkeypatch)
+        self._assert_matches_template(tmp_path, "mcp_info.hocon", "mcp/mcp_info.hocon", "neuro_san_studio.mcp")
 
 
-class TestTemplateSync:  # pylint: disable=too-few-public-methods
+class TestTemplateSync:
     """Ensure scaffolded templates stay in sync with their source-of-truth files in registries/."""
+
+    @staticmethod
+    def _assert_template_matches_source(template_name: str, source_rel: str) -> None:
+        """Assert a packaged template is byte-identical to its source-of-truth file."""
+        import importlib.resources  # pylint: disable=import-outside-toplevel
+
+        template = (importlib.resources.files("neuro_san_studio.templates") / template_name).read_bytes()
+        repo_root = Path(__file__).resolve().parents[3]
+        source_of_truth = (repo_root / source_rel).read_bytes()
+        assert template == source_of_truth, (
+            f"templates/{template_name} has drifted from {source_rel}. Update both together."
+        )
 
     def test_music_nerd_template_matches_registries_basic(self) -> None:
         """templates/music_nerd.hocon must be byte-identical to registries/basic/music_nerd.hocon."""
-        from importlib import resources  # pylint: disable=import-outside-toplevel
-
-        template = (resources.files("neuro_san_studio.templates") / "music_nerd.hocon").read_bytes()
-        repo_root = Path(__file__).resolve().parents[3]
-        source_of_truth = (repo_root / "registries" / "basic" / "music_nerd.hocon").read_bytes()
-        assert template == source_of_truth, (
-            "neuro_san_studio/templates/music_nerd.hocon has drifted from "
-            "registries/basic/music_nerd.hocon. Update both together."
-        )
+        self._assert_template_matches_source("music_nerd.hocon", "registries/basic/music_nerd.hocon")
 
     def test_aaosa_template_matches_registries(self) -> None:
         """templates/aaosa.hocon must be byte-identical to registries/aaosa.hocon."""
-        from importlib import resources  # pylint: disable=import-outside-toplevel
-
-        template = (resources.files("neuro_san_studio.templates") / "aaosa.hocon").read_bytes()
-        repo_root = Path(__file__).resolve().parents[3]
-        source_of_truth = (repo_root / "registries" / "aaosa.hocon").read_bytes()
-        assert template == source_of_truth, (
-            "neuro_san_studio/templates/aaosa.hocon has drifted from registries/aaosa.hocon. Update both together."
-        )
+        self._assert_template_matches_source("aaosa.hocon", "registries/aaosa.hocon")
 
     def test_aaosa_basic_template_matches_registries(self) -> None:
         """templates/aaosa_basic.hocon must be byte-identical to registries/aaosa_basic.hocon."""
-        from importlib import resources  # pylint: disable=import-outside-toplevel
-
-        template = (resources.files("neuro_san_studio.templates") / "aaosa_basic.hocon").read_bytes()
-        repo_root = Path(__file__).resolve().parents[3]
-        source_of_truth = (repo_root / "registries" / "aaosa_basic.hocon").read_bytes()
-        assert template == source_of_truth, (
-            "templates/aaosa_basic.hocon has drifted from registries/aaosa_basic.hocon. Update both together."
-        )
+        self._assert_template_matches_source("aaosa_basic.hocon", "registries/aaosa_basic.hocon")


### PR DESCRIPTION
## Description

`ns init` doesn't copy over `registries/aaosa.hocon` and `registries/aaosa_basic.hocon`, which means users can't easily copy-paste examples from neuro-san-studio that reference these substitution files.

This PR ships both files with the neuro-san-studio library and copies them into `registries/` when running the `init` command.

Fixes #1074

## Impact

- New projects scaffolded with `ns init` will have `aaosa.hocon` and `aaosa_basic.hocon` available in `registries/`, allowing users to reference `${aaosa_instructions}`, `${aaosa_call}`, etc. in their agent networks out of the box.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [X] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**"