### PR TITLE
#1085 Make ns init create config/plugins.hocon

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ ns init
 directory:
 
 * `config/llm_config.hocon` — provider/model wiring (defaults to OpenAI `gpt-5.2`)
+* `config/plugins.hocon` — observability and logging plugin wiring (the rich-formatted log bridge is enabled by default)
 * `registries/manifest.hocon` — registry of active agent networks
 * `registries/music_nerd.hocon` — sample agent network
 * `registries/aaosa.hocon` — AAOSA substitution variables (instructions, call, command)

--- a/neuro_san_studio/commands/init.py
+++ b/neuro_san_studio/commands/init.py
@@ -78,6 +78,7 @@ class InitCommand:  # pylint: disable=too-few-public-methods
         for shared in ("aaosa.hocon", "aaosa_basic.hocon", "aaosa_basic_debug.hocon"):
             self._copy_template(shared, os.path.join("registries", shared), package="registries")
         self._copy_template("mcp_info.hocon", os.path.join("mcp", "mcp_info.hocon"), package="neuro_san_studio.mcp")
+        self._copy_template("plugins.hocon", os.path.join("config", "plugins.hocon"))
         self._write_file(os.path.join("config", "llm_config.hocon"), self._render_llm_config(providers))
 
         self._print_next_steps()

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -61,7 +61,7 @@ class NeuroSanRunner:
         # Load environment variables from .env file
         self.load_env_variables()
 
-        plugins_file = os.path.join(self.root_dir, "config", "plugins.hocon")
+        plugins_file = PluginLoader.resolve_plugins_file(self.root_dir)
         self.plugin_classes = PluginLoader.load_plugin_classes(plugins_file)
 
         # Default Configuration

--- a/neuro_san_studio/plugins/plugin_loader.py
+++ b/neuro_san_studio/plugins/plugin_loader.py
@@ -23,6 +23,7 @@ Used by both the runner (neuro_san_studio/commands/run.py) and the server wrappe
 
 import importlib
 import logging
+import os
 import types
 from typing import Any
 from typing import Dict
@@ -34,11 +35,33 @@ from pyhocon import ConfigFactory
 from pyhocon import ConfigTree
 from pyhocon.exceptions import ConfigException
 
+from neuro_san_studio import templates as _templates_pkg
+
 _logger = logging.getLogger("PluginLoader")
 
+# Path to the plugins.hocon that ships inside the neuro_san_studio package.
+# Resolving via the imported package's __file__ works both in-repo (where
+# neuro_san_studio/ is just a folder on sys.path) and after `pip install`
+# (where it lives in site-packages), on every supported platform.
+_BUNDLED_PLUGINS_FILE = os.path.join(os.path.dirname(_templates_pkg.__file__), "plugins.hocon")
 
-class PluginLoader:  # pylint: disable=too-few-public-methods
+
+class PluginLoader:
     """Loads plugin classes from a HOCON configuration file."""
+
+    @staticmethod
+    def resolve_plugins_file(root_dir: str) -> str:
+        """Resolve the plugins.hocon file path.
+
+        Precedence:
+          1. <root_dir>/config/plugins.hocon if it exists (user's editable copy,
+             scaffolded by `ns init`).
+          2. The plugins.hocon shipped inside the neuro_san_studio package.
+        """
+        scaffolded_path = os.path.join(root_dir, "config", "plugins.hocon")
+        if os.path.isfile(scaffolded_path):
+            return scaffolded_path
+        return _BUNDLED_PLUGINS_FILE
 
     @staticmethod
     def _is_enabled(plugin_entry: Dict[str, Any]) -> bool:

--- a/neuro_san_studio/runner/neuro_san_server_wrapper.py
+++ b/neuro_san_studio/runner/neuro_san_server_wrapper.py
@@ -41,7 +41,7 @@ class NeuroSanServerWrapper:  # pylint: disable=too-few-public-methods
         if self.root_dir not in sys.path:
             sys.path.insert(0, self.root_dir)
 
-        plugins_file = os.path.join(self.root_dir, "config", "plugins.hocon")
+        plugins_file = PluginLoader.resolve_plugins_file(self.root_dir)
         self.plugin_classes = PluginLoader.load_plugin_classes(plugins_file)
 
         # Instantiate plugins now that args are fully built

--- a/neuro_san_studio/templates/plugins.hocon
+++ b/neuro_san_studio/templates/plugins.hocon
@@ -1,0 +1,23 @@
+plugins = [
+    # Observability plugins
+    {
+        class = neuro_san_studio.plugins.phoenix.phoenix_plugin.PhoenixPlugin
+        enabled = false
+        # Override the enabled value with an environment variable, if provided.
+        enabled = ${?PHOENIX_ENABLED}
+    }
+    {
+        class = neuro_san_studio.plugins.langfuse.langfuse_plugin.LangfusePlugin
+        enabled = false
+        # Override the enabled value with an environment variable, if provided.
+        enabled = ${?LANGFUSE_ENABLED}
+    }
+
+    # Logging plugins
+    {
+        class = neuro_san_studio.plugins.log_bridge.process_log_bridge_plugin.ProcessLogBridgePlugin
+        enabled = true
+        # Override the enabled value with an environment variable, if provided.
+        enabled = ${?LOGBRIDGE_ENABLED}
+    }
+]

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -227,7 +227,7 @@ class TestRunFlow:
 
 
 class TestTemplateSync:
-    """Ensure scaffolded templates stay in sync with their source-of-truth files in registries/."""
+    """Ensure scaffolded templates stay in sync with their source-of-truth files in registries/ and config/."""
 
     @staticmethod
     def _assert_template_matches_source(template_name: str, source_rel: str) -> None:

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -124,7 +124,7 @@ class TestRunFlow:
         assert local == upstream
 
     def test_run_scaffolds_all_files(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
-        """`init --providers openai` should create all six starter files."""
+        """`init --providers openai` should create all starter files."""
         monkeypatch.chdir(tmp_path)
         self._run_init(tmp_path, monkeypatch)
 
@@ -143,6 +143,7 @@ class TestRunFlow:
         main_manifest = (tmp_path / "registries" / "manifest.hocon").read_text()
         assert 'include "registries/generated/manifest.hocon"' in main_manifest
         assert (tmp_path / "mcp" / "mcp_info.hocon").is_file()
+        assert (tmp_path / "config" / "plugins.hocon").is_file()
         llm_config = (tmp_path / "config" / "llm_config.hocon").read_text()
         assert '"model_name": "gpt-5.2"' in llm_config
         assert '"class"' not in llm_config
@@ -219,8 +220,13 @@ class TestRunFlow:
         self._run_init(tmp_path, monkeypatch)
         self._assert_matches_template(tmp_path, "mcp_info.hocon", "mcp/mcp_info.hocon", "neuro_san_studio.mcp")
 
+    def test_plugins_sourced_from_templates(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        """plugins.hocon should be copied from neuro_san_studio.templates."""
+        self._run_init(tmp_path, monkeypatch)
+        self._assert_matches_template(tmp_path, "plugins.hocon", "config/plugins.hocon")
 
-class TestTemplateSync:  # pylint: disable=too-few-public-methods
+
+class TestTemplateSync:
     """Ensure scaffolded templates stay in sync with their source-of-truth files in registries/."""
 
     @staticmethod
@@ -238,3 +244,7 @@ class TestTemplateSync:  # pylint: disable=too-few-public-methods
     def test_music_nerd_template_matches_registries_basic(self) -> None:
         """templates/music_nerd.hocon must be byte-identical to registries/basic/music_nerd.hocon."""
         self._assert_template_matches_source("music_nerd.hocon", "registries/basic/music_nerd.hocon")
+
+    def test_plugins_template_matches_config(self) -> None:
+        """templates/plugins.hocon must be byte-identical to config/plugins.hocon."""
+        self._assert_template_matches_source("plugins.hocon", "config/plugins.hocon")

--- a/tests/neuro_san_studio/plugins/test_plugin_loader.py
+++ b/tests/neuro_san_studio/plugins/test_plugin_loader.py
@@ -18,6 +18,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -267,3 +268,20 @@ class TestIsEnabled:  # pylint: disable=protected-access
     def test_string_false_variants(self, value):
         """Test that string falsy values are recognized."""
         assert PluginLoader._is_enabled({"enabled": value}) is False
+
+
+class TestResolvePluginsFile:
+    """Tests for PluginLoader.resolve_plugins_file."""
+
+    def test_user_local_path_used_when_file_exists(self, tmp_path: Path) -> None:
+        """A scaffolded <root_dir>/config/plugins.hocon wins over the bundled fallback."""
+        scaffolded = tmp_path / "config" / "plugins.hocon"
+        scaffolded.parent.mkdir()
+        scaffolded.write_text("plugins = []\n")
+        assert PluginLoader.resolve_plugins_file(str(tmp_path)) == str(scaffolded)
+
+    def test_falls_back_to_bundled(self, tmp_path: Path) -> None:
+        """With no scaffolded copy, the bundled templates path is returned."""
+        result = PluginLoader.resolve_plugins_file(str(tmp_path))
+        assert os.path.isfile(result)
+        assert result.endswith(os.path.join("neuro_san_studio", "templates", "plugins.hocon"))


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

`ns init` was not initializing plugins. Now it does.

Fixes #1085 

## Impact

The `ProcessLogBridgePlugin` plugin is now enabled by default, which means in a newly initialized project the logs are formatted in the same way as in neuro-san-studio.

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [X] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
