### PR TITLE
Add Esc to exit from ns import/export

### DIFF
--- a/neuro_san_studio/commands/export_networks.py
+++ b/neuro_san_studio/commands/export_networks.py
@@ -26,6 +26,7 @@ import questionary
 
 from neuro_san_studio.discovery.agent_network_registry import AgentNetworkRegistry
 from neuro_san_studio.exporter.agent_network_exporter import AgentNetworkExporter
+from neuro_san_studio.utils.cli_prompt import CliPrompt
 from neuro_san_studio.utils.cli_status import CliStatus
 
 
@@ -138,12 +139,16 @@ class ExportCommand:  # pylint: disable=too-few-public-methods
 
         choices = self._build_picker_choices(networks_by_group)
         try:
-            return questionary.select(
+            question = questionary.select(
                 "Pick a network to export:",
                 choices=choices,
-            ).ask()
+            )
+            answer = CliPrompt.bind_exit_on_esc(question).ask()
         except (KeyboardInterrupt, EOFError):
             return None
+        if answer is None or answer == CliPrompt.EXIT:
+            return None
+        return answer
 
     @staticmethod
     def _build_picker_choices(networks_by_group: Dict[str, List[str]]) -> List:

--- a/neuro_san_studio/commands/import_networks.py
+++ b/neuro_san_studio/commands/import_networks.py
@@ -35,6 +35,7 @@ from neuro_san_studio.utils.package_paths import PackagePaths
 
 CUSTOM = "__custom__"
 ALL = "__all__"
+FROM_FILE = "__from_file__"
 BACK = "__back__"
 
 
@@ -63,7 +64,7 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
             sys.exit(1)
 
         if self.from_file:
-            self._run_from_file()
+            self._run_from_file(self.from_file)
             return
 
         CliStatus.info("Discovering available agent networks...")
@@ -81,6 +82,12 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
             selected = self._parse_arg(self.networks_arg, networks_by_group)
         else:
             selected = self._prompt(networks_by_group)
+
+        # "From File" picked interactively — first slot is the FROM_FILE marker, second
+        # is the user-typed path. Same end behavior as `ns import -f <path>`.
+        if selected and selected[0] == FROM_FILE:
+            self._run_from_file(selected[1])
+            return
 
         if not selected:
             print()
@@ -110,12 +117,12 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
     def _verify_project_initialized(self) -> bool:
         return os.path.exists(os.path.join(self.target_dir, "registries", "manifest.hocon"))
 
-    def _run_from_file(self) -> None:
+    def _run_from_file(self, file_path: str) -> None:
         """Import a single .hocon (self-contained) or a .zip bundle (path-preserving)."""
-        source_path = os.path.abspath(os.path.expanduser(self.from_file))
+        source_path = os.path.abspath(os.path.expanduser(file_path))
         if not os.path.isfile(source_path):
             print()
-            CliStatus.err(f"File not found: {self.from_file}")
+            CliStatus.err(f"File not found: {file_path}")
             print()
             sys.exit(1)
         suffix = os.path.splitext(source_path)[1].lower()
@@ -239,14 +246,21 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
 
     @classmethod
     def _prompt(cls, networks_by_group: Dict[str, List[str]]) -> List[str]:
-        """Two-tier flow: pick a group / All / Custom; Custom drills into a network checkbox.
-        Left arrow on a sub-screen returns to the top screen, discarding selections."""
+        """Two-tier flow: pick a group / All / Custom / From File; Custom drills into a
+        network checkbox. Left/Esc on a sub-screen returns to the top screen, discarding
+        selections. From File is signalled by returning :data:`FROM_FILE`; the caller
+        diverts to the file-import path instead of resolving names against the registry."""
         while True:
             top = cls._prompt_top(networks_by_group)
             if top is None or top == CliPrompt.EXIT:
                 return []
             if top == ALL:
                 return [path for paths in networks_by_group.values() for path in paths]
+            if top == FROM_FILE:
+                picked = cls._prompt_for_file_path()
+                if picked is None:  # ←/Esc on path prompt → back to top menu
+                    continue
+                return [FROM_FILE, picked]
             if top == CUSTOM:
                 confirmed = cls._custom_flow(networks_by_group)
                 if confirmed is None:  # user pressed ←/Esc at the first custom step
@@ -256,21 +270,41 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _prompt_top(networks_by_group: Dict[str, List[str]]) -> Optional[str]:
+        """Top-menu picker. Group rows first (data), then a separator, then action rows
+        (All / Custom selection / From File) — actions are styled distinctly so they
+        read as commands rather than just another bucket."""
         total = sum(len(paths) for paths in networks_by_group.values())
-        choices = [
+        choices: List = [
             questionary.Choice(title=f"{group.capitalize()} ({len(paths)})", value=group)
             for group, paths in networks_by_group.items()
         ]
         choices += [
             questionary.Separator(),
-            questionary.Choice(title="Custom selection", value=CUSTOM),
-            questionary.Choice(title=f"All ({total})", value=ALL),
+            questionary.Choice(title=[("class:action", f"All ({total})")], value=ALL),
+            questionary.Choice(title=[("class:action", "Custom selection")], value=CUSTOM),
+            questionary.Choice(title=[("class:action", "From File")], value=FROM_FILE),
         ]
         question = questionary.select(
             "What do you want to import?",
             choices=choices,
+            style=questionary.Style([("action", "fg:#5fafd7 italic")]),
         )
         return CliPrompt.bind_exit_on_esc(question).ask()
+
+    @staticmethod
+    def _prompt_for_file_path() -> Optional[str]:
+        """Ask for a .hocon or .zip path; ←/Esc returns None so the caller pops back to
+        the top menu (same back-semantics as the other sub-screens). Validation is left
+        to ``_run_from_file`` so messages stay consistent with the ``-f`` flag path."""
+        try:
+            question = questionary.path("Path to .hocon or .zip:", only_directories=False)
+            answer = CliPrompt.bind_back_keys(question, BACK).ask()
+        except (KeyboardInterrupt, EOFError):
+            return None
+        if answer is None or answer == BACK:
+            return None
+        answer = answer.strip()
+        return answer or None
 
     @classmethod
     def _custom_flow(cls, networks_by_group: Dict[str, List[str]]) -> Optional[List[str]]:

--- a/neuro_san_studio/commands/import_networks.py
+++ b/neuro_san_studio/commands/import_networks.py
@@ -24,12 +24,12 @@ from typing import List
 from typing import Optional
 
 import questionary
-from prompt_toolkit.keys import Keys
 
 from neuro_san_studio.discovery.agent_network_registry import AgentNetworkRegistry
 from neuro_san_studio.discovery.dependency_analyzer import DependencyAnalyzer
 from neuro_san_studio.importer.agent_network_importer import AgentNetworkImporter
 from neuro_san_studio.importer.agent_network_importer import is_skippable_metadata
+from neuro_san_studio.utils.cli_prompt import CliPrompt
 from neuro_san_studio.utils.cli_status import CliStatus
 from neuro_san_studio.utils.package_paths import PackagePaths
 
@@ -201,9 +201,11 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
         if not sys.stdin.isatty():
             return True
         try:
-            return questionary.confirm("Proceed with import?", default=True).ask() is True
+            question = questionary.confirm("Proceed with import?", default=True)
+            answer = CliPrompt.bind_exit_on_esc(question).ask()
         except (KeyboardInterrupt, EOFError):
             return False
+        return answer is True
 
     @staticmethod
     def _parse_arg(arg: str, networks_by_group: Dict[str, List[str]]) -> List[str]:
@@ -241,13 +243,13 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
         Left arrow on a sub-screen returns to the top screen, discarding selections."""
         while True:
             top = cls._prompt_top(networks_by_group)
-            if top is None:
+            if top is None or top == CliPrompt.EXIT:
                 return []
             if top == ALL:
                 return [path for paths in networks_by_group.values() for path in paths]
             if top == CUSTOM:
                 confirmed = cls._custom_flow(networks_by_group)
-                if confirmed is None:  # user pressed Left at the first custom step
+                if confirmed is None:  # user pressed ←/Esc at the first custom step
                     continue
                 return confirmed
             return list(networks_by_group.get(top, []))
@@ -264,10 +266,11 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
             questionary.Choice(title="Custom selection", value=CUSTOM),
             questionary.Choice(title=f"All ({total})", value=ALL),
         ]
-        return questionary.select(
+        question = questionary.select(
             "What do you want to import?",
             choices=choices,
-        ).ask()
+        )
+        return CliPrompt.bind_exit_on_esc(question).ask()
 
     @classmethod
     def _custom_flow(cls, networks_by_group: Dict[str, List[str]]) -> Optional[List[str]]:
@@ -335,19 +338,16 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
         if not sys.stdin.isatty():
             return True
         try:
-            return questionary.confirm("Proceed with import?", default=True).ask() is True
+            question = questionary.confirm("Proceed with import?", default=True)
+            answer = CliPrompt.bind_exit_on_esc(question).ask()
         except (KeyboardInterrupt, EOFError):
             return False
+        return answer is True
 
     @staticmethod
     def _ask_with_back(question):
-        """Run a questionary checkbox with Left=exit-with-BACK sentinel."""
-
-        @question.application.key_bindings.add(Keys.Left)
-        def _back(event):
-            event.app.exit(result=BACK)
-
-        return question.ask()
+        """Run a questionary checkbox with ← / Esc → BACK sentinel (intuitive return-to-prev-screen)."""
+        return CliPrompt.bind_back_keys(question, BACK).ask()
 
     def _import(self, hocon_paths: List[str], registry: AgentNetworkRegistry) -> None:
         analyzer = DependencyAnalyzer(

--- a/neuro_san_studio/commands/import_networks.py
+++ b/neuro_san_studio/commands/import_networks.py
@@ -193,7 +193,8 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
             "middleware/": sum(1 for n in real if n.startswith("middleware/")),
             "skills/": sum(1 for n in real if n.startswith("skills/")),
         }
-        print(f"\nFiles to import (from {os.path.basename(source_path)}):")
+        print()
+        CliStatus.info(f"Files to import (from {os.path.basename(source_path)}):")
         if registries:
             print("  registries/")
             for rel in registries:
@@ -201,10 +202,12 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
         for bucket, count in bucket_counts.items():
             if count:
                 print(f"  {bucket:<14}({count} files)")
+        print()
         if force:
-            print("\nNote:\n--force is set: existing files in the target will be OVERWRITTEN.\n")
+            CliStatus.warn("--force is set: existing files in the target will be OVERWRITTEN.")
         else:
-            print("\nNote:\nThis will not overwrite any of the existing files.\nTo overwrite, re-run with --force.\n")
+            CliStatus.info("This will not overwrite any of the existing files. To overwrite, re-run with --force.")
+        print()
         if not sys.stdin.isatty():
             return True
         try:
@@ -282,12 +285,13 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
             questionary.Separator(),
             questionary.Choice(title=[("class:action", f"All ({total})")], value=ALL),
             questionary.Choice(title=[("class:action", "Custom selection")], value=CUSTOM),
-            questionary.Choice(title=[("class:action", "From File")], value=FROM_FILE),
+            questionary.Separator(),
+            questionary.Choice(title=[("class:from-file", "From File")], value=FROM_FILE),
         ]
         question = questionary.select(
             "What do you want to import?",
             choices=choices,
-            style=questionary.Style([("action", "fg:#5fafd7 italic")]),
+            style=questionary.Style([("action", "fg:#5fafd7"), ("from-file", "fg:#d7875f")]),
         )
         return CliPrompt.bind_exit_on_esc(question).ask()
 
@@ -362,13 +366,16 @@ class ImportCommand:  # pylint: disable=too-few-public-methods
     @staticmethod
     def _confirm_import(selected: List[str], force: bool = False) -> bool:
         """Show the final list + a non-overwrite note, then ask y/N. Non-TTY auto-confirms."""
-        print("\nNetworks to import:")
+        print()
+        CliStatus.info("Networks to import:")
         for path in selected:
             print(f"  - {path}")
+        print()
         if force:
-            print("\nNote:\n--force is set: existing files in the target will be OVERWRITTEN.\n")
+            CliStatus.warn("--force is set: existing files in the target will be OVERWRITTEN.")
         else:
-            print("\nNote:\nThis will not overwrite any of the existing files.\nTo overwrite, re-run with --force.\n")
+            CliStatus.info("This will not overwrite any of the existing files. To overwrite, re-run with --force.")
+        print()
         if not sys.stdin.isatty():
             return True
         try:

--- a/neuro_san_studio/utils/cli_prompt.py
+++ b/neuro_san_studio/utils/cli_prompt.py
@@ -1,0 +1,82 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Shared key-binding helpers for questionary prompts.
+
+Esc is bound ``eager=True`` so the binding fires on a bare Escape press without
+waiting out the prompt_toolkit Esc-as-meta-prefix timeout. Composite keys (arrow
+keys, etc.) arrive at prompt_toolkit pre-assembled by the terminal, so they
+aren't affected by the eager binding.
+"""
+
+from typing import Any
+
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding import merge_key_bindings
+from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+from prompt_toolkit.keys import Keys
+
+
+class CliPrompt:
+    """Bind extra keys onto a ``questionary`` prompt before ``.ask()`` is called.
+
+    Two flavours:
+
+    - :py:meth:`bind_back_keys` — ← / Esc resolve a sub-menu prompt to a caller-supplied
+      back sentinel. The two keys play the same role ("go back one screen") so they
+      share a binding entry-point.
+    - :py:meth:`bind_exit_on_esc` — Esc resolves a top-level prompt to :data:`EXIT`,
+      meaning "abort the entire flow". Use on screens where there's nothing to back up
+      to (top menu, final confirm).
+    """
+
+    EXIT = "__exit__"
+
+    @classmethod
+    def bind_back_keys(cls, question: Any, back_sentinel: str) -> Any:
+        """Bind ← and Esc → ``back_sentinel`` on a sub-menu prompt. Returns ``question``."""
+        cls._bind(question, Keys.Left, back_sentinel)
+        cls._bind(question, Keys.Escape, back_sentinel, eager=True)
+        return question
+
+    @classmethod
+    def bind_exit_on_esc(cls, question: Any) -> Any:
+        """Bind Esc → :data:`EXIT` on a prompt with no back target. Returns ``question``."""
+        cls._bind(question, Keys.Escape, cls.EXIT, eager=True)
+        return question
+
+    @staticmethod
+    def _bind(question: Any, key: Keys, sentinel: str, *, eager: bool = False) -> None:
+        """Register ``key`` to resolve the prompt to ``sentinel`` via ``event.app.exit``.
+
+        Some questionary prompts (e.g. ``confirm``) expose a read-only ``_MergedKeyBindings``
+        on their application — we can't ``.add`` to that directly. Build a fresh writable
+        registry, merge it on top of whatever's there, and reassign. This works uniformly
+        for both writable and read-only registries.
+        """
+        extra = KeyBindings()
+        registrar = extra.add(key, eager=eager)
+        registrar(lambda event: CliPrompt._resolve(event, sentinel))
+        # Order matters: put our extra first so it wins over any existing handler for
+        # the same key. (questionary.confirm already binds Esc to "no answer / None"; we
+        # want our EXIT sentinel to take precedence so the caller can distinguish.)
+        existing = question.application.key_bindings
+        question.application.key_bindings = merge_key_bindings([extra, existing]) if existing else extra
+
+    @staticmethod
+    def _resolve(event: KeyPressEvent, sentinel: str) -> None:
+        """Resolve the prompt to ``sentinel`` (questionary returns this from ``ask()``)."""
+        event.app.exit(result=sentinel)

--- a/tests/neuro_san_studio/commands/test_export_networks.py
+++ b/tests/neuro_san_studio/commands/test_export_networks.py
@@ -40,12 +40,23 @@ def _scaffold_project(project_dir: Path) -> None:
     )
 
 
+class _StubApplication:  # pylint: disable=too-few-public-methods
+    """Just enough of questionary's application surface for the Esc-binding helper to attach."""
+
+    def __init__(self) -> None:
+        # pylint: disable-next=import-outside-toplevel
+        from prompt_toolkit.key_binding import KeyBindings
+
+        self.key_bindings = KeyBindings()
+
+
 class _StubQuestion:  # pylint: disable=too-few-public-methods
     """Stand-in for ``questionary.select(...)`` — captures the choices and returns a preset value."""
 
     def __init__(self, return_value: Optional[str], capture: dict) -> None:
         self._return_value = return_value
         self._capture = capture
+        self.application = _StubApplication()
 
     def ask(self) -> Optional[str]:
         """Return the preset value, mimicking questionary's blocking ask()."""
@@ -117,6 +128,9 @@ class TestInteractivePicker:
 
         class _RaisingQuestion:  # pylint: disable=too-few-public-methods
             """Stub questionary object whose ask() raises KeyboardInterrupt."""
+
+            def __init__(self) -> None:
+                self.application = _StubApplication()
 
             def ask(self):
                 """Simulate Ctrl-C at the prompt."""


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description
Small UX polish for `ns import` / `ns export`:
- Esc to exit / go back: Pressing Esc on a top-level prompt cleanly exits the command; on a sub-screen it acts like <- and pops back one level. Matches the intuition users have from most TUIs.
- "From File" entry in the import menu: Surfaces the existing `ns import -f` flow as a discoverable top-menu option, with a path prompt that supports tab-completion. Esc on the path prompt returns to the top menu.
- Clearer section headers: Confirmation screens now lead each section with a `[info]` / `[warn]` prefix so they line up visually with the rest of the CLI's output style.

### Fixes #1083 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
