### PR TITLE
Adopt neuro-san 0.6.57 API: rename find_all_top_agents to find_all_front_man_agents and simplify validator calls

### DIFF
--- a/coded_tools/agent_network_editor/designer_network_inspector.py
+++ b/coded_tools/agent_network_editor/designer_network_inspector.py
@@ -63,7 +63,7 @@ class DesignerNetworkInspector(AgentNetworkInspector):
         """
         # The validator stuff uses the same internal network dictionary format
         validator = UnreachableNodesNetworkValidator()
-        front_men: set[str] = validator.find_all_top_agents(self.network_def)
+        front_men: set[str] = validator.find_all_front_man_agents(self.network_def)
         if len(front_men) == 0:
             return None
 

--- a/coded_tools/agent_network_editor/designer_network_inspector.py
+++ b/coded_tools/agent_network_editor/designer_network_inspector.py
@@ -55,11 +55,17 @@ class DesignerNetworkInspector(AgentNetworkInspector):
         """
         return agent_spec.get("name")
 
-    def find_front_man(self) -> str:
+    def find_front_man(self) -> str | None:
         """
         :return: A single tool name to use as the root of the chat agent.
-                 This guy will be user facing.  If there are none or > 1,
-                 an exception will be raised.
+                 This guy will be user facing.
+                 Returns None when no front-man exists yet (e.g., during interactive
+                 build before an entry agent has been added) — cardinality errors
+                 (zero or multiple front-men) are surfaced by the validation
+                 middleware rather than raised here, so the designer agent can
+                 iteratively fix the network.
+                 When multiple front-men exist, an arbitrary one is returned;
+                 callers are expected to have already validated the network.
         """
         # The validator stuff uses the same internal network dictionary format
         validator = UnreachableNodesNetworkValidator()

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1268,9 +1268,25 @@ For more information on toolbox, please see [Toolbox Info HOCON File Reference](
 ## MCP Servers
 
 Agents can invoke tools exposed by remote **Model Context Protocol (MCP)** servers.
-URLs must either:
-- start with `https://mcp`, **or**
-- end with `/mcp`.
+
+MCP server URLs are recognized when they conform to the
+[MCP canonical server URI specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri):
+they must use the `http` or `https` scheme, must include a host, and must not contain a fragment.
+To distinguish MCP server URLs from other external agent URLs, the literal `mcp` must appear either
+as a label in the hostname (e.g. `mcp.example.com`) or as any segment of the URL path
+(e.g. `/mcp`, `/mcp/free`, `/server/mcp`, `/v1/mcp/server`).
+
+Examples of URLs that are recognized as MCP servers:
+
+- `https://mcp.example.com/mcp`
+- `https://mcp.example.com`
+- `https://mcp.example.com:8443`
+- `https://example.com/mcp/free`
+- `https://example.com/v1/mcp/server`
+- `http://localhost:8000/mcp/`
+
+If a URL you want to use does not satisfy these rules, fall back to the dictionary form below,
+which is always treated as an MCP reference regardless of URL shape.
 
 ### MCP Server Configuration
 
@@ -1290,7 +1306,8 @@ MCP servers can be configured in one of two formats under the `tools` field.
 
 2. Dictionary Reference
 
-    Use this format when you want to explicitly control which tools are exposed from a given MCP server.
+    Use this format when you want to explicitly control which tools are exposed from a given MCP server,
+    or when your URL does not satisfy the recognition rules above.
 
     ```json
     "tools": [
@@ -1301,8 +1318,8 @@ MCP servers can be configured in one of two formats under the `tools` field.
     ]
     ```
 
-   - The tools key specifies a whitelist of tools made available to the agent.
-   - If the tools key is omitted, all tools from the MCP server will be accessible.
+   - The `tools` key specifies a whitelist of tools made available to the agent.
+   - If the `tools` key is omitted, all tools from the MCP server will be accessible.
 
 ### Authentication
 

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -223,7 +223,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             subnetwork_names,
             mcp_servers,
         )
-        top_agent_name: str = UnreachableNodesNetworkValidator().find_all_top_agents(network_def).pop()
+        top_agent_name: str = UnreachableNodesNetworkValidator().find_all_front_man_agents(network_def).pop()
 
         # Always assemble and store HOCON content for client consumption.
         persisted_content: str = await HoconAgentNetworkAssembler(DEMO_MODE).assemble_agent_network(

--- a/middleware/agent_network_designer/validation/agent_network_instructions_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_instructions_validation_middleware.py
@@ -58,10 +58,10 @@ class AgentNetworkInstructionsValidationMiddleware(AgentNetworkValidationMiddlew
                 description: str = agent_copy.pop("description")
                 agent_copy["function"] = {"description": description}
             use_network_def[agent_name] = agent_copy
-        # Only check that "instructions" and "description" fields are present and non-empty.
+        # The keyword validator only checks that "instructions" and "description" fields are present and non-empty.
         # We do not check if "tools" field is a list of str here since that is related to structure validation and
         # this agent network has no tools to fix this issue.
-        return KeywordNetworkValidator(keywords=["instructions", "description"]).validate(use_network_def)
+        return KeywordNetworkValidator().validate(use_network_def)
 
     def format_error(self, error_list: list[str]) -> str:
         """

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -16,7 +16,6 @@
 
 from typing import Any
 
-from neuro_san.internals.validation.network.keyword_network_validator import KeywordNetworkValidator
 from neuro_san.internals.validation.network.structure_network_validator import StructureNetworkValidator
 from neuro_san.internals.validation.network.toolbox_network_validator import ToolboxNetworkValidator
 from neuro_san.internals.validation.network.url_network_validator import UrlNetworkValidator

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -56,15 +56,6 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
         :return: A list of error strings (empty if valid)
         """
 
-        # Check that "tools" field is a list of str first since if it is not,
-        # the other validators will fail and raise an error.
-        # Note that the keywords argument restricts the check to specific keywords.
-        # Available keywords are "description", "instructions", and "tools".
-        # If keywords is not provided, all keywords will be checked.
-        tool_not_list_error: list[str] = KeywordNetworkValidator(keywords=["tools"]).validate(network_def)
-        if tool_not_list_error:
-            return tool_not_list_error
-
         # Get infos from sly_data. These should have been put there by the respective tools
         # from the agent network editor.
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
@@ -72,6 +63,11 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
         toolbox_tools: dict[str, Any] = await GetToolbox.get_toolbox_info(self.sly_data)
 
         return (
+            # The structure validator checks for the followingstructural issues:
+            # - tools shape: tools field must be a list of strings or dictionaries
+            # - cycle networks: the network must not contain cycles
+            # - missing agents: all agents referred to in "tools" must be defined in the network
+            # - unreachable nodes: all agents must be reachable
             StructureNetworkValidator().validate(network_def)
             + ToolboxNetworkValidator(toolbox_tools).validate(network_def)
             + UrlNetworkValidator(subnetwork_names, mcp_servers).validate(network_def)

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -62,9 +62,9 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
         toolbox_tools: dict[str, Any] = await GetToolbox.get_toolbox_info(self.sly_data)
 
         return (
-            # The structure validator checks for the followingstructural issues:
-            # - tools shape: tools field must be a list of strings or dictionaries
-            # - cycle networks: the network must not contain cycles
+            # The structure validator checks for the following structural issues:
+            # - tools shape: the tools field must be a list of strings or dictionaries
+            # - cyclic networks: the network must not contain cycles
             # - missing agents: all agents referred to in "tools" must be defined in the network
             # - unreachable nodes: all agents must be reachable
             StructureNetworkValidator().validate(network_def)

--- a/neuro_san_studio/discovery/dependency_analyzer.py
+++ b/neuro_san_studio/discovery/dependency_analyzer.py
@@ -58,7 +58,7 @@ class DependencyAnalyzer:
         try:
             restorer = AbstractAsyncConfigRestorer(file_purpose="dependency analysis", must_exist=True)
             config = restorer.restore(file_reference=hocon_path)
-        except (FileNotFoundError, ParseException):
+        except (FileNotFoundError, ParseException, ValueError):
             return deps
 
         self._extract_from_config(config, deps)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Neuro SAN
 leaf-common>=1.2.40
-neuro-san==0.6.55
+neuro-san==0.6.57
 nsflow==0.6.15
 
 # For config parsing


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

- Bump neuro-san to `0.6.57`
- Update `find_all_top_agents` -> `find_all_front_man_agents` at the two call sites in `designer_network_inspector` and `agent_network_persistence_middleware`
- Drop redundant keywords arguments from `KeywordNetworkValidator`; defaults now cover instructions/description checks
- Remove the standalone tools-shape pre-check since `StructureNetworkValidator` handles it
- Catch `ValueError` in `dependency_analyzer` since the parsing exception now return value error
- Update MCP server definition in user guide

Fixes #1106, #1107

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Dependency upgrade
- [x] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [x] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
