### PR TITLE
fix: use logger instead of print in run.py (#994)

### DIFF
--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -52,12 +52,13 @@ class NeuroSanRunner:
     def __init__(self):
         """Initialize configuration and parse CLI arguments."""
         self._logger = logging.getLogger(self.__class__.__name__)
+        self._configure_logging()
         self.is_windows = os.name == "nt"
         self.root_dir = os.getcwd()
         self.logs_dir = os.path.join(self.root_dir, "logs")
         self.thinking_file = os.path.join(self.logs_dir, "agent_thinking.txt")
         self.thinking_dir = os.path.join(self.logs_dir, "thinking_dir")
-        print(f"Root directory: {self.root_dir}")
+        self._logger.info("Root directory: %s", self.root_dir)
         # Load environment variables from .env file
         self.load_env_variables()
 
@@ -109,6 +110,22 @@ class NeuroSanRunner:
         self.server_process = None
         self.nsflow_process = None
 
+    @staticmethod
+    def _configure_logging() -> None:
+        """Install a basic root console handler so runner output is visible.
+
+        Runner messages are emitted through ``self._logger`` so they honor the
+        logging configuration (level, formatter, and the ProcessLogBridge rich
+        handler) instead of going straight to stdout. Without this bootstrap the
+        earliest messages, logged before the plugin layer configures the root
+        logger, would be dropped because the root logger defaults to WARNING with
+        no handler. ``basicConfig`` is idempotent: it only adds a handler when the
+        root logger has none, and the ProcessLogBridge later calls
+        ``root.handlers.clear()`` before installing its rich handler, so this
+        hands off cleanly without duplicate output.
+        """
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
+
     def _apply_toolbox_env(self) -> None:
         """Export AGENT_TOOLBOX_INFO_FILE only if a user-provided toolbox path is configured.
 
@@ -118,9 +135,9 @@ class NeuroSanRunner:
         toolbox_file = self.args["agent_toolbox_info_file"]
         if toolbox_file:
             os.environ["AGENT_TOOLBOX_INFO_FILE"] = toolbox_file
-            print(f"AGENT_TOOLBOX_INFO_FILE set to: {toolbox_file}")
+            self._logger.info("AGENT_TOOLBOX_INFO_FILE set to: %s", toolbox_file)
         else:
-            print("AGENT_TOOLBOX_INFO_FILE: (not set — using built-in default toolbox)")
+            self._logger.info("AGENT_TOOLBOX_INFO_FILE: (not set, using built-in default toolbox)")
 
     def _resolve_toolbox_info_file(self) -> str:
         """Resolve the toolbox info file path, or return "" if it should not be exported.
@@ -163,9 +180,9 @@ class NeuroSanRunner:
         env_path = os.path.join(self.root_dir, ".env")
         if os.path.exists(env_path):
             load_dotenv(env_path)
-            print(f"Loaded environment variables from: {env_path}")
+            self._logger.info("Loaded environment variables from: %s", env_path)
         else:
-            print(f"No .env file found at {env_path}. \nUsing defaults.\n")
+            self._logger.info("No .env file found at %s. Using defaults.", env_path)
 
     def parse_args(self):
         """Parses command-line arguments for configuration."""
@@ -244,8 +261,8 @@ class NeuroSanRunner:
 
     def set_environment_variables(self):
         """Set required environment variables, optionally using neuro-san defaults."""
-        print("\n" + "=" * 50 + "\n")
-        print("Setting environment variables...\n")
+        self._logger.info("=" * 50)
+        self._logger.info("Setting environment variables...")
         # Common env variables
         self.set_pythonpath()
         os.environ["AGENT_MANIFEST_FILE"] = self.args["agent_manifest_file"]
@@ -255,44 +272,46 @@ class NeuroSanRunner:
         os.environ["NEURO_SAN_SERVER_CONNECTION"] = self.args["server_connection"]
         os.environ["AGENT_MANIFEST_UPDATE_PERIOD_SECONDS"] = str(self.args["manifest_update_period_seconds"])
         os.environ["LOG_LEVEL"] = self.args["log_level"]
-        print(f"PYTHONPATH set to: {os.environ['PYTHONPATH']}")
-        print(f"AGENT_MANIFEST_FILE set to: {os.environ['AGENT_MANIFEST_FILE']}")
-        print(f"AGENT_TOOL_PATH set to: {os.environ['AGENT_TOOL_PATH']}")
-        print(f"MCP_SERVERS_INFO_FILE set to: {os.environ['MCP_SERVERS_INFO_FILE']}")
-        print(f"NEURO_SAN_SERVER_CONNECTION set to: {os.environ['NEURO_SAN_SERVER_CONNECTION']}")
-        print(f"AGENT_MANIFEST_UPDATE_PERIOD_SECONDS set to: {os.environ['AGENT_MANIFEST_UPDATE_PERIOD_SECONDS']}")
-        print(f"LOG_LEVEL set to: {os.environ['LOG_LEVEL']}\n")
+        self._logger.info("PYTHONPATH set to: %s", os.environ["PYTHONPATH"])
+        self._logger.info("AGENT_MANIFEST_FILE set to: %s", os.environ["AGENT_MANIFEST_FILE"])
+        self._logger.info("AGENT_TOOL_PATH set to: %s", os.environ["AGENT_TOOL_PATH"])
+        self._logger.info("MCP_SERVERS_INFO_FILE set to: %s", os.environ["MCP_SERVERS_INFO_FILE"])
+        self._logger.info("NEURO_SAN_SERVER_CONNECTION set to: %s", os.environ["NEURO_SAN_SERVER_CONNECTION"])
+        self._logger.info(
+            "AGENT_MANIFEST_UPDATE_PERIOD_SECONDS set to: %s", os.environ["AGENT_MANIFEST_UPDATE_PERIOD_SECONDS"]
+        )
+        self._logger.info("LOG_LEVEL set to: %s", os.environ["LOG_LEVEL"])
 
         # Client-only env variables
         if not self.args["server_only"]:
             os.environ["THINKING_FILE"] = self.args["thinking_file"]
             os.environ["THINKING_DIR"] = self.args["thinking_dir"]
-            print(f"THINKING_FILE set to: {os.environ['THINKING_FILE']}")
-            print(f"THINKING_DIR set to: {os.environ['THINKING_DIR']}")
+            self._logger.info("THINKING_FILE set to: %s", os.environ["THINKING_FILE"])
+            self._logger.info("THINKING_DIR set to: %s", os.environ["THINKING_DIR"])
             os.environ["NSFLOW_HOST"] = str(self.args["nsflow_host"])
             os.environ["NSFLOW_PORT"] = str(self.args["nsflow_port"])
             os.environ["NSFLOW_PLUGIN_CRUSE"] = str(self.args["nsflow_plugin_cruse"])
             os.environ["VITE_API_PROTOCOL"] = str(self.args["vite_api_protocol"])
             os.environ["VITE_WS_PROTOCOL"] = str(self.args["vite_ws_protocol"])
-            print(f"NSFLOW_HOST set to: {os.environ['NSFLOW_HOST']}")
-            print(f"NSFLOW_PORT set to: {os.environ['NSFLOW_PORT']}")
-            print(f"NSFLOW_PLUGIN_CRUSE set to: {os.environ['NSFLOW_PLUGIN_CRUSE']}")
-            print(f"VITE_API_PROTOCOL set to: {os.environ['VITE_API_PROTOCOL']}")
-            print(f"VITE_WS_PROTOCOL set to: {os.environ['VITE_WS_PROTOCOL']}")
+            self._logger.info("NSFLOW_HOST set to: %s", os.environ["NSFLOW_HOST"])
+            self._logger.info("NSFLOW_PORT set to: %s", os.environ["NSFLOW_PORT"])
+            self._logger.info("NSFLOW_PLUGIN_CRUSE set to: %s", os.environ["NSFLOW_PLUGIN_CRUSE"])
+            self._logger.info("VITE_API_PROTOCOL set to: %s", os.environ["VITE_API_PROTOCOL"])
+            self._logger.info("VITE_WS_PROTOCOL set to: %s", os.environ["VITE_WS_PROTOCOL"])
             # Set env variable for using nsflow in client-only mode
             if self.args["client_only"]:
                 os.environ["NSFLOW_CLIENT_ONLY"] = "True"
-                print(f"NSFLOW_CLIENT_ONLY set to: {os.environ['NSFLOW_CLIENT_ONLY']}")
+                self._logger.info("NSFLOW_CLIENT_ONLY set to: %s", os.environ["NSFLOW_CLIENT_ONLY"])
 
         # Server-only env variables
         if not self.args["client_only"]:
             os.environ["NEURO_SAN_SERVER_HOST"] = self.args["server_host"]
             os.environ["NEURO_SAN_SERVER_HTTP_PORT"] = str(self.args["server_http_port"])
 
-            print(f"NEURO_SAN_SERVER_HOST set to: {os.environ['NEURO_SAN_SERVER_HOST']}")
-            print(f"NEURO_SAN_SERVER_HTTP_PORT set to: {os.environ['NEURO_SAN_SERVER_HTTP_PORT']}\n")
+            self._logger.info("NEURO_SAN_SERVER_HOST set to: %s", os.environ["NEURO_SAN_SERVER_HOST"])
+            self._logger.info("NEURO_SAN_SERVER_HTTP_PORT set to: %s", os.environ["NEURO_SAN_SERVER_HTTP_PORT"])
 
-        print("\n" + "=" * 50 + "\n")
+        self._logger.info("=" * 50)
 
     def start_process(self, command, process_name, log_file):
         """Start a subprocess and capture logs."""
@@ -319,7 +338,7 @@ class NeuroSanRunner:
                 start_new_session=True,
             )
 
-        print(f"Started {process_name} with PID {process.pid}")
+        self._logger.info("Started %s with PID %s", process_name, process.pid)
 
         for plugin in self.plugins:
             plugin.args["process_name"] = process_name
@@ -331,7 +350,7 @@ class NeuroSanRunner:
 
     def start_neuro_san(self):
         """Start the Neuro SAN server."""
-        print("Starting Neuro SAN server...")
+        self._logger.info("Starting Neuro SAN server...")
         command = [
             sys.executable,
             "-u",
@@ -341,11 +360,11 @@ class NeuroSanRunner:
             str(self.args["server_http_port"]),
         ]
         self.server_process = self.start_process(command, "NeuroSan", "logs/server.log")
-        print("NeuroSan server http started on port: ", self.args["server_http_port"])
+        self._logger.info("NeuroSan server http started on port: %s", self.args["server_http_port"])
 
     def start_nsflow(self):
         """Start nsflow client."""
-        print("Starting nsflow client...")
+        self._logger.info("Starting nsflow client...")
         command = [
             sys.executable,
             "-u",
@@ -360,15 +379,15 @@ class NeuroSanRunner:
         ]
 
         self.nsflow_process = self.start_process(command, "nsflow", "logs/nsflow.log")
-        print(f"nsflow client started on {self.args['nsflow_host']}:{self.args['nsflow_port']}")
+        self._logger.info("nsflow client started on %s:%s", self.args["nsflow_host"], self.args["nsflow_port"])
 
     # pylint: disable=unused-argument
     def signal_handler(self, signum, frame):
         """Handle termination signals to cleanly exit."""
-        print("\nTermination signal received. Stopping all processes...")
+        self._logger.info("Termination signal received. Stopping all processes...")
 
         if self.server_process:
-            print(f"\nStopping SERVER (PID {self.server_process.pid})...")
+            self._logger.info("Stopping SERVER (PID %s)...", self.server_process.pid)
             if self.is_windows:
                 self.server_process.terminate()
             else:
@@ -377,7 +396,7 @@ class NeuroSanRunner:
             self.server_process.wait(timeout=10)
 
         if self.nsflow_process:
-            print(f"Stopping NSFLOW (PID {self.nsflow_process.pid})...")
+            self._logger.info("Stopping NSFLOW (PID %s)...", self.nsflow_process.pid)
             if self.is_windows:
                 self.nsflow_process.terminate()
             else:
@@ -423,7 +442,7 @@ class NeuroSanRunner:
     def _kill_processes_on_ports(self, ports: list[int]):
         """Kill processes using the specified ports."""
         for port in ports:
-            print(f"Attempting to kill process on port {port}...")
+            self._logger.info("Attempting to kill process on port %s...", port)
             try:
                 if self.is_windows:
                     # Windows: Find and kill process using netstat and taskkill
@@ -434,7 +453,7 @@ class NeuroSanRunner:
                         if f":{port}" in line and "LISTENING" in line:
                             pid = line.strip().split()[-1]
                             subprocess.run(["taskkill", "/F", "/PID", pid], check=True)
-                            print(f"  Killed process {pid} on port {port}")
+                            self._logger.info("Killed process %s on port %s", pid, port)
                             break
                 else:
                     # Unix/Mac: Use lsof to find and kill process
@@ -443,13 +462,13 @@ class NeuroSanRunner:
                         pids = result.stdout.strip().split("\n")
                         for pid in pids:
                             subprocess.run(["kill", "-9", pid], check=True)
-                            print(f"  Killed process {pid} on port {port}")
+                            self._logger.info("Killed process %s on port %s", pid, port)
                     else:
-                        print(f"  No process found on port {port}")
+                        self._logger.info("No process found on port %s", port)
             except subprocess.CalledProcessError as e:
-                print(f"  Failed to kill process on port {port}: {e}")
+                self._logger.warning("Failed to kill process on port %s: %s", port, e)
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"  Error handling port {port}: {e}")
+                self._logger.error("Error handling port %s: %s", port, e)
 
     def _validate_yes_no_input(self, prompt: str, max_attempts: int = 3) -> bool:
         """Prompt the user for a yes/no answer, validating against a whitelist.
@@ -468,10 +487,10 @@ class NeuroSanRunner:
                 # if there are remaining attempts or gives up otherwise with a 'no'.
                 raw = timedinput(prompt, timeout=INPUT_TIMEOUT_SECONDS, default="").strip().lower()
             except EOFError:
-                print("No input available. Considering the answer is 'no'.")
+                self._logger.warning("No input available. Considering the answer is 'no'.")
                 return False
             except KeyboardInterrupt:
-                print("\nInput interrupted. Considering the answer is 'no'.")
+                self._logger.warning("Input interrupted. Considering the answer is 'no'.")
                 return False
             if raw in valid_yes:
                 return True
@@ -479,8 +498,8 @@ class NeuroSanRunner:
                 return False
             remaining = max_attempts - attempt - 1
             if remaining > 0:
-                print(f"Invalid input. Please enter 'yes' or 'no'. ({remaining} attempt(s) left)")
-        print("Too many invalid responses. Considering the answer is 'no'.")
+                self._logger.warning("Invalid input. Please enter 'yes' or 'no'. (%s attempt(s) left)", remaining)
+        self._logger.warning("Too many invalid responses. Considering the answer is 'no'.")
         return False
 
     def conditional_start_servers(self):
@@ -492,37 +511,38 @@ class NeuroSanRunner:
         server_only = self.args["server_only"]
 
         if client_only and server_only:
-            print("Cannot use --client-only and --server-only together.")
+            self._logger.error("Cannot use --client-only and --server-only together.")
             sys.exit(1)
 
         port_conflicts, conflicting_ports = self._check_port_conflicts()
 
         # Exit early if any conflict is found
         if port_conflicts:
-            print("\n" + "=" * 50)
+            self._logger.warning("=" * 50)
             for msg in port_conflicts:
-                print(msg)
-            print("=" * 50)
+                self._logger.warning(msg)
+            self._logger.warning("=" * 50)
 
             if self._validate_yes_no_input("\nDo you want to kill the processes using these ports? (yes/no): "):
                 self._kill_processes_on_ports(conflicting_ports)
-                print("\nProcesses killed. Continuing with startup...\n")
+                self._logger.info("Processes killed. Continuing with startup...")
             else:
-                print("\nExiting due to port conflicts.\n")
+                self._logger.warning("Exiting due to port conflicts.")
                 sys.exit(1)
 
         if not server_only:
             self.start_nsflow()
-            print("nsflow client is now running.")
+            self._logger.info("nsflow client is now running.")
 
         if not client_only:
             self.start_neuro_san()
             time.sleep(3)
-            print("Neuro-San server is now running.")
+            self._logger.info("Neuro-San server is now running.")
 
     def run(self):
         """Run the Neuro SAN server and a client."""
-        print("\nInitial Run Config:\n" + "\n".join(f"{key}: {value}" for key, value in self.args.items()) + "\n")
+        run_config = "\n".join(f"{key}: {value}" for key, value in self.args.items())
+        self._logger.info("Initial Run Config:\n%s", run_config)
 
         # Set environment variables
         self.set_environment_variables()
@@ -560,10 +580,10 @@ class NeuroSanRunner:
                     log_file = os.path.join(self.logs_dir, f"{name.lower()}.log")
                     simple_logger.attach_process_logger(proc, name, log_file)
 
-        print("\n" + "=" * 50 + "\n")
-        print("All processes now running.")
-        print("Press Ctrl+C to stop any running processes.")
-        print("\n" + "=" * 50 + "\n")
+        self._logger.info("=" * 50)
+        self._logger.info("All processes now running.")
+        self._logger.info("Press Ctrl+C to stop any running processes.")
+        self._logger.info("=" * 50)
 
         # Wait on active processes to finish
         if self.nsflow_process:

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -105,26 +105,84 @@ class NeuroSanRunner:
 
         # Parse command-line arguments
         self.args.update(self.parse_args())
+        # Re-apply the resolved log level now that --log-level has been parsed, so a
+        # CLI override that was not visible during the early bootstrap takes effect.
+        self._apply_log_level(self.args["log_level"])
 
         # Process references
         self.server_process = None
         self.nsflow_process = None
 
     @staticmethod
-    def _configure_logging() -> None:
-        """Install a basic root console handler so runner output is visible.
+    def _resolve_log_level(level_name: str) -> int:
+        """Map a log-level name (e.g. "warning") to its logging level int, defaulting to INFO."""
+        return getattr(logging, str(level_name).upper(), logging.INFO)
 
-        Runner messages are emitted through ``self._logger`` so they honor the
-        logging configuration (level, formatter, and the ProcessLogBridge rich
-        handler) instead of going straight to stdout. Without this bootstrap the
-        earliest messages, logged before the plugin layer configures the root
-        logger, would be dropped because the root logger defaults to WARNING with
-        no handler. ``basicConfig`` is idempotent: it only adds a handler when the
-        root logger has none, and the ProcessLogBridge later calls
-        ``root.handlers.clear()`` before installing its rich handler, so this
-        hands off cleanly without duplicate output.
+    @staticmethod
+    def _early_log_level() -> str:
+        """Resolve the requested log level before argparse runs.
+
+        Scans sys.argv for --log-level so even the earliest startup messages
+        honor a CLI override, falling back to the LOG_LEVEL env var and finally
+        "info". The full argparse pass later re-applies the resolved level.
         """
-        logging.basicConfig(level=logging.INFO, format="%(message)s")
+        argv = sys.argv[1:]
+        for index, arg in enumerate(argv):
+            if arg == "--log-level" and index + 1 < len(argv):
+                return argv[index + 1]
+            if arg.startswith("--log-level="):
+                return arg.split("=", 1)[1]
+        return os.getenv("LOG_LEVEL", "info")
+
+    def _configure_logging(self) -> None:
+        """Configure root logging so runner output is visible and honors the log level.
+
+        Runner messages are emitted through ``self._logger`` so they are governed
+        by the logging configuration rather than going straight to stdout. This
+        bootstrap runs before argparse, so it resolves the level from
+        ``--log-level`` (scanned from argv) or ``LOG_LEVEL``, and attaches a
+        console handler plus a ``logs/runner.log`` file handler so even the
+        earliest startup messages are captured both on the console and in the
+        runner log. The ProcessLogBridge later calls ``root.handlers.clear()``
+        before installing its rich + rotating-file handlers, so this hands off
+        cleanly without duplicate output. When the root logger is already
+        configured (e.g. by an imported module's ``basicConfig``), only the level
+        is applied so handlers are never stacked.
+        """
+        level = self._resolve_log_level(self._early_log_level())
+        root = logging.getLogger()
+        if root.handlers:
+            root.setLevel(level)
+            return
+
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(logging.Formatter("%(message)s"))
+        root.addHandler(console_handler)
+
+        # Mirror early runner output to logs/runner.log so it is captured before
+        # the ProcessLogBridge installs its own rotating file handler. logs_dir is
+        # derived the same way __init__ derives it, since __init__ has not set the
+        # attribute yet when this runs.
+        logs_dir = os.path.join(os.getcwd(), "logs")
+        try:
+            os.makedirs(logs_dir, exist_ok=True)
+            file_handler = logging.FileHandler(os.path.join(logs_dir, "runner.log"), encoding="utf-8")
+            file_handler.setFormatter(logging.Formatter("%(asctime)s | %(levelname)-8s | %(name)s - %(message)s"))
+            root.addHandler(file_handler)
+        except OSError:
+            # If the logs directory cannot be created, fall back to console only.
+            pass
+
+        root.setLevel(level)
+
+    def _apply_log_level(self, level_name: str) -> None:
+        """Re-apply the resolved log level to the root logger after argparse.
+
+        The early bootstrap resolves the level from argv/env, but a value set via
+        a plugin-contributed flag or normalized during parsing is only known after
+        ``parse_args``; this keeps the root logger in sync with the final value.
+        """
+        logging.getLogger().setLevel(self._resolve_log_level(level_name))
 
     def _apply_toolbox_env(self) -> None:
         """Export AGENT_TOOLBOX_INFO_FILE only if a user-provided toolbox path is configured.

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -176,13 +176,20 @@ class NeuroSanRunner:
         root.setLevel(level)
 
     def _apply_log_level(self, level_name: str) -> None:
-        """Re-apply the resolved log level to the root logger after argparse.
+        """Re-apply the resolved log level after argparse.
 
-        The early bootstrap resolves the level from argv/env, but a value set via
-        a plugin-contributed flag or normalized during parsing is only known after
-        ``parse_args``; this keeps the root logger in sync with the final value.
+        The early bootstrap resolves the level from argv/env, but the final value
+        is only known after ``parse_args``; this keeps the root logger in sync.
+        It also propagates the level to any process-logger plugin (e.g. the
+        ProcessLogBridge) whose console handler was frozen at construction time,
+        before ``--log-level`` was parsed, so console verbosity honors the override
+        even after the plugin reconfigures the root logger on process attach.
         """
         logging.getLogger().setLevel(self._resolve_log_level(level_name))
+        for plugin in getattr(self, "plugins", []):
+            set_console_level = getattr(plugin, "set_console_level", None)
+            if callable(set_console_level):
+                set_console_level(level_name)
 
     def _apply_toolbox_env(self) -> None:
         """Export AGENT_TOOLBOX_INFO_FILE only if a user-provided toolbox path is configured.

--- a/neuro_san_studio/plugins/log_bridge/process_log_bridge.py
+++ b/neuro_san_studio/plugins/log_bridge/process_log_bridge.py
@@ -189,6 +189,19 @@ class ProcessLogBridge(ProcessLoggerInterface):
         self._streams: Dict[Tuple[str, str], Dict[str, Any]] = {}
 
     # ---------- public API ----------
+    def set_console_level(self, level_name: str) -> None:
+        """Update the console (rich) handler level after construction.
+
+        The runner constructs this bridge before argparse runs, so a
+        ``--log-level`` override is not known at construction time. The runner
+        calls this once the level is resolved, so console verbosity honors the
+        requested level even after ``_ensure_root_configured`` installs the rich
+        handler on first process attach. The file handler stays at DEBUG so the
+        runner log keeps full detail regardless of console verbosity.
+        """
+        self.level_name = level_name.upper()
+        self.rich_handler.setLevel(getattr(logging, self.level_name, logging.INFO))
+
     def _ensure_root_configured(self) -> None:
         """Configure the root logger with rich + file handlers (idempotent)."""
         if self._root_configured:

--- a/neuro_san_studio/plugins/log_bridge/process_log_bridge_plugin.py
+++ b/neuro_san_studio/plugins/log_bridge/process_log_bridge_plugin.py
@@ -44,6 +44,17 @@ class ProcessLogBridgePlugin(BasePlugin, ProcessLoggerInterface):
             runner_log_file=self.log_file,
         )
 
+    def set_console_level(self, level_name: str) -> None:
+        """Propagate a resolved log level to the internal ProcessLogBridge.
+
+        Lets the runner honor a ``--log-level`` override that was parsed after
+        this plugin (and its bridge) were constructed.
+
+        Args:
+            level_name: Log-level name (e.g. "warning") for the console handler.
+        """
+        self.log_bridge.set_console_level(level_name)
+
     def attach_process_logger(self, process, process_name: str, log_file: str) -> None:
         """Delegate to the internal ProcessLogBridge instance.
 

--- a/tests/neuro_san_studio/commands/test_run.py
+++ b/tests/neuro_san_studio/commands/test_run.py
@@ -16,27 +16,37 @@
 
 """Tests for NeuroSanRunner."""
 
+import logging
 import os
 from collections.abc import Callable
 from collections.abc import Iterable
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from pytest import CaptureFixture
+from pytest import LogCaptureFixture
 from pytest import MonkeyPatch
 
 from neuro_san_studio.commands import run as run_module
 from neuro_san_studio.commands.run import NeuroSanRunner
 
 
-class TestNeuroSanRunner:
+class TestNeuroSanRunner:  # pylint: disable=too-many-public-methods
     """Tests for NeuroSanRunner"""
 
     @staticmethod
     def _make_runner() -> NeuroSanRunner:
-        """Construct a NeuroSanRunner without invoking its heavy __init__."""
-        return NeuroSanRunner.__new__(NeuroSanRunner)
+        """Construct a NeuroSanRunner without invoking its heavy __init__.
+
+        ``__new__`` skips ``__init__``, so the logger that the real constructor
+        sets up is attached here too: every method now emits through
+        ``self._logger`` rather than ``print``, and would raise AttributeError
+        without it.
+        """
+        runner = NeuroSanRunner.__new__(NeuroSanRunner)
+        runner._logger = logging.getLogger(NeuroSanRunner.__name__)  # pylint: disable=protected-access
+        return runner
 
     @staticmethod
     def _scripted_input(responses: Iterable[str]) -> Callable[..., str]:
@@ -64,19 +74,23 @@ class TestNeuroSanRunner:
         monkeypatch.setattr(run_module, "timedinput", self._scripted_input([response]))
         assert self._make_runner()._validate_yes_no_input("prompt: ") is False
 
-    def test_reprompts_then_accepts_valid(self, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]) -> None:
-        """Test that invalid input triggers a re-prompt before a valid one succeeds."""
-        monkeypatch.setattr(run_module, "timedinput", self._scripted_input(["maybe", "y"]))
-        assert self._make_runner()._validate_yes_no_input("prompt: ") is True
-        captured = capsys.readouterr()
-        assert "Invalid input" in captured.out
+    def test_reprompts_then_accepts_valid(self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
+        """Test that invalid input triggers a re-prompt before a valid one succeeds.
 
-    def test_returns_false_after_max_attempts(self, monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]) -> None:
+        The re-prompt feedback is now logged at WARNING level (it used to print
+        to stdout), so assert against the captured log instead of capsys.
+        """
+        monkeypatch.setattr(run_module, "timedinput", self._scripted_input(["maybe", "y"]))
+        with caplog.at_level(logging.WARNING, logger="NeuroSanRunner"):
+            assert self._make_runner()._validate_yes_no_input("prompt: ") is True
+        assert "Invalid input" in caplog.text
+
+    def test_returns_false_after_max_attempts(self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
         """Test that exhausting all attempts with invalid input returns False."""
         monkeypatch.setattr(run_module, "timedinput", self._scripted_input(["a", "b", "c"]))
-        assert self._make_runner()._validate_yes_no_input("prompt: ") is False
-        captured = capsys.readouterr()
-        assert "Too many invalid responses." in captured.out
+        with caplog.at_level(logging.WARNING, logger="NeuroSanRunner"):
+            assert self._make_runner()._validate_yes_no_input("prompt: ") is False
+        assert "Too many invalid responses." in caplog.text
 
     def test_respects_custom_max_attempts(self, monkeypatch: MonkeyPatch) -> None:
         """Test that max_attempts controls the number of allowed retries."""
@@ -138,7 +152,7 @@ class TestNeuroSanRunner:
         assert result.endswith(os.path.join("neuro_san_studio", "mcp", "mcp_info.hocon"))
 
     def test_set_environment_variables_skips_empty_toolbox(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path, capsys: CaptureFixture[str]
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, caplog: LogCaptureFixture
     ) -> None:
         """set_environment_variables should not export AGENT_TOOLBOX_INFO_FILE when the arg is empty."""
         monkeypatch.setattr(os, "environ", os.environ.copy())
@@ -160,9 +174,10 @@ class TestNeuroSanRunner:
             "thinking_file": str(tmp_path / "thinking.txt"),
             "thinking_dir": str(tmp_path / "thinking"),
         }
-        runner.set_environment_variables()
+        with caplog.at_level(logging.INFO, logger="NeuroSanRunner"):
+            runner.set_environment_variables()
         assert "AGENT_TOOLBOX_INFO_FILE" not in os.environ
-        assert "using built-in default toolbox" in capsys.readouterr().out
+        assert "using built-in default toolbox" in caplog.text
 
     def test_set_environment_variables_exports_toolbox_when_present(
         self, monkeypatch: MonkeyPatch, tmp_path: Path
@@ -201,3 +216,107 @@ class TestNeuroSanRunner:
         monkeypatch.setattr(run_module, "timedinput", _capturing_input)
         self._make_runner()._validate_yes_no_input("Kill processes? ")
         assert seen_prompts == ["Kill processes? "]
+
+    # ---- #994: output is routed through the logger, not print ----
+
+    @staticmethod
+    def _full_args(tmp_path: Path) -> dict[str, Any]:
+        """Return a complete args dict suitable for set_environment_variables()."""
+        return {
+            "agent_manifest_file": str(tmp_path / "manifest.hocon"),
+            "agent_tool_path": str(tmp_path / "coded_tools"),
+            "agent_toolbox_info_file": "",
+            "mcp_servers_info_file": str(tmp_path / "mcp_info.hocon"),
+            "server_connection": "http",
+            "manifest_update_period_seconds": 5,
+            "log_level": "info",
+            "server_only": True,
+            "client_only": False,
+            "server_host": "localhost",
+            "server_http_port": 8080,
+            "thinking_file": str(tmp_path / "thinking.txt"),
+            "thinking_dir": str(tmp_path / "thinking"),
+        }
+
+    def test_no_bare_print_calls_in_source(self) -> None:
+        """Regression guard for #994: run.py must route output through the logger.
+
+        A bare ``print(`` reintroduces the stdout bypass this issue removed.
+        Asserting against the source keeps the guard robust even for code paths
+        that are hard to exercise (server startup, signal handling).
+        """
+        source = Path(run_module.__file__).read_text(encoding="utf-8")
+        assert "print(" not in source
+
+    def test_configure_logging_installs_root_handler(self) -> None:
+        """_configure_logging must leave the root logger with at least one handler."""
+        NeuroSanRunner._configure_logging()  # pylint: disable=protected-access
+        assert logging.getLogger().handlers
+
+    def test_load_env_variables_logs_when_missing(self, tmp_path: Path, caplog: LogCaptureFixture) -> None:
+        """With no .env present, the 'using defaults' notice is logged at INFO."""
+        runner = self._make_runner()
+        runner.root_dir = str(tmp_path)
+        with caplog.at_level(logging.INFO, logger="NeuroSanRunner"):
+            runner.load_env_variables()
+        assert "No .env file found" in caplog.text
+
+    def test_load_env_variables_logs_when_found(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, caplog: LogCaptureFixture
+    ) -> None:
+        """With a .env present, the runner logs that it loaded variables at INFO."""
+        runner = self._make_runner()
+        runner.root_dir = str(tmp_path)
+        (tmp_path / ".env").write_text("FOO=bar\n", encoding="utf-8")
+        monkeypatch.setattr(run_module, "load_dotenv", lambda *_a, **_k: True)
+        with caplog.at_level(logging.INFO, logger="NeuroSanRunner"):
+            runner.load_env_variables()
+        assert "Loaded environment variables from:" in caplog.text
+
+    def test_set_environment_variables_logs_each_setting(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, caplog: LogCaptureFixture
+    ) -> None:
+        """Exported env vars are announced through the logger at INFO."""
+        monkeypatch.setattr(os, "environ", os.environ.copy())
+        runner = self._make_runner()
+        runner.root_dir = str(tmp_path)
+        runner.args = self._full_args(tmp_path)
+        with caplog.at_level(logging.INFO, logger="NeuroSanRunner"):
+            runner.set_environment_variables()
+        assert "AGENT_MANIFEST_FILE set to:" in caplog.text
+        assert "LOG_LEVEL set to:" in caplog.text
+
+    def test_signal_handler_logs_and_exits(self, caplog: LogCaptureFixture) -> None:
+        """signal_handler logs the shutdown at INFO and exits with status 0."""
+        runner = self._make_runner()
+        runner.is_windows = False
+        runner.server_process = None
+        runner.nsflow_process = None
+        runner.plugins = []
+        with caplog.at_level(logging.INFO, logger="NeuroSanRunner"):
+            with pytest.raises(SystemExit) as exc_info:
+                runner.signal_handler(2, None)
+        assert exc_info.value.code == 0
+        assert "Termination signal received" in caplog.text
+
+    def test_kill_processes_on_ports_logs(self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
+        """_kill_processes_on_ports announces each port through the logger.
+
+        ``subprocess.run`` is stubbed to report no listening process, so no real
+        signal is sent; we only assert the logging behavior.
+        """
+        runner = self._make_runner()
+        runner.is_windows = False
+        monkeypatch.setattr(run_module.subprocess, "run", lambda *_a, **_k: SimpleNamespace(stdout=""))
+        with caplog.at_level(logging.INFO, logger="NeuroSanRunner"):
+            runner._kill_processes_on_ports([4173])
+        assert "Attempting to kill process on port 4173" in caplog.text
+        assert "No process found on port 4173" in caplog.text
+
+    def test_invalid_input_logged_at_warning_level(self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
+        """Invalid interactive input is logged at WARNING, not INFO."""
+        monkeypatch.setattr(run_module, "timedinput", self._scripted_input(["bad", "yes"]))
+        with caplog.at_level(logging.WARNING, logger="NeuroSanRunner"):
+            assert self._make_runner()._validate_yes_no_input("prompt: ") is True
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("Invalid input" in message for message in warning_messages)

--- a/tests/neuro_san_studio/commands/test_run.py
+++ b/tests/neuro_san_studio/commands/test_run.py
@@ -343,6 +343,45 @@ class TestNeuroSanRunner:  # pylint: disable=too-many-public-methods
         self._make_runner()._apply_log_level("warning")
         assert logging.getLogger().level == logging.WARNING
 
+    def test_apply_log_level_propagates_to_process_logger_plugin(self) -> None:
+        """_apply_log_level forwards the resolved level to a plugin that supports it.
+
+        Covers the default run path where a process-logger plugin (the
+        ProcessLogBridge) is constructed before --log-level is parsed, so its
+        console level must be updated afterwards or the override is lost.
+        """
+        recorded: list[str] = []
+        runner = self._make_runner()
+        runner.plugins = [SimpleNamespace(set_console_level=recorded.append)]
+        runner._apply_log_level("warning")
+        assert recorded == ["warning"]
+        assert logging.getLogger().level == logging.WARNING
+
+    def test_apply_log_level_skips_plugin_without_setter(self) -> None:
+        """Plugins lacking set_console_level are skipped without error."""
+        runner = self._make_runner()
+        runner.plugins = [SimpleNamespace(name="no-logging-hook")]
+        runner._apply_log_level("warning")  # must not raise
+        assert logging.getLogger().level == logging.WARNING
+
+    def test_process_log_bridge_plugin_honors_late_log_level(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        """End-to-end handoff: a real ProcessLogBridgePlugin adopts a level resolved after construction.
+
+        Reproduces the reported failure path: the bridge is built with the
+        pre-parse level ("info"), then the runner applies the resolved "warning"
+        after argparse, and the bridge's console handler must follow.
+        """
+        # pylint: disable=import-outside-toplevel
+        from neuro_san_studio.plugins.log_bridge.process_log_bridge_plugin import ProcessLogBridgePlugin
+
+        monkeypatch.chdir(tmp_path)
+        plugin = ProcessLogBridgePlugin(args={"logs_dir": str(tmp_path / "logs"), "log_level": "info"})
+        assert plugin.log_bridge.rich_handler.level == logging.INFO
+        runner = self._make_runner()
+        runner.plugins = [plugin]
+        runner._apply_log_level("warning")
+        assert plugin.log_bridge.rich_handler.level == logging.WARNING
+
     def test_load_env_variables_logs_when_missing(self, tmp_path: Path, caplog: LogCaptureFixture) -> None:
         """With no .env present, the 'using defaults' notice is logged at INFO."""
         runner = self._make_runner()

--- a/tests/neuro_san_studio/commands/test_run.py
+++ b/tests/neuro_san_studio/commands/test_run.py
@@ -18,6 +18,7 @@
 
 import logging
 import os
+import sys
 from collections.abc import Callable
 from collections.abc import Iterable
 from pathlib import Path
@@ -34,6 +35,25 @@ from neuro_san_studio.commands.run import NeuroSanRunner
 
 class TestNeuroSanRunner:  # pylint: disable=too-many-public-methods
     """Tests for NeuroSanRunner"""
+
+    @pytest.fixture(autouse=True)
+    def _restore_root_logger(self):
+        """Snapshot and restore the root logger around each test.
+
+        ``_configure_logging`` mutates the global root logger (handlers + level)
+        and opens a ``runner.log`` file handler, so restore the prior state and
+        close any file handlers added during the test to avoid leaking config or
+        descriptors into other tests.
+        """
+        root = logging.getLogger()
+        saved_handlers = root.handlers[:]
+        saved_level = root.level
+        yield
+        for handler in root.handlers[:]:
+            if handler not in saved_handlers and isinstance(handler, logging.FileHandler):
+                handler.close()
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
 
     @staticmethod
     def _make_runner() -> NeuroSanRunner:
@@ -248,10 +268,80 @@ class TestNeuroSanRunner:  # pylint: disable=too-many-public-methods
         source = Path(run_module.__file__).read_text(encoding="utf-8")
         assert "print(" not in source
 
-    def test_configure_logging_installs_root_handler(self) -> None:
-        """_configure_logging must leave the root logger with at least one handler."""
-        NeuroSanRunner._configure_logging()  # pylint: disable=protected-access
-        assert logging.getLogger().handlers
+    def test_resolve_log_level_maps_names(self) -> None:
+        """_resolve_log_level maps names case-insensitively and defaults to INFO."""
+        assert NeuroSanRunner._resolve_log_level("warning") == logging.WARNING
+        assert NeuroSanRunner._resolve_log_level("DEBUG") == logging.DEBUG
+        assert NeuroSanRunner._resolve_log_level("bogus") == logging.INFO
+
+    def test_early_log_level_prefers_cli_flag(self, monkeypatch: MonkeyPatch) -> None:
+        """--log-level on argv wins over the LOG_LEVEL env var."""
+        monkeypatch.setenv("LOG_LEVEL", "error")
+        monkeypatch.setattr(sys, "argv", ["ns", "run", "--log-level", "warning"])
+        assert NeuroSanRunner._early_log_level() == "warning"
+
+    def test_early_log_level_accepts_equals_form(self, monkeypatch: MonkeyPatch) -> None:
+        """The --log-level=value form is parsed as well as the space-separated form."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        monkeypatch.setattr(sys, "argv", ["ns", "run", "--log-level=debug"])
+        assert NeuroSanRunner._early_log_level() == "debug"
+
+    def test_early_log_level_falls_back_to_env(self, monkeypatch: MonkeyPatch) -> None:
+        """Without a CLI flag, the LOG_LEVEL env var is used."""
+        monkeypatch.setenv("LOG_LEVEL", "warning")
+        monkeypatch.setattr(sys, "argv", ["ns", "run"])
+        assert NeuroSanRunner._early_log_level() == "warning"
+
+    def test_configure_logging_honors_log_level(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        """Regression for #994: LOG_LEVEL=warning suppresses INFO startup chatter.
+
+        The earlier bootstrap hard-coded INFO; this asserts the root level follows
+        the requested level so info-level runner messages are dropped.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LOG_LEVEL", "warning")
+        monkeypatch.setattr(sys, "argv", ["ns", "run"])
+        logging.getLogger().handlers.clear()
+        self._make_runner()._configure_logging()
+        assert logging.getLogger().level == logging.WARNING
+
+    def test_configure_logging_writes_runner_log(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        """Regression for #994: early runner output is captured in logs/runner.log.
+
+        Messages logged before the ProcessLogBridge attaches (which happens only
+        on first process start) must still reach the runner log, not just the
+        console.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LOG_LEVEL", "info")
+        monkeypatch.setattr(sys, "argv", ["ns", "run"])
+        logging.getLogger().handlers.clear()
+        runner = self._make_runner()
+        runner._configure_logging()
+        runner._logger.info("startup probe line")
+        for handler in logging.getLogger().handlers:
+            handler.flush()
+        runner_log = tmp_path / "logs" / "runner.log"
+        assert runner_log.is_file()
+        assert "startup probe line" in runner_log.read_text(encoding="utf-8")
+
+    def test_configure_logging_does_not_stack_handlers(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        """When the root logger already has handlers, only the level is applied."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LOG_LEVEL", "warning")
+        monkeypatch.setattr(sys, "argv", ["ns", "run"])
+        root = logging.getLogger()
+        root.handlers.clear()
+        sentinel = logging.NullHandler()
+        root.addHandler(sentinel)
+        self._make_runner()._configure_logging()
+        assert root.handlers == [sentinel]
+        assert root.level == logging.WARNING
+
+    def test_apply_log_level_overrides_after_parse(self) -> None:
+        """_apply_log_level updates the root logger to the resolved level (CLI override)."""
+        self._make_runner()._apply_log_level("warning")
+        assert logging.getLogger().level == logging.WARNING
 
     def test_load_env_variables_logs_when_missing(self, tmp_path: Path, caplog: LogCaptureFixture) -> None:
         """With no .env present, the 'using defaults' notice is logged at INFO."""

--- a/tests/neuro_san_studio/plugins/test_process_log_bridge.py
+++ b/tests/neuro_san_studio/plugins/test_process_log_bridge.py
@@ -142,3 +142,25 @@ class TestInferLevelFromText:
         bridge = self._make_bridge()
         line = '{"error": "something broke", "level": "info"}'
         assert bridge._infer_level_from_text(line) == logging.INFO  # pylint: disable=protected-access
+
+
+class TestSetConsoleLevel:
+    """Tests for ProcessLogBridge.set_console_level."""
+
+    def test_updates_rich_handler_level_and_name(self) -> None:
+        """set_console_level updates the rich (console) handler level and stored name.
+
+        Lets the runner honor a --log-level override parsed after the bridge was
+        constructed, without disturbing the file handler's full-detail capture.
+        """
+        bridge = ProcessLogBridge(level="info", runner_log_file=None)
+        assert bridge.rich_handler.level == logging.INFO
+        bridge.set_console_level("warning")
+        assert bridge.rich_handler.level == logging.WARNING
+        assert bridge.level_name == "WARNING"
+
+    def test_unknown_level_falls_back_to_info(self) -> None:
+        """An unrecognized level name falls back to INFO rather than raising."""
+        bridge = ProcessLogBridge(level="info", runner_log_file=None)
+        bridge.set_console_level("bogus")
+        assert bridge.rich_handler.level == logging.INFO


### PR DESCRIPTION
## Description

`NeuroSanRunner` emitted 56 `print()` calls directly to stdout, bypassing the logging configuration. As the issue states, output should flow through the logger so the level, formatter, and the `ProcessLogBridge` handlers govern it rather than going straight to stdout.

This converts every `print()` to the class's existing logger (`self._logger = logging.getLogger(self.__class__.__name__)`), with levels chosen by intent: INFO for status/config, WARNING for recoverable input/port issues and exit-on-conflict, ERROR for the broad `except` and the mutually-exclusive flag guard. f-strings become lazy `%s` arguments to match the existing calls and stay pylint-clean.

Fixes #994

## Logging configuration actually governs the output

A naive `print` to `self._logger` swap is not enough: the root logger defaults to WARNING with no handler, the runner logs before plugins load, and the `ProcessLogBridge` reconfigures root only on first process start. The conversion is backed by three changes so the logging config genuinely governs runner output:

1. **Level is honored, including the earliest messages.** `_configure_logging` resolves the level before argparse (scanning argv for `--log-level`, then `LOG_LEVEL`, then `info`); `__init__` re-applies the resolved level after `parse_args`. `LOG_LEVEL=warning` or `--log-level warning` suppresses the INFO startup chatter.
2. **Early output is captured in `logs/runner.log`.** The bootstrap installs a console handler plus a `logs/runner.log` file handler, so startup messages logged before the bridge attaches are persisted, not just printed. The bridge still `clear()`s root handlers before installing its rotating handler, so the handoff is clean with no duplicate output.
3. **`--log-level` survives the bridge handoff.** The bridge is constructed before `parse_args`, so it froze its console handler to the pre-parse level and a CLI `--log-level` was lost once it attached (env `LOG_LEVEL` worked, the flag did not). `ProcessLogBridge.set_console_level()` (delegated by the plugin) lets `_apply_log_level` update the console level after the flag is parsed; the file handler stays at DEBUG so the runner log keeps full detail.

Verified locally against the exact failure cases:

\`\`\`text
--log-level warning       -> root + bridge console resolve to WARNING, no INFO chatter   PASS
LOG_LEVEL=warning         -> INFO suppressed, WARNING still shown                         PASS
early runner message      -> captured in logs/runner.log with timestamp/level            PASS
bridge handoff            -> console level stays WARNING after attach (was reverting)     PASS
already-configured root   -> level applied, no handler stacking                          PASS
\`\`\`

## Impact

Runner output now goes through the logging system (controllable by level/handlers) instead of raw stdout, startup output lands in `logs/runner.log`, and `--log-level` is honored end-to-end. The bridge gains one small `set_console_level` setter; no public API, CLI flags, or dependencies change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally. 61 pass across `test_run.py` + `test_process_log_bridge.py`; 170 across the rest of `tests/neuro_san_studio/commands/`. `ruff format --check` and `ruff check` clean on the `make lint-check` SOURCES + TESTS scope; `pylint` 10.00/10 on all touched source and test files (gate is `fail-under = 10.0`).
- [x] Added/updated tests. Migrated `capsys` assertions to `caplog`; source guard that no bare `print(` remains; level-precedence and suppression tests; `runner.log` capture; no-handler-stacking; post-parse override; plugin-handoff coverage (real `ProcessLogBridgePlugin` built at "info" then updated to "warning") and bridge-level `set_console_level` unit tests; autouse fixture that restores root-logger state.
- [x] Updated relevant documentation. Docstrings document the level resolution, the `runner.log` handoff, and the `set_console_level` rationale; no user-facing docs reference the prior `print` behavior.
- [ ] Added dependencies to appropriate `requirements.txt`. No dependency changes.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**