### PR TITLE
Force selector event loop on Windows for in-process subnetwork streaming

### DIFF
--- a/neuro_san_studio/runner/neuro_san_server_wrapper.py
+++ b/neuro_san_studio/runner/neuro_san_server_wrapper.py
@@ -20,14 +20,24 @@ This module ensures that plugins are initialized in the same Python process as t
 allowing, for instance, proper tracing and observability.
 """
 
+import asyncio
 import logging
 import os
 import signal
 import sys
 
-from neuro_san.service.main_loop.server_main_loop import ServerMainLoop
+# Force the selector event loop on Windows. The default ProactorEventLoop on
+# Python 3.8+/Windows can silently stall the in-process sub-network streaming
+# used when agent_network_designer invokes /agent_network_editor via
+# AsyncDirectAgentSession - the producer task hands chat messages to a
+# consumer via an asyncio queue, and that handoff never connects under
+# Proactor, so the editor never returns its first tool call.
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-from neuro_san_studio.plugins.plugin_loader import PluginLoader
+from neuro_san.service.main_loop.server_main_loop import ServerMainLoop  # noqa: E402
+
+from neuro_san_studio.plugins.plugin_loader import PluginLoader  # noqa: E402
 
 
 class NeuroSanServerWrapper:  # pylint: disable=too-few-public-methods

--- a/neuro_san_studio/runner/neuro_san_server_wrapper.py
+++ b/neuro_san_studio/runner/neuro_san_server_wrapper.py
@@ -35,6 +35,7 @@ import sys
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
+# pylint: disable=wrong-import-position
 from neuro_san.service.main_loop.server_main_loop import ServerMainLoop  # noqa: E402
 
 from neuro_san_studio.plugins.plugin_loader import PluginLoader  # noqa: E402


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

<!-- Brief description of what this PR does and why -->

Fixes bug [https://github.com/cognizant-ai-lab/neuro-san-studio/issues/1120]

The default WindowsProactorEventLoopPolicy on Python 3.8+/Windows silently stalls the in-process sub-network handoff used when agent_network_designer invokes /agent_network_editor via AsyncDirectAgentSession. The producer task hands chat messages to a consumer via an asyncio queue, and that handoff never connects under Proactor - the editor never returns its first tool call, no error is raised, and the streaming response just hangs. Switching to WindowsSelectorEventLoopPolicy at the server entry point (before any neuro_san imports) restores the expected behavior. Verified end-to-end on Windows 11 / Python 3.13 / neuro-san 0.6.57: agent_network_designer now produces registries/generated/<name>.hocon as expected. Tested with both small (one-agent) and large (Santa's Workshop, 15-agent) prompts.

Fixes # <!-- Issue number, if applicable -->
[https://github.com/cognizant-ai-lab/neuro-san-studio/issues/1120]

## Impact
See comments on ticket. It looks like someone else already fixed the following files involved in this fix, that were calling an older version of neuro-san:

> .\coded_tools\agent_network_editor\designer_network_inspector.py
> .\middleware\agent_network_desginer\persistence\agent_network_persistence_middleware.py

The code called UnreachableNodesNetworkValidator().find_all_top_agents(...), but upstream neuro-san (0.6.57 installed locally vs. 0.6.55 pinned in requirements.txt) renamed that method to find_all_front_man_agents. Calling the old name raised AttributeError inside aafter_agent's _assemble_and_persist, before any persistence markers could log — so the file never got written and no error surfaced in the UI.
Fix: Renamed both call sites to find_all_front_man_agents.
It looks like these issues were already fixed. However, those changes will not run on Windows without this fix.

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
