### PR TITLE
fix: preserve user-selected provider order during ns init (#1076)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ Skip the prompt with `--providers`:
 ns init --providers openai,anthropic,google
 ```
 
+Providers are written in the order you select them. The first becomes the primary model and the rest
+become ordered fallbacks; OpenAI is used only as the default when no selection is made.
+
 #### 3. Set your API key
 
 Set your provider key, e.g. `OPENAI_API_KEY` (or create a `.env` file in the current directory).

--- a/neuro_san_studio/commands/init.py
+++ b/neuro_san_studio/commands/init.py
@@ -167,7 +167,17 @@ class InitCommand:  # pylint: disable=too-few-public-methods
         which extracts the ``fallbacks`` list and iterates it in order. The first
         entry resolves as the primary model; subsequent entries are tried in
         order on failure. See ``docs/examples/basic/music_nerd_llm_fallbacks.md``.
+
+        Raises:
+            ValueError: If ``providers`` is empty. An empty list would render an
+                empty ``fallbacks`` array, which the runtime rejects with "No
+                fully-specified LLM found". Every caller path already guarantees
+                at least one provider; this guard makes the contract explicit so
+                a future caller cannot scaffold an unbootable project.
         """
+        if not providers:
+            raise ValueError("_render_llm_config requires at least one provider.")
+
         if len(providers) == 1:
             model = PROVIDERS[providers[0]]["model_name"]
             return '{\n    "llm_config": {\n        "model_name": "' + model + '"\n    }\n}\n'

--- a/neuro_san_studio/commands/init.py
+++ b/neuro_san_studio/commands/init.py
@@ -156,22 +156,19 @@ class InitCommand:  # pylint: disable=too-few-public-methods
     def _render_llm_config(providers: List[str]) -> str:
         """Render config/llm_config.hocon for the selected providers.
 
-        Ordering: if OpenAI is selected, it is promoted to first position. Otherwise
-        providers are emitted in user-selected order.
+        Providers are emitted in user-selected order: the first provider becomes
+        the primary model, and any subsequent providers become its fallbacks in
+        the order the user listed them. With a single provider, a flat
+        ``model_name`` block is rendered instead of a ``fallbacks`` list.
         """
-        ordered = providers[:]
-        if "openai" in ordered and ordered[0] != "openai":
-            ordered.remove("openai")
-            ordered.insert(0, "openai")
-
-        if len(ordered) == 1:
-            model = PROVIDERS[ordered[0]]["model_name"]
+        if len(providers) == 1:
+            model = PROVIDERS[providers[0]]["model_name"]
             return '{\n    "llm_config": {\n        "model_name": "' + model + '"\n    }\n}\n'
 
         lines = ["{", '    "llm_config": {', '        "fallbacks": [']
-        for i, key in enumerate(ordered):
+        for i, key in enumerate(providers):
             model = PROVIDERS[key]["model_name"]
-            comma = "," if i < len(ordered) - 1 else ""
+            comma = "," if i < len(providers) - 1 else ""
             lines.append(f'            {{ "model_name": "{model}" }}{comma}')
         lines.extend(["        ]", "    }", "}", ""])
         return "\n".join(lines)

--- a/neuro_san_studio/commands/init.py
+++ b/neuro_san_studio/commands/init.py
@@ -160,6 +160,13 @@ class InitCommand:  # pylint: disable=too-few-public-methods
         the primary model, and any subsequent providers become its fallbacks in
         the order the user listed them. With a single provider, a flat
         ``model_name`` block is rendered instead of a ``fallbacks`` list.
+
+        Runtime semantics: this matches the shape of
+        ``registries/basic/music_nerd_llm_fallbacks.hocon``. The neuro-san agent
+        chain reads it via ``langchain_run_context.create_agent_with_fallbacks``,
+        which extracts the ``fallbacks`` list and iterates it in order. The first
+        entry resolves as the primary model; subsequent entries are tried in
+        order on failure. See ``docs/examples/basic/music_nerd_llm_fallbacks.md``.
         """
         if len(providers) == 1:
             model = PROVIDERS[providers[0]]["model_name"]

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -21,6 +21,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from pyhocon import ConfigFactory
 from pytest import MonkeyPatch
 
 from neuro_san_studio.commands import init as init_module
@@ -212,6 +213,33 @@ class TestRunFlow:
         InitCommand(providers_arg=None, root_dir=str(tmp_path)).run()
         llm_config = (tmp_path / "config" / "llm_config.hocon").read_text()
         assert llm_config.index("claude-sonnet") < llm_config.index("gpt-5.2")
+
+    def test_parsed_fallbacks_first_entry_is_user_primary(self, tmp_path: Path) -> None:
+        """Behavioral regression for #1076: parse the generated config the same
+        way the agent chain does and assert ``fallbacks[0]`` is the user's
+        first-selected provider.
+
+        The runtime path is ``langchain_run_context.create_agent_with_fallbacks``,
+        which extracts ``fallbacks`` from the parsed ``llm_config`` and iterates
+        it; the first entry is treated as primary. Asserting that here gives a
+        higher-fidelity check than substring ordering in the rendered text.
+        """
+        InitCommand(providers_arg="anthropic,openai", root_dir=str(tmp_path)).run()
+        raw = (tmp_path / "config" / "llm_config.hocon").read_text()
+        parsed_llm_config = ConfigFactory.parse_string(raw)["llm_config"]
+        fallbacks = [dict(fb) for fb in parsed_llm_config["fallbacks"]]
+        assert fallbacks[0]["model_name"] == "claude-sonnet"
+        assert fallbacks[1]["model_name"] == "gpt-5.2"
+
+    def test_parsed_fallbacks_three_provider_order_preserved(self, tmp_path: Path) -> None:
+        """Behavioral regression for #1076: a three-provider selection preserves
+        order through HOCON parsing into the runtime ``fallbacks`` list.
+        """
+        InitCommand(providers_arg="google,anthropic,openai", root_dir=str(tmp_path)).run()
+        raw = (tmp_path / "config" / "llm_config.hocon").read_text()
+        parsed_llm_config = ConfigFactory.parse_string(raw)["llm_config"]
+        fallbacks = [dict(fb) for fb in parsed_llm_config["fallbacks"]]
+        assert [fb["model_name"] for fb in fallbacks] == ["gemini-3-flash", "claude-sonnet", "gpt-5.2"]
 
     def test_run_interactive_empty_input_defaults_to_openai(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """Pressing enter at the prompt should accept the default (OpenAI)."""

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -114,6 +114,29 @@ class TestLlmConfigRendering:
         rendered = InitCommand._render_llm_config(["google", "anthropic"])
         assert rendered.index("gemini-3-flash") < rendered.index("claude-sonnet")
 
+    def test_two_provider_openai_already_first_unchanged(self) -> None:
+        """Boundary for #1076: when OpenAI is already first, order is unchanged.
+
+        The removed promotion only fired when OpenAI was selected but not first
+        (``ordered[0] != "openai"``); this pins the symmetric case where the
+        promotion was always a no-op, so a future reintroduction is caught.
+        """
+        # pylint: disable=protected-access
+        rendered = InitCommand._render_llm_config(["openai", "google"])
+        fallbacks = [dict(fb) for fb in ConfigFactory.parse_string(rendered)["llm_config"]["fallbacks"]]
+        assert [fb["model_name"] for fb in fallbacks] == ["gpt-5.2", "gemini-3-flash"]
+
+    def test_empty_providers_raises(self) -> None:
+        """An empty provider list must raise rather than render an empty fallbacks array.
+
+        An empty ``fallbacks`` list is syntactically valid HOCON but the neuro-san
+        runtime rejects it with "No fully-specified LLM found"; the guard turns a
+        silent unbootable-project footgun into an explicit error.
+        """
+        # pylint: disable=protected-access
+        with pytest.raises(ValueError, match="at least one provider"):
+            InitCommand._render_llm_config([])
+
 
 class TestRunFlow:
     """Tests for the full InitCommand.run() flow."""
@@ -240,6 +263,51 @@ class TestRunFlow:
         parsed_llm_config = ConfigFactory.parse_string(raw)["llm_config"]
         fallbacks = [dict(fb) for fb in parsed_llm_config["fallbacks"]]
         assert [fb["model_name"] for fb in fallbacks] == ["gemini-3-flash", "claude-sonnet", "gpt-5.2"]
+
+    def test_issue_1076_interactive_2_1_parsed_anthropic_first(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        """Behavioral regression for #1076 at the parsed layer: the exact ``2,1``
+        keystrokes from the issue must yield ``fallbacks == [anthropic, openai]``
+        once the generated HOCON is parsed the way the agent chain parses it.
+
+        This raises the issue's literal reproduction from substring ordering
+        (``test_run_interactive_anthropic_first_preserves_order``) to the
+        structural layer the runtime actually reads.
+        """
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(init_module, "timedinput", lambda *_a, **_kw: "2,1")
+        InitCommand(providers_arg=None, root_dir=str(tmp_path)).run()
+        raw = (tmp_path / "config" / "llm_config.hocon").read_text()
+        parsed_llm_config = ConfigFactory.parse_string(raw)["llm_config"]
+        models = [dict(fb)["model_name"] for fb in parsed_llm_config["fallbacks"]]
+        assert models == ["claude-sonnet", "gpt-5.2"]
+
+    def test_single_provider_parsed_is_flat_no_fallbacks(self, tmp_path: Path) -> None:
+        """Regression guard for the untouched single-provider branch.
+
+        The runtime wraps a flat ``llm_config`` as a one-entry fallback list via
+        ``llm_config.get("fallbacks", [llm_config])``; an accidental ``fallbacks``
+        wrap or a stray ``class`` key here would change resolution. Asserts the
+        parsed shape rather than substrings.
+        """
+        InitCommand(providers_arg="openai", root_dir=str(tmp_path)).run()
+        raw = (tmp_path / "config" / "llm_config.hocon").read_text()
+        parsed_llm_config = ConfigFactory.parse_string(raw)["llm_config"]
+        assert parsed_llm_config["model_name"] == "gpt-5.2"
+        assert "fallbacks" not in parsed_llm_config
+        assert "class" not in parsed_llm_config
+
+    def test_multi_provider_has_no_top_level_model_name(self, tmp_path: Path) -> None:
+        """Multi-provider config must rely solely on the ``fallbacks`` list.
+
+        A stray top-level ``model_name`` would be read as a default by any
+        consumer that does not enter the fallback loop (the exact misread that
+        made the original review believe the fix was cosmetic).
+        """
+        InitCommand(providers_arg="anthropic,openai", root_dir=str(tmp_path)).run()
+        raw = (tmp_path / "config" / "llm_config.hocon").read_text()
+        parsed_llm_config = ConfigFactory.parse_string(raw)["llm_config"]
+        assert "model_name" not in parsed_llm_config
+        assert "fallbacks" in parsed_llm_config
 
     def test_run_interactive_empty_input_defaults_to_openai(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """Pressing enter at the prompt should accept the default (OpenAI)."""

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -87,11 +87,25 @@ class TestLlmConfigRendering:
         assert openai_pos < anthropic_pos < google_pos
         assert '"class"' not in rendered
 
-    def test_openai_promoted_to_front_of_fallbacks(self) -> None:
-        """Even if OpenAI is selected last, it should lead the fallback list."""
+    def test_user_order_preserved_when_openai_not_first(self) -> None:
+        """Regression test for #1076: user-selected order must be honored.
+
+        Earlier behavior auto-promoted OpenAI to position 0 even when the user
+        explicitly listed it last; this asserts the fix that respects the
+        user's order.
+        """
         # pylint: disable=protected-access
         rendered = InitCommand._render_llm_config(["anthropic", "openai"])
-        assert rendered.index("gpt-5.2") < rendered.index("claude-sonnet")
+        assert rendered.index("claude-sonnet") < rendered.index("gpt-5.2")
+
+    def test_three_provider_order_preserved_with_openai_last(self) -> None:
+        """Regression test for #1076: arbitrary three-provider order is preserved."""
+        # pylint: disable=protected-access
+        rendered = InitCommand._render_llm_config(["google", "anthropic", "openai"])
+        google_pos = rendered.index("gemini-3-flash")
+        anthropic_pos = rendered.index("claude-sonnet")
+        openai_pos = rendered.index("gpt-5.2")
+        assert google_pos < anthropic_pos < openai_pos
 
     def test_non_openai_order_preserved(self) -> None:
         """Without OpenAI, the user's order should be preserved."""
@@ -179,6 +193,25 @@ class TestRunFlow:
         assert '"fallbacks"' in llm_config
         assert "gpt-5.2" in llm_config
         assert "claude-sonnet" in llm_config
+
+    def test_run_providers_arg_preserves_anthropic_first(self, tmp_path: Path) -> None:
+        """Regression test for #1076: ``--providers anthropic,openai`` yields Anthropic-first config."""
+        InitCommand(providers_arg="anthropic,openai", root_dir=str(tmp_path)).run()
+        llm_config = (tmp_path / "config" / "llm_config.hocon").read_text()
+        assert llm_config.index("claude-sonnet") < llm_config.index("gpt-5.2")
+
+    def test_run_interactive_anthropic_first_preserves_order(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        """Regression test for #1076: interactive selection ``2,1`` yields Anthropic-first config.
+
+        Mirrors the exact reproduction steps in the issue: pick Anthropic (2)
+        then OpenAI (1) at the prompt, and confirm the generated fallback file
+        lists Anthropic before OpenAI.
+        """
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(init_module, "timedinput", lambda *_a, **_kw: "2,1")
+        InitCommand(providers_arg=None, root_dir=str(tmp_path)).run()
+        llm_config = (tmp_path / "config" / "llm_config.hocon").read_text()
+        assert llm_config.index("claude-sonnet") < llm_config.index("gpt-5.2")
 
     def test_run_interactive_empty_input_defaults_to_openai(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """Pressing enter at the prompt should accept the default (OpenAI)."""


### PR DESCRIPTION
## Description

The `ns init` interactive prompt and `--providers` flag accept multiple LLM providers in user-selected order, but `_render_llm_config()` then auto-promoted OpenAI to position 0 of the generated `fallbacks` list. As a result, picking Anthropic (2) then OpenAI (1) at the prompt produced a config where OpenAI was the primary model and Anthropic the fallback. That is the inverse of the user's expressed preference.

This PR drops the OpenAI-first promotion and emits providers in the order the user selected. OpenAI remains the default for non-interactive runs and empty prompt input. Only **explicit** selections are now honored verbatim.

Fixes #1076

## Runtime semantics and verification

The generated file uses the fallbacks-only shape, matching `registries/basic/music_nerd_llm_fallbacks.hocon` (the canonical example) and the contract in `docs/examples/basic/music_nerd_llm_fallbacks.md`: *"The list is ordered, and the first LLM that succeeds will be used."*

The runtime path is `langchain_run_context.create_agent_with_fallbacks` in the `neuro-san` library: it reads `llm_config.fallbacks`, iterates the list in order, and treats the first entry as the primary model. So `fallbacks=[{model_name: claude-sonnet}, {model_name: gpt-5.2}]` resolves Anthropic as primary.

Verified end-to-end through three independent paths for the `anthropic,openai` selection, each resolving `class=anthropic` (`claude-sonnet-4-6`) as primary:

1. The agent-chain fallback loop (`create_agent_with_fallbacks`).
2. A loaded `DefaultLlmFactory` resolving `fallbacks[0]`.
3. The `ns check-config` command's own extraction logic (`extract_llm_configs_from_studio_config` plus `create_and_load_llm_factory`).

Note for reviewers: calling `DefaultLlmFactory.create_full_llm_config` on the **entire** `llm_config` dict (rather than on each `fallbacks` entry) bypasses the chain's iteration and falls through to `default_config`'s `model_name`, which is OpenAI. That is the wrong layer to verify runtime behavior at; the fallback loop is the right one.

## Impact

Behavior change is scoped to the `config/llm_config.hocon` file generated by `ns init` when more than one provider is selected:

- **Before:** Selection `2,1` (Anthropic, OpenAI) -> fallbacks `[OpenAI, Anthropic]`
- **After:** Selection `2,1` (Anthropic, OpenAI) -> fallbacks `[Anthropic, OpenAI]`

No effect on the single-provider path, the empty-input default, the non-TTY default, or any other CLI command. No new dependencies. No template changes.

## Screenshots / Logs / Examples

`ns check-config` expansion of the generated `anthropic,openai` config, with each entry resolved through the framework factory:

\`\`\`text
llm_config.hocon (fallback 0): {'model_name': 'claude-sonnet'}  -> class=anthropic, model=claude-sonnet-4-6   (PRIMARY)
llm_config.hocon (fallback 1): {'model_name': 'gpt-5.2'}        -> class=openai,    model=gpt-5.2-2025-12-11   (fallback)
\`\`\`

End-to-end behavioral check across selections:

\`\`\`text
[PASS] --providers='anthropic,openai':         runtime primary = anthropic
[PASS] --providers='google,anthropic,openai':  runtime primary = gemini
[PASS] --providers='openai,anthropic':         runtime primary = openai
\`\`\`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally. 34/34 pass in `tests/neuro_san_studio/commands/test_init.py`. `ruff format --check` and `ruff check` are clean on the `make lint-check` SOURCES + TESTS scope (`apps`, `coded_tools`, `middleware`, `neuro_san_studio`, `tests`). `pylint` is 10.00/10 on both touched source/test files. `pymarkdown` scan of `README.md` is clean.
- [x] Added/updated tests. Flipped the test that locked in the broken behavior; added regression tests covering string ordering, the `--providers` flag path, the interactive prompt with the exact `2,1` keystrokes from the issue, and parsed-HOCON behavioral tests at the runtime extraction layer (`fallbacks[0]` is the user's primary; multi-provider config has no top-level `model_name`; single-provider stays a flat block). Added a boundary test for the openai-already-first no-op and a guard test for the empty-providers case.
- [x] Updated relevant documentation. Added an order-preservation note to the `ns init` quickstart in `README.md`, and documented the runtime semantics in the `_render_llm_config` docstring with a pointer to `docs/examples/basic/music_nerd_llm_fallbacks.md`.
- [ ] Added dependencies to appropriate `requirements.txt`. No dependency changes.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**