### PR TITLE
Add Checkmarx One workflow

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -6,9 +6,6 @@ permissions:
     security-events: write
 
 on:
-    push:
-        branches:
-            - devin/1781038401-add-checkmarx
     schedule:
         # M-F at 3:00 am UTC (offset from neuro-san and neuro-san-ui)
         - cron: "0 3 * * 1-5"

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,0 +1,34 @@
+---
+name: Checkmarx One
+
+permissions:
+    contents: read
+    security-events: write
+
+on:
+    push:
+        branches:
+            - devin/1781038401-add-checkmarx
+    schedule:
+        # M-F at 3:00 am UTC (offset from neuro-san and neuro-san-ui)
+        - cron: "0 3 * * 1-5"
+    workflow_dispatch:
+
+jobs:
+    checkmarx-scan:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              # v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+              with:
+                  fetch-depth: 0
+
+            - name: Run Checkmarx One scan
+              # build-common 1.0.7
+              uses: cognizant-ai-lab/build-common/actions/checkmarx-one@3ead7f681f92044709ffc3a533f41c3f48230cfd
+              with:
+                  base-uri: ${{ vars.CX_BASE_URI }}
+                  cx-tenant: ${{ vars.CX_TENANT }}
+                  cx-client-id: ${{ vars.CX_CLIENT_ID }}
+                  cx-client-secret: ${{ secrets.CX_CLIENT_SECRET }}


### PR DESCRIPTION
## Description

Adds a Checkmarx One SAST/SCA scan workflow using the `build-common/actions/checkmarx-one@1.0.7` composite action. Runs on a M–F schedule (3:00 UTC) and supports `workflow_dispatch`. Includes a temporary push trigger for branch validation that will be removed before merge.
 
 We run it nightly in the same way in neuro-san and neuro-san-ui, and report failures to the NightWatcher so we'll know if we regress anything in Checkmarx.

## Impact

Enables periodic Checkmarx security scanning for neuro-san-studio, matching the setup already in place for neuro-san and neuro-san-ui.

## Type of Change

- [x] New feature

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/fa003ff86bb34485a399856794ea8d65
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/1141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->