### PR TITLE
Bump build-common to 1.0.7

### DIFF
--- a/.github/workflows/agent_network_designer.yml
+++ b/.github/workflows/agent_network_designer.yml
@@ -12,8 +12,8 @@ jobs:
   agent-network-designer-test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san-studio'
-    # cognizant-ai-lab/build-common 1.0.5
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@550f3d7338e598c813b9580a238141328f7baaaa
+    # cognizant-ai-lab/build-common 1.0.6
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@e5f749a7ba5de8bb8106cb172e89f21ca581a697
     with:
       python-version: '3.13'
       # Required by build_scripts/server_start.sh:

--- a/.github/workflows/agent_network_designer.yml
+++ b/.github/workflows/agent_network_designer.yml
@@ -12,8 +12,8 @@ jobs:
   agent-network-designer-test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san-studio'
-    # cognizant-ai-lab/build-common 1.0.6
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@e5f749a7ba5de8bb8106cb172e89f21ca581a697
+    # cognizant-ai-lab/build-common 1.0.7
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
     with:
       python-version: '3.13'
       # Required by build_scripts/server_start.sh:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   test:
-    # cognizant-ai-lab/build-common 1.0.5
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@550f3d7338e598c813b9580a238141328f7baaaa
+    # cognizant-ai-lab/build-common 1.0.6
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@e5f749a7ba5de8bb8106cb172e89f21ca581a697
     with:
       python-version: '3.13'
       # No lint steps in the original workflow

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   test:
-    # cognizant-ai-lab/build-common 1.0.6
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@e5f749a7ba5de8bb8106cb172e89f21ca581a697
+    # cognizant-ai-lab/build-common 1.0.7
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
     with:
       python-version: '3.13'
       # No lint steps in the original workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python environment
-        # 1.0.5
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@550f3d7338e598c813b9580a238141328f7baaaa
+        # 1.0.6
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -41,8 +41,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.5
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@550f3d7338e598c813b9580a238141328f7baaaa
+        # 1.0.6
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@e5f749a7ba5de8bb8106cb172e89f21ca581a697
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python environment
-        # 1.0.6
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697
+        # 1.0.7
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@3ead7f681f92044709ffc3a533f41c3f48230cfd
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -41,8 +41,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.6
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@e5f749a7ba5de8bb8106cb172e89f21ca581a697
+        # 1.0.7
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@3ead7f681f92044709ffc3a533f41c3f48230cfd
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    # 1.0.6
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@e5f749a7ba5de8bb8106cb172e89f21ca581a697
+    # 1.0.7
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
     with:
       python-version: '3.13'
       run-hadolint: true


### PR DESCRIPTION
## Description

Bump all `cognizant-ai-lab/build-common` references to 1.0.7 (`3ead7f6`). The `tests.yml` workflow was already on 1.0.6; the remaining workflows (`agent_network_designer.yml`, `integration.yml`, `publish.yml`) were on 1.0.5. All four are now on 1.0.7.

## Impact

CI workflows will use the latest build-common composites and reusable workflows.

## Type of Change

- [x] Dependency upgrade

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/5af2ecdfbaf04a0cb7bbf4cfa9f469c4
Requested by: @donn-leaf