### PR TITLE
Add `ns --version` to the CLI

### DIFF
--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -37,8 +37,7 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
         add_completion=False,
     )
 
-    @staticmethod
-    def _version_callback(value: bool) -> None:
+    def _version_callback(value: bool) -> bool:  # pylint: disable=no-self-argument
         """Print the installed neuro-san-studio version and exit (for `--version`)."""
         if value:
             # pylint: disable-next=import-outside-toplevel
@@ -46,6 +45,7 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
 
             typer.echo(f"neuro-san-studio {studio_version()}")
             raise typer.Exit()
+        return value
 
     @staticmethod
     @app.callback()

--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -38,6 +38,30 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
     )
 
     @staticmethod
+    def _version_callback(value: bool) -> None:
+        """Print the installed neuro-san-studio version and exit (for `--version`)."""
+        if value:
+            # pylint: disable-next=import-outside-toplevel
+            from neuro_san_studio.utils.version import studio_version
+
+            typer.echo(f"neuro-san-studio {studio_version()}")
+            raise typer.Exit()
+
+    @staticmethod
+    @app.callback()
+    def _main(
+        _version: bool = typer.Option(
+            False,
+            "--version",
+            "-V",
+            help="Show the installed neuro-san-studio version and exit.",
+            callback=_version_callback,
+            is_eager=True,
+        ),
+    ) -> None:
+        """Neuro SAN Studio CLI."""
+
+    @staticmethod
     def _invoke_run(extra_args: List[str]) -> None:
         """Run the server, exposing `extra_args` to NeuroSanRunner.parse_args() via sys.argv."""
         sys.argv = [sys.argv[0], *extra_args]

--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -37,13 +37,15 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
         add_completion=False,
     )
 
-    def _version_callback(value: bool) -> bool:  # pylint: disable=no-self-argument
-        """Print the installed neuro-san-studio version and exit (for `--version`)."""
+    @staticmethod
+    def _version_callback(value: bool) -> bool:
+        """Print the neuro-san-studio version (and where it resolved from) and exit."""
         if value:
             # pylint: disable-next=import-outside-toplevel
-            from neuro_san_studio.utils.version import studio_version
+            from neuro_san_studio.utils.version import resolve_version
 
-            typer.echo(f"neuro-san-studio {studio_version()}")
+            version, source = resolve_version()
+            typer.echo(f"neuro-san-studio {version} ({source})")
             raise typer.Exit()
         return value
 

--- a/neuro_san_studio/utils/version.py
+++ b/neuro_san_studio/utils/version.py
@@ -14,21 +14,52 @@
 #
 # END COPYRIGHT
 
+import logging
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as library_version
+from pathlib import Path
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
 
 # The distribution name as published / installed (see pyproject `[project].name`).
 DISTRIBUTION_NAME = "neuro-san-studio"
 
+# Repo root (…/neuro_san_studio/utils/version.py -> two parents up), for the
+# source-checkout fallback when the package isn't installed.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Where the version was resolved from.
+SOURCE_INSTALLED = "installed"
+SOURCE_SCM = "source"
+SOURCE_UNKNOWN = "unknown"
+
 
 def studio_version() -> str:
-    """Resolve the installed neuro-san-studio version.
+    """Bare version string, for callers that don't care where it came from."""
+    return resolve_version()[0]
 
-    Reads the installed distribution metadata (populated by setuptools-scm at build
-    time). Returns 'unknown' if it can't be found, so callers always get a string
-    and never raise.
-    """
+
+def resolve_version() -> Tuple[str, str]:
+    """Resolve ``(version, source)``, never raising: installed metadata, then scm, then unknown."""
     try:
-        return str(library_version(DISTRIBUTION_NAME))
+        return str(library_version(DISTRIBUTION_NAME)), SOURCE_INSTALLED
     except PackageNotFoundError:
-        return "unknown"
+        logger.warning(
+            "%s is not installed as a distribution; falling back to setuptools-scm.",
+            DISTRIBUTION_NAME,
+        )
+    scm = _scm_version()
+    if scm:
+        return scm, SOURCE_SCM
+    return "unknown", SOURCE_UNKNOWN
+
+
+def _scm_version() -> str:
+    """Version from setuptools-scm reading the repo, or '' if it isn't importable."""
+    try:
+        from setuptools_scm import get_version  # pylint: disable=import-outside-toplevel
+
+        return str(get_version(root=str(_REPO_ROOT)))
+    except (ImportError, LookupError, OSError):
+        return ""

--- a/neuro_san_studio/utils/version.py
+++ b/neuro_san_studio/utils/version.py
@@ -1,0 +1,34 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as library_version
+
+# The distribution name as published / installed (see pyproject `[project].name`).
+DISTRIBUTION_NAME = "neuro-san-studio"
+
+
+def studio_version() -> str:
+    """Resolve the installed neuro-san-studio version.
+
+    Reads the installed distribution metadata (populated by setuptools-scm at build
+    time). Returns 'unknown' if it can't be found, so callers always get a string
+    and never raise.
+    """
+    try:
+        return str(library_version(DISTRIBUTION_NAME))
+    except PackageNotFoundError:
+        return "unknown"

--- a/neuro_san_studio/utils/version.py
+++ b/neuro_san_studio/utils/version.py
@@ -15,6 +15,7 @@
 # END COPYRIGHT
 
 import logging
+import subprocess
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as library_version
 from pathlib import Path
@@ -26,12 +27,13 @@ logger = logging.getLogger(__name__)
 DISTRIBUTION_NAME = "neuro-san-studio"
 
 # Repo root (…/neuro_san_studio/utils/version.py -> two parents up), for the
-# source-checkout fallback when the package isn't installed.
+# source-checkout fallbacks when the package isn't installed.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Where the version was resolved from.
 SOURCE_INSTALLED = "installed"
 SOURCE_SCM = "source"
+SOURCE_GIT = "git"
 SOURCE_UNKNOWN = "unknown"
 
 
@@ -41,17 +43,22 @@ def studio_version() -> str:
 
 
 def resolve_version() -> Tuple[str, str]:
-    """Resolve ``(version, source)``, never raising: installed metadata, then scm, then unknown."""
+    """Resolve ``(version, source)``, never raising: installed metadata, then scm, then git sha, then unknown."""
     try:
         return str(library_version(DISTRIBUTION_NAME)), SOURCE_INSTALLED
     except PackageNotFoundError:
-        logger.warning(
-            "%s is not installed as a distribution; falling back to setuptools-scm.",
-            DISTRIBUTION_NAME,
-        )
+        logger.warning("%s is not installed as a distribution; trying setuptools-scm.", DISTRIBUTION_NAME)
+
     scm = _scm_version()
     if scm:
         return scm, SOURCE_SCM
+
+    logger.warning("setuptools-scm unavailable; trying the git sha.")
+    sha = _git_sha()
+    if sha:
+        return sha, SOURCE_GIT
+
+    logger.warning("Could not determine a git sha; version is unknown.")
     return "unknown", SOURCE_UNKNOWN
 
 
@@ -62,4 +69,18 @@ def _scm_version() -> str:
 
         return str(get_version(root=str(_REPO_ROOT)))
     except (ImportError, LookupError, OSError):
+        return ""
+
+
+def _git_sha() -> str:
+    """Short git sha of the repo checkout, or '' if not a git checkout / git is missing."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(_REPO_ROOT), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
         return ""

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -16,3 +16,6 @@ pytest-xdist>=3.6.1
 # Code quality
 ruff==0.11.12
 pylint==3.3.1
+
+# Lets `ns --version` resolve the version from a source checkout.
+setuptools-scm==8.1.0

--- a/tests/neuro_san_studio/commands/test_cli.py
+++ b/tests/neuro_san_studio/commands/test_cli.py
@@ -124,3 +124,19 @@ class TestMainEntryPoint:
         monkeypatch.setattr(sys, "argv", ["neuro-san-studio", "run"])
         with pytest.raises(RuntimeError, match="boom"):
             main()
+
+    @pytest.mark.parametrize("flag", ["--version", "-V"])
+    def test_version_flag_prints_version_and_exits(
+        self, flag: str, monkeypatch: MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`ns --version` / `-V` prints the resolved version and exits without starting the server."""
+        call_order = self._install_fake_runner(monkeypatch)
+        monkeypatch.setattr(
+            "neuro_san_studio.utils.version.studio_version",
+            lambda: "1.2.3",
+        )
+        monkeypatch.setattr(sys, "argv", ["neuro-san-studio", flag])
+        # The eager callback raises typer.Exit(0); main() swallows clean exits.
+        main()
+        assert "neuro-san-studio 1.2.3" in capsys.readouterr().out
+        assert not call_order

--- a/tests/neuro_san_studio/commands/test_cli.py
+++ b/tests/neuro_san_studio/commands/test_cli.py
@@ -132,11 +132,11 @@ class TestMainEntryPoint:
         """`ns --version` / `-V` prints the resolved version and exits without starting the server."""
         call_order = self._install_fake_runner(monkeypatch)
         monkeypatch.setattr(
-            "neuro_san_studio.utils.version.studio_version",
-            lambda: "1.2.3",
+            "neuro_san_studio.utils.version.resolve_version",
+            lambda: ("1.2.3", "installed"),
         )
         monkeypatch.setattr(sys, "argv", ["neuro-san-studio", flag])
         # The eager callback raises typer.Exit(0); main() swallows clean exits.
         main()
-        assert "neuro-san-studio 1.2.3" in capsys.readouterr().out
+        assert "neuro-san-studio 1.2.3 (installed)" in capsys.readouterr().out
         assert not call_order

--- a/tests/neuro_san_studio/utils/test_version.py
+++ b/tests/neuro_san_studio/utils/test_version.py
@@ -19,16 +19,26 @@ from importlib.metadata import PackageNotFoundError
 import pytest
 
 from neuro_san_studio.utils import version as version_module
+from neuro_san_studio.utils.version import resolve_version
 from neuro_san_studio.utils.version import studio_version
 
 
-class TestStudioVersion:
-    """Resolving the installed neuro-san-studio version."""
+class TestResolveVersion:
+    """Resolving (version, source) for neuro-san-studio."""
 
-    def test_returns_installed_distribution_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The resolved string is whatever the distribution metadata reports."""
+    @staticmethod
+    def _uninstalled(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Make the distribution-metadata lookup behave as not-installed."""
+
+        def boom(_name: str) -> str:
+            raise PackageNotFoundError("neuro-san-studio")
+
+        monkeypatch.setattr(version_module, "library_version", boom)
+
+    def test_installed_distribution_reports_installed_source(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Distribution metadata gives the version tagged as 'installed'."""
         monkeypatch.setattr(version_module, "library_version", lambda _name: "1.2.3")
-        assert studio_version() == "1.2.3"
+        assert resolve_version() == ("1.2.3", "installed")
 
     def test_resolves_the_studio_distribution_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The resolver looks up the published distribution name, not the import package."""
@@ -39,14 +49,32 @@ class TestStudioVersion:
             return "9.9.9"
 
         monkeypatch.setattr(version_module, "library_version", fake_version)
-        studio_version()
+        resolve_version()
         assert seen["name"] == "neuro-san-studio"
 
-    def test_falls_back_to_unknown_when_not_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A missing distribution surfaces 'unknown' rather than raising."""
+    def test_scm_fallback_reports_source(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An uninstalled checkout resolves via setuptools-scm, tagged 'source'."""
+        self._uninstalled(monkeypatch)
+        monkeypatch.setattr(version_module, "_scm_version", lambda: "0.0.0.dev1+gabc1234")
+        assert resolve_version() == ("0.0.0.dev1+gabc1234", "source")
 
-        def boom(_name: str) -> str:
-            raise PackageNotFoundError("neuro-san-studio")
+    def test_unknown_when_not_installed_and_no_scm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No distribution and no setuptools-scm surfaces ('unknown', 'unknown')."""
+        self._uninstalled(monkeypatch)
+        monkeypatch.setattr(version_module, "_scm_version", lambda: "")
+        assert resolve_version() == ("unknown", "unknown")
 
-        monkeypatch.setattr(version_module, "library_version", boom)
-        assert studio_version() == "unknown"
+    def test_warns_when_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The not-installed fallback logs a warning rather than failing silently."""
+        self._uninstalled(monkeypatch)
+        monkeypatch.setattr(version_module, "_scm_version", lambda: "")
+        with caplog.at_level("WARNING"):
+            resolve_version()
+        assert "not installed" in caplog.text
+
+    def test_studio_version_returns_bare_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """studio_version() drops the source tag, returning just the version string."""
+        monkeypatch.setattr(version_module, "library_version", lambda _name: "1.2.3")
+        assert studio_version() == "1.2.3"

--- a/tests/neuro_san_studio/utils/test_version.py
+++ b/tests/neuro_san_studio/utils/test_version.py
@@ -58,21 +58,32 @@ class TestResolveVersion:
         monkeypatch.setattr(version_module, "_scm_version", lambda: "0.0.0.dev1+gabc1234")
         assert resolve_version() == ("0.0.0.dev1+gabc1234", "source")
 
-    def test_unknown_when_not_installed_and_no_scm(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """No distribution and no setuptools-scm surfaces ('unknown', 'unknown')."""
+    def test_git_fallback_reports_git_source(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no distribution and no scm, the short git sha is used, tagged 'git'."""
         self._uninstalled(monkeypatch)
         monkeypatch.setattr(version_module, "_scm_version", lambda: "")
+        monkeypatch.setattr(version_module, "_git_sha", lambda: "abc1234")
+        assert resolve_version() == ("abc1234", "git")
+
+    def test_unknown_when_nothing_resolves(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No distribution, no scm, and no git sha surfaces ('unknown', 'unknown')."""
+        self._uninstalled(monkeypatch)
+        monkeypatch.setattr(version_module, "_scm_version", lambda: "")
+        monkeypatch.setattr(version_module, "_git_sha", lambda: "")
         assert resolve_version() == ("unknown", "unknown")
 
-    def test_warns_when_not_installed(
+    def test_warns_through_each_fallback(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """The not-installed fallback logs a warning rather than failing silently."""
+        """Each degradation step logs a warning rather than failing silently."""
         self._uninstalled(monkeypatch)
         monkeypatch.setattr(version_module, "_scm_version", lambda: "")
+        monkeypatch.setattr(version_module, "_git_sha", lambda: "")
         with caplog.at_level("WARNING"):
             resolve_version()
         assert "not installed" in caplog.text
+        assert "setuptools-scm unavailable" in caplog.text
+        assert "git sha" in caplog.text
 
     def test_studio_version_returns_bare_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """studio_version() drops the source tag, returning just the version string."""

--- a/tests/neuro_san_studio/utils/test_version.py
+++ b/tests/neuro_san_studio/utils/test_version.py
@@ -1,0 +1,52 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+
+from neuro_san_studio.utils import version as version_module
+from neuro_san_studio.utils.version import studio_version
+
+
+class TestStudioVersion:
+    """Resolving the installed neuro-san-studio version."""
+
+    def test_returns_installed_distribution_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The resolved string is whatever the distribution metadata reports."""
+        monkeypatch.setattr(version_module, "library_version", lambda _name: "1.2.3")
+        assert studio_version() == "1.2.3"
+
+    def test_resolves_the_studio_distribution_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The resolver looks up the published distribution name, not the import package."""
+        seen: dict = {}
+
+        def fake_version(name: str) -> str:
+            seen["name"] = name
+            return "9.9.9"
+
+        monkeypatch.setattr(version_module, "library_version", fake_version)
+        studio_version()
+        assert seen["name"] == "neuro-san-studio"
+
+    def test_falls_back_to_unknown_when_not_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A missing distribution surfaces 'unknown' rather than raising."""
+
+        def boom(_name: str) -> str:
+            raise PackageNotFoundError("neuro-san-studio")
+
+        monkeypatch.setattr(version_module, "library_version", boom)
+        assert studio_version() == "unknown"


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description
Add a sub-command `ns --version` / `ns -V` to print the installed neuro-san-studio version, backed by a reusable studio_version() resolver.
The version resolver chain is: `installed -> scm -> git sha -> unknown`
Note: If neuro-san-studio isn't pip/uv installed to its own repo, the command would be `python -m neuro-san-studio --version` because `ns` isn't registered as an alias without installation.

Fixes #1139

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
