### PR TITLE
Resolve repo-root style path as registries/ relative

### DIFF
--- a/neuro_san_studio/exporter/agent_network_exporter.py
+++ b/neuro_san_studio/exporter/agent_network_exporter.py
@@ -22,6 +22,7 @@ import shutil
 import zipfile
 from dataclasses import dataclass
 from dataclasses import field
+from pathlib import Path
 from typing import List
 from typing import Optional
 from typing import Set
@@ -275,6 +276,9 @@ class AgentNetworkExporter:  # pylint: disable=too-few-public-methods
 
     def _resolve_network(self, network: str) -> str:
         """Map a user-supplied name to a registries-relative `.hocon` path; raise if missing."""
+        # Tolerate a repo-root-style `registries/...` prefix: `ns export
+        # registries/basic/hello_world.hocon` should behave like `basic/hello_world.hocon`.
+        network = self._strip_registries_prefix(network)
         candidate = network if network.endswith(".hocon") else f"{network}.hocon"
 
         # Direct relative path under registries/ (e.g., 'basic/music_nerd.hocon').
@@ -292,6 +296,16 @@ class AgentNetworkExporter:  # pylint: disable=too-few-public-methods
             f"Network '{network}' not found under {self.registries_dir}. "
             f"Pass a name like 'music_nerd' or a relative path like 'basic/music_nerd'."
         )
+
+    @staticmethod
+    def _strip_registries_prefix(network: str) -> str:
+        """Drop a leading `registries/` segment so a repo-root-style path resolves like
+        the registries-relative form. `Path.parts` collapses `./` and interior `.` so
+        equivalent spellings are handled by one rule."""
+        parts = Path(network).parts
+        if parts and parts[0] == "registries":
+            return str(Path(*parts[1:])) if len(parts) > 1 else ""
+        return network
 
     @staticmethod
     def _has_dependencies(deps: AgentNetworkDependencies) -> bool:

--- a/neuro_san_studio/exporter/agent_network_exporter.py
+++ b/neuro_san_studio/exporter/agent_network_exporter.py
@@ -22,7 +22,7 @@ import shutil
 import zipfile
 from dataclasses import dataclass
 from dataclasses import field
-from pathlib import Path
+from pathlib import PurePosixPath
 from typing import List
 from typing import Optional
 from typing import Set
@@ -300,11 +300,12 @@ class AgentNetworkExporter:  # pylint: disable=too-few-public-methods
     @staticmethod
     def _strip_registries_prefix(network: str) -> str:
         """Drop a leading `registries/` segment so a repo-root-style path resolves like
-        the registries-relative form. `Path.parts` collapses `./` and interior `.` so
-        equivalent spellings are handled by one rule."""
-        parts = Path(network).parts
+        the registries-relative form. `PurePosixPath.parts` collapses `./` and interior
+        `.` so equivalent spellings are handled by one rule, and keeps the result `/`-
+        separated (it feeds zip arcnames, which must stay POSIX on every OS)."""
+        parts = PurePosixPath(network).parts
         if parts and parts[0] == "registries":
-            return str(Path(*parts[1:])) if len(parts) > 1 else ""
+            return str(PurePosixPath(*parts[1:])) if len(parts) > 1 else ""
         return network
 
     @staticmethod

--- a/tests/neuro_san_studio/commands/test_agent_network_exporter.py
+++ b/tests/neuro_san_studio/commands/test_agent_network_exporter.py
@@ -77,6 +77,31 @@ class TestExportNoDeps:
         assert (tmp_path / "music_nerd.hocon").is_file()
         assert result.network_name == "music_nerd"
 
+    def test_export_strips_registries_prefix(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A repo-root-style 'registries/basic/music_nerd.hocon' resolves like 'basic/music_nerd'."""
+        self._build_no_deps_project(tmp_path / "project")
+        monkeypatch.chdir(tmp_path)
+
+        exporter = AgentNetworkExporter(project_dir=str(tmp_path / "project"))
+        result = exporter.export("registries/basic/music_nerd.hocon")
+
+        assert (tmp_path / "music_nerd.hocon").is_file()
+        assert result.network_name == "music_nerd"
+        # The stripped path stays registries-relative — the bundled-files key must not
+        # double up the prefix (would be 'registries/registries/...' if stripping leaked).
+        assert result.bundled_files == ["registries/basic/music_nerd.hocon"]
+
+    def test_export_strips_dot_slash_registries_prefix(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A './registries/...' spelling normalizes to the same registries-relative path."""
+        self._build_no_deps_project(tmp_path / "project")
+        monkeypatch.chdir(tmp_path)
+
+        exporter = AgentNetworkExporter(project_dir=str(tmp_path / "project"))
+        result = exporter.export("./registries/basic/music_nerd.hocon")
+
+        assert (tmp_path / "music_nerd.hocon").is_file()
+        assert result.network_name == "music_nerd"
+
     def test_missing_network_raises_filenotfound(self, tmp_path: Path) -> None:
         """An unknown network name surfaces FileNotFoundError, not a silent empty export."""
         self._build_no_deps_project(tmp_path / "project")


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

`ns export` now accepts a repo-root-style path, so the `registries/` prefix is optional:

```bash
ns export registries/basic/hello_world.hocon   # now works
ns export basic/hello_world.hocon              # still works
ns export hello_world                          # addressed by name without extension, still works
```

A leading registries/ segment is stripped before resolution. Everything after stays registries-relative, so the on-disk lookup and the bundled zip layout are unchanged.

<!-- Brief description of what this PR does and why -->

Fixes #1112 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
