### PR TITLE
Reducing log noise

### DIFF
--- a/neuro_san_studio/plugins/log_bridge/process_log_bridge.py
+++ b/neuro_san_studio/plugins/log_bridge/process_log_bridge.py
@@ -635,33 +635,29 @@ class ProcessLogBridge(ProcessLoggerInterface):
 
     def _emit_json_block(self, state: Dict[str, Any], record: Dict[str, Any]) -> None:
         """
-        Emit a fully parsed JSON record to the logger.
-        Steps:
-            1. Infer log level from `message_type`.
-            2. Build header including process name and optional source.
-            3. Parse nested JSON inside the `"message"` field (if present).
-            4. Pretty-print JSON.
-            5. If the message looks like traceback text, print a Rich-formatted traceback.
-        :param state (dict): Per-stream logging state.
-        :param record (dict): Parsed JSON dictionary representing the log event.
+        Emit a parsed JSON record as a single-line `header: message` log entry.
+        Other metadata fields (user_id, Timestamp, request_id, ...) are dropped
+        from the display because they are noise for routine logs; the full
+        record is still mirrored to the per-process raw log file via tee.
         """
         level = self._infer_level_from_message_type(record)
         src = str(record.get("source") or "").strip() or None
         header = self._src_header(state["logger"].name, src)
 
-        # Display copy
-        display_rec = dict(record)
-        inner = self._lenient_inner_json_parse(display_rec.get("message"))
-        if inner is not None:
-            display_rec["message"] = inner
+        msg: Any = record.get("message", "")
+        if isinstance(msg, str):
+            inner = self._lenient_inner_json_parse(msg)
+            if inner is not None:
+                msg = json.dumps(inner, ensure_ascii=False)
+        elif isinstance(msg, (dict, list)):
+            msg = json.dumps(msg, ensure_ascii=False)
 
-        body = self._pretty_json(display_rec)
-        self._log(state, level, header + "\n" + body)
+        self._log(state, level, f"{header}: {msg}")
 
         # If message was traceback-like text, pretty print after
-        msg = record.get("message")
-        if isinstance(msg, str):
-            tb_text = self._normalize_traceback_str(msg)
+        original = record.get("message")
+        if isinstance(original, str):
+            tb_text = self._normalize_traceback_str(original)
             if self._looks_like_traceback(tb_text):
                 self._log(state, level, header + " (traceback)")
                 self.console.print(Syntax(tb_text, "pytb", word_wrap=False))

--- a/neuro_san_studio/plugins/log_bridge/process_log_bridge.py
+++ b/neuro_san_studio/plugins/log_bridge/process_log_bridge.py
@@ -479,18 +479,6 @@ class ProcessLogBridge(ProcessLoggerInterface):
 
     # ---------- json helpers ----------
     @staticmethod
-    def _pretty_json(obj: Any) -> str:
-        """
-        Pretty-print a JSON object.
-        :param obj (Any): Any JSON-serializable object.
-        :return str: Indented JSON, or `str(obj)` on failure.
-        """
-        try:
-            return json.dumps(obj, indent=2, ensure_ascii=False)
-        except Exception:  # pylint: disable=broad-except
-            return str(obj)
-
-    @staticmethod
     def _try_parse_json_fragment(text: str) -> Optional[Dict[str, Any]]:
         """
         Try to parse a JSON dictionary from a text line.
@@ -639,25 +627,27 @@ class ProcessLogBridge(ProcessLoggerInterface):
         Other metadata fields (user_id, Timestamp, request_id, ...) are dropped
         from the display because they are noise for routine logs; the full
         record is still mirrored to the per-process raw log file via tee.
+        :param state (dict): Per-stream logging state.
+        :param record (dict): Parsed JSON dictionary representing the log event.
         """
         level = self._infer_level_from_message_type(record)
         src = str(record.get("source") or "").strip() or None
         header = self._src_header(state["logger"].name, src)
 
-        msg: Any = record.get("message", "")
-        if isinstance(msg, str):
-            inner = self._lenient_inner_json_parse(msg)
+        display_msg: Any = record.get("message", "")
+        if isinstance(display_msg, str):
+            inner = self._lenient_inner_json_parse(display_msg)
             if inner is not None:
-                msg = json.dumps(inner, ensure_ascii=False)
-        elif isinstance(msg, (dict, list)):
-            msg = json.dumps(msg, ensure_ascii=False)
+                display_msg = json.dumps(inner, ensure_ascii=False)
+        elif isinstance(display_msg, (dict, list)):
+            display_msg = json.dumps(display_msg, ensure_ascii=False)
 
-        self._log(state, level, f"{header}: {msg}")
+        self._log(state, level, header + ": " + str(display_msg))
 
-        # If message was traceback-like text, pretty print after
-        original = record.get("message")
-        if isinstance(original, str):
-            tb_text = self._normalize_traceback_str(original)
+        # Re-read the raw message; display_msg above may have been JSON-serialized.
+        raw_msg = record.get("message")
+        if isinstance(raw_msg, str):
+            tb_text = self._normalize_traceback_str(raw_msg)
             if self._looks_like_traceback(tb_text):
                 self._log(state, level, header + " (traceback)")
                 self.console.print(Syntax(tb_text, "pytb", word_wrap=False))


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description (Quality of life improvement)

Collapse each parsed JSON log record emitted by ProcessLogBridge from a 9‑line pretty-printed block into a single header: message line. Drops the user_id / Timestamp / request_id / message_type / source metadata from the terminal display only — the raw record is still mirrored verbatim to the per-process log files via the existing tee. Cuts the console output by ~9× and makes the launcher terminal usable again during agent loading and chat traffic.

## Impact

Every routine ADDED network for agent ... and per-request lifecycle message currently renders 10 lines in python -m neuro_san_studio run. Server startup produces hundreds of these; a single chat session adds several more. WARN/ERROR lines and useful signals get buried, terminal scrollback gets exhausted, and the per-record metadata fields are almost always "None" for routine events. Reducing it to a single line simplifies it by a lot.

## Follow UP PRs:

We could further clean up logs as follows:

1. 
```
[2026-05-26 17:22:53 PDT] INFO     NeuroSan - [2026-05-26 17:22:53 PDT] INFO     Validating agent network keywords...                                                                             
[2026-05-26 17:22:53 PDT] INFO     NeuroSan - [2026-05-26 17:22:53 PDT] INFO     Validating agent network structure...                                                                            
[2026-05-26 17:22:53 PDT] INFO     NeuroSan - [2026-05-26 17:22:53 PDT] INFO     Validating URLs for MCP tools and subnetwork...    
```
2. Remove or merge into one
```
[2026-05-26 17:22:53 PDT] WARNING  NeuroSan - [2026-05-26 17:22:53 PDT] WARNING  Manifest entry for tools/a2a_research_report.hocon in file /Users/978131/curly-braces/registries/manifest.hocon  
                                   will not be served, per the 'serve' key in its                                                                                                                 
[2026-05-26 17:22:53 PDT] INFO     NeuroSan -                                    config (default is False). Skipping. 
```

## Logs
FROM:
```
[2026-05-26 15:39:27 PDT] INFO     NeuroSan:HttpServer
                                   {
                                     "message": "REPLACED network for agent agent_network_editor : 4838210736",
                                     "user_id": "None",
                                     "Timestamp": "2026-05-26T15:39:27.109088",
                                     "source": "HttpServer",
                                     "message_type": "Other",
                                     "request_id": "None"
                                   }
```

TO
```                                                      
[2026-05-26 15:39:27 PDT] INFO     NeuroSan:HttpServer: REPLACED network for agent agent_network_editor : 4838210736
```                                         
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**