### PR TITLE
#1114: Add validate subcommand to the neuro-san-studio CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,3 +13,4 @@ Run `neuro-san-studio --help` for the full list and shared options.
 | [`export`](./cli/export.md) | Bundle a network from the current project into a shareable `.hocon` or `.zip`. |
 | [`check-config`](./cli/check_config.md) | Validate every LLM configuration in a HOCON file. |
 | [`check-llm-keys`](./cli/check_llm_keys.md) | Validate LLM API keys and other critical environment variables. |
+| [`validate`](./cli/validate.md) | Validate the structure of an agent network HOCON file. |

--- a/docs/cli/validate.md
+++ b/docs/cli/validate.md
@@ -1,0 +1,50 @@
+# validate
+
+Validates the *structure* of an agent network HOCON file against neuro-san's agent network validation rules. Use it to
+catch problems before starting a server, for example:
+
+- Agents that are referenced but not defined (missing nodes)
+- Unreachable agents and front-man problems
+- Invalid tool names
+- Invalid URL references
+- Malformed `tools` fields and unrecognized keywords
+
+Unlike [`check-config`](./check_config.md), `validate` does **not** call any LLM — it performs purely structural
+validation, so it needs no API keys.
+
+Under the hood this command delegates to neuro-san's `HoconValidatorCli` (the tool also available as
+`python -m neuro_san.client.hocon_validator_cli`), so it stays in sync with the library's validation rules.
+
+## Usage
+
+```bash
+# Validate an agent network HOCON file
+neuro-san-studio validate registries/music_nerd.hocon
+
+# Same command via the shorter alias
+ns validate registries/music_nerd.hocon
+
+# Print an agent network summary when validation passes
+ns validate registries/music_nerd.hocon --verbose
+```
+
+The command exits with code `0` when the file is valid and `1` when it is invalid or cannot be found, parsed, or
+otherwise loaded.
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--verbose` | Print an agent network summary (agents, their type, and sub-tools) when validation passes. |
+| `--external-agents` | Comma-separated external agent references to treat as valid, e.g. `'/agent1,/agent2'`. |
+| `--mcp-servers` | Comma-separated MCP server URLs to treat as valid. |
+| `--registry-dir` | Base directory for resolving HOCON `include` directives. Defaults to the current directory. |
+
+`--external-agents` and `--mcp-servers` exist because an agent network may reference agents or tool servers that live
+outside the file being validated. Listing them tells the validator they are legitimate so it does not report them as
+missing.
+
+## Output
+
+On success the command prints `Validation passed: No errors found.` (followed by the agent network summary when
+`--verbose` is set). On failure it prints each validation error on its own numbered line.

--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -200,6 +200,48 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
 
         raise typer.Exit(code=CheckConfigCommand(hocon_path=hocon_path).run())
 
+    @staticmethod
+    @app.command("validate", help="Validate the structure of an agent network HOCON file.")
+    def _validate_command(
+        hocon_path: str = typer.Argument(
+            ...,
+            help="Path to the agent network HOCON file to validate.",
+        ),
+        verbose: bool = typer.Option(
+            False,
+            "--verbose",
+            help="Print an agent network summary when validation passes.",
+        ),
+        external_agents: Optional[str] = typer.Option(
+            None,
+            "--external-agents",
+            help="Comma-separated external agent references to treat as valid (e.g. '/agent1,/agent2').",
+        ),
+        mcp_servers: Optional[str] = typer.Option(
+            None,
+            "--mcp-servers",
+            help="Comma-separated MCP server URLs to treat as valid.",
+        ),
+        registry_dir: Optional[str] = typer.Option(
+            None,
+            "--registry-dir",
+            help="Base directory for resolving HOCON includes. Defaults to the current directory.",
+        ),
+    ) -> None:
+        """Run the agent network HOCON validation and propagate its exit code."""
+        # pylint: disable-next=import-outside-toplevel
+        from neuro_san_studio.commands.validate import ValidateCommand
+
+        raise typer.Exit(
+            code=ValidateCommand(
+                hocon_path=hocon_path,
+                verbose=verbose,
+                external_agents=external_agents,
+                mcp_servers=mcp_servers,
+                registry_dir=registry_dir,
+            ).run()
+        )
+
 
 def main() -> None:
     """Entry point for the `neuro-san-studio` console script."""

--- a/neuro_san_studio/commands/validate.py
+++ b/neuro_san_studio/commands/validate.py
@@ -1,0 +1,105 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Implementation of the `neuro-san-studio validate` command.
+
+Validates the structure of an agent network HOCON file by delegating to the
+neuro-san library's ``HoconValidatorCli`` (the tool also exposed as
+``python -m neuro_san.client.hocon_validator_cli``). Studio stays a thin
+wrapper: it marshals the command options into the arguments that
+``HoconValidatorCli`` expects, runs it, and normalizes the exit code to studio's
+0/1 convention (studio's ``main()`` reserves exit code 2 for clean help exits).
+
+Because the actual validation lives in the library, any future improvement there
+(for example, gracefully handling non-agent-network files) is picked up here
+automatically. A broad guard around the call keeps the command from printing a
+raw traceback if the underlying validator raises.
+
+Unlike ``check-config``, this command does NOT call any LLM - it performs purely
+structural validation and therefore needs no API keys.
+"""
+
+import sys
+from typing import List
+from typing import Optional
+
+from neuro_san.client.hocon_validator_cli import HoconValidatorCli
+
+# Exit codes. neuro-san-studio's main() treats code 2 as a clean "help" exit,
+# so (like check-config) we normalize to a binary contract: 0 = valid, 1 = problem.
+EXIT_OK = 0
+EXIT_ERROR = 1
+
+
+class ValidateCommand:  # pylint: disable=too-few-public-methods
+    """Validate the structure of an agent network HOCON file.
+
+    Thin wrapper around neuro-san's ``HoconValidatorCli``. Returns exit code 0
+    when the file is valid and 1 when it is invalid or cannot be validated.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        hocon_path: str,
+        *,
+        verbose: bool = False,
+        external_agents: Optional[str] = None,
+        mcp_servers: Optional[str] = None,
+        registry_dir: Optional[str] = None,
+    ):
+        """Initialize the command.
+
+        Args:
+            hocon_path: Path to the agent network HOCON file to validate.
+            verbose: When True, print an agent network summary on success.
+            external_agents: Comma-separated valid external agent references
+                (e.g. ``/agent1,/agent2``).
+            mcp_servers: Comma-separated valid MCP server URLs.
+            registry_dir: Base directory for resolving HOCON includes.
+        """
+        self.hocon_path = hocon_path
+        self.verbose = verbose
+        self.external_agents = external_agents
+        self.mcp_servers = mcp_servers
+        self.registry_dir = registry_dir
+
+    def _build_argv(self) -> List[str]:
+        """Marshal the command options into an argv list for HoconValidatorCli."""
+        argv: List[str] = ["hocon_validator_cli", self.hocon_path]
+        if self.verbose:
+            argv.append("--verbose")
+        if self.external_agents:
+            argv.extend(["--external-agents", self.external_agents])
+        if self.mcp_servers:
+            argv.extend(["--mcp-servers", self.mcp_servers])
+        if self.registry_dir:
+            argv.extend(["--registry-dir", self.registry_dir])
+        return argv
+
+    def run(self) -> int:
+        """Delegate to HoconValidatorCli and return a normalized exit code (0 ok, 1 problem)."""
+        # HoconValidatorCli.main() reads sys.argv, so temporarily install our argv
+        # and restore it afterwards regardless of outcome.
+        saved_argv: List[str] = sys.argv
+        try:
+            sys.argv = self._build_argv()
+            exit_code: int = HoconValidatorCli().main()
+            return EXIT_OK if exit_code == 0 else EXIT_ERROR
+        except Exception as exception:  # pylint: disable=broad-except
+            print(f"Error: Could not validate '{self.hocon_path}' - {exception}", file=sys.stderr)
+            return EXIT_ERROR
+        finally:
+            sys.argv = saved_argv

--- a/tests/neuro_san_studio/commands/test_validate.py
+++ b/tests/neuro_san_studio/commands/test_validate.py
@@ -1,0 +1,110 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import sys
+from unittest import TestCase
+from unittest.mock import patch
+
+from neuro_san_studio.commands.validate import ValidateCommand
+
+_MODULE = "neuro_san_studio.commands.validate"
+
+
+class TestValidateCommandRun(TestCase):
+    """Tests for ValidateCommand.run - a thin wrapper over HoconValidatorCli."""
+
+    def test_valid_returns_zero(self):
+        """When the underlying validator returns 0, run() returns 0."""
+        with patch(f"{_MODULE}.HoconValidatorCli") as mock_cli:
+            mock_cli.return_value.main.return_value = 0
+            self.assertEqual(ValidateCommand("agent.hocon").run(), 0)
+
+    def test_validation_errors_return_one(self):
+        """When the underlying validator returns 1, run() returns 1."""
+        with patch(f"{_MODULE}.HoconValidatorCli") as mock_cli:
+            mock_cli.return_value.main.return_value = 1
+            self.assertEqual(ValidateCommand("agent.hocon").run(), 1)
+
+    def test_load_error_code_two_is_normalized_to_one(self):
+        """The library's exit code 2 (load error) is normalized to 1 for studio's CLI."""
+        with patch(f"{_MODULE}.HoconValidatorCli") as mock_cli:
+            mock_cli.return_value.main.return_value = 2
+            self.assertEqual(ValidateCommand("agent.hocon").run(), 1)
+
+    def test_unexpected_validator_error_returns_one(self):
+        """An exception raised by the validator is caught and reported as exit code 1."""
+        with patch(f"{_MODULE}.HoconValidatorCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = AttributeError("boom")
+            self.assertEqual(ValidateCommand("agent.hocon").run(), 1)
+
+    def test_builds_argv_from_all_options(self):
+        """All command options are marshaled into the argv passed to HoconValidatorCli."""
+        captured = {}
+
+        def fake_main():
+            captured["argv"] = list(sys.argv)
+            return 0
+
+        with patch(f"{_MODULE}.HoconValidatorCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = fake_main
+            ValidateCommand(
+                "agent.hocon",
+                verbose=True,
+                external_agents="/a,/b",
+                mcp_servers="http://server",
+                registry_dir="/reg",
+            ).run()
+
+        argv = captured["argv"]
+        self.assertEqual(argv[1], "agent.hocon")
+        self.assertIn("--verbose", argv)
+        self.assertIn("--external-agents", argv)
+        self.assertIn("/a,/b", argv)
+        self.assertIn("--mcp-servers", argv)
+        self.assertIn("http://server", argv)
+        self.assertIn("--registry-dir", argv)
+        self.assertIn("/reg", argv)
+
+    def test_optional_flags_omitted_when_not_set(self):
+        """Only the file path is passed when no optional flags are provided."""
+        captured = {}
+
+        def fake_main():
+            captured["argv"] = list(sys.argv)
+            return 0
+
+        with patch(f"{_MODULE}.HoconValidatorCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = fake_main
+            ValidateCommand("agent.hocon").run()
+
+        argv = captured["argv"]
+        self.assertEqual(argv, ["hocon_validator_cli", "agent.hocon"])
+
+    def test_sys_argv_restored_after_success(self):
+        """sys.argv is restored after a normal run."""
+        before = list(sys.argv)
+        with patch(f"{_MODULE}.HoconValidatorCli") as mock_cli:
+            mock_cli.return_value.main.return_value = 0
+            ValidateCommand("agent.hocon").run()
+        self.assertEqual(sys.argv, before)
+
+    def test_sys_argv_restored_after_exception(self):
+        """sys.argv is restored even when the validator raises."""
+        before = list(sys.argv)
+        with patch(f"{_MODULE}.HoconValidatorCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = RuntimeError("boom")
+            ValidateCommand("agent.hocon").run()
+        self.assertEqual(sys.argv, before)

--- a/tests/neuro_san_studio/commands/test_validate.py
+++ b/tests/neuro_san_studio/commands/test_validate.py
@@ -64,7 +64,7 @@ class TestValidateCommandRun(TestCase):
                 "agent.hocon",
                 verbose=True,
                 external_agents="/a,/b",
-                mcp_servers="http://server",
+                mcp_servers="https://mcp.example.com",
                 registry_dir="/reg",
             ).run()
 
@@ -74,7 +74,7 @@ class TestValidateCommandRun(TestCase):
         self.assertIn("--external-agents", argv)
         self.assertIn("/a,/b", argv)
         self.assertIn("--mcp-servers", argv)
-        self.assertIn("http://server", argv)
+        self.assertIn("https://mcp.example.com", argv)
         self.assertIn("--registry-dir", argv)
         self.assertIn("/reg", argv)
 


### PR DESCRIPTION
## Description

Adds a `validate` subcommand to the neuro-san-studio CLI:

    ns validate path/to/agent.hocon

It performs structural validation of an agent network HOCON file (missing/unreachable
agents, invalid tool names/URLs, malformed `tools`, etc.). Per maintainer guidance, it is
a **thin wrapper around neuro-san's `HoconValidatorCli`** (the tool also exposed as
`python -m neuro_san.client.hocon_validator_cli`) — no validation logic is duplicated in
studio, so any future improvement to the validator in neuro-san is inherited here
automatically.

Studio-side concerns only: it marshals the CLI options into the arguments
`HoconValidatorCli` expects, and normalizes the exit code to studio's `0`/`1` convention
(studio's `main()` reserves exit code `2` for clean help exits). Unlike `check-config`,
this command makes no LLM calls and needs no API keys.

Verified against `neuro-san==0.6.57`.

Fixes #1114. Supersedes #1116.

## Impact

Additive new subcommand; no changes to existing commands. Exits `0` when the file is a
valid agent network and `1` otherwise. Non-agent-network HOCON files (e.g. shared
`include` value files) currently surface the library's error and exit `1`; the command
guards against printing a raw traceback. Gracefully handling those files is planned in the
neuro-san validator itself, and studio will inherit that fix automatically since it
delegates to the library.

## Screenshots / Logs / Examples (optional)

    # Valid agent network
    $ ns validate registries/agent_network_query_generator.hocon
    Validation passed: No errors found.            # exit 0

    # Network with a broken reference
    $ ns validate path/to/broken.hocon
    Validation failed with 2 error(s):
    1. Agent 'concierge' references non-existent agent(s) in tools: 'rom_service'
    2. Unreachable agents found: ['room_service']   # exit 1

    # Missing file
    $ ns validate path/to/missing.hocon
    Error: File not found - [Errno 2] No such file or directory: ...   # exit 1

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->
