### PR TITLE
Fix `ns import` coded tools resolution hierarchy

### DIFF
--- a/neuro_san_studio/discovery/dependency_analyzer.py
+++ b/neuro_san_studio/discovery/dependency_analyzer.py
@@ -125,11 +125,18 @@ class DependencyAnalyzer:
             module_file = os.path.join(root, *parts[1:-1]) + ".py"
             return f"{parts[0]}/" + "/".join(parts[1:-1]) + ".py" if os.path.exists(module_file) else None
 
-        # Short reference like "order_api.OrderAPI" — resolve under context_dir
+        # Short reference like "order_api.OrderAPI" — resolve up the context hierarchy, the way
+        # neuro-san does (abstract_class_activation._attempt_resolve): try the per-network dir
+        # first, then strip one trailing level at a time down to coded_tools/ root. So a tool at
+        # the group level (coded_tools/basic/accountant.py) is found even when the network's
+        # context_dir is basic/music_nerd_pro (issue #1147).
         if len(parts) == 2 and context_dir:
-            candidate = os.path.join(self.coded_tools_dir, context_dir, parts[0] + ".py")
-            if os.path.exists(candidate):
-                return f"coded_tools/{context_dir}/{parts[0]}.py"
+            context_parts = context_dir.split("/")
+            module = parts[0]
+            for depth in range(len(context_parts), -1, -1):
+                rel = "/".join([*context_parts[:depth], f"{module}.py"])
+                if os.path.exists(os.path.join(self.coded_tools_dir, rel)):
+                    return f"coded_tools/{rel}"
 
         # Long-form reference under coded_tools/
         if os.path.exists(os.path.join(self.coded_tools_dir, *parts[:-1]) + ".py"):

--- a/tests/neuro_san_studio/discovery/test_coded_tool_resolution.py
+++ b/tests/neuro_san_studio/discovery/test_coded_tool_resolution.py
@@ -1,0 +1,60 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for DependencyAnalyzer.resolve_coded_tool_path short-form hierarchy resolution."""
+
+# pylint: disable=protected-access
+
+from pathlib import Path
+
+from neuro_san_studio.discovery.dependency_analyzer import DependencyAnalyzer
+
+
+def _analyzer(tmp_path: Path) -> DependencyAnalyzer:
+    """A DependencyAnalyzer pointed at empty registries/coded_tools/middleware under tmp_path."""
+    return DependencyAnalyzer(
+        str(tmp_path / "registries"),
+        str(tmp_path / "coded_tools"),
+        str(tmp_path / "middleware"),
+    )
+
+
+class TestShortFormResolution:
+    """A short-form ``module.Class`` ref resolves up the group hierarchy, like neuro-san."""
+
+    def test_resolves_tool_in_per_network_dir(self, tmp_path: Path) -> None:
+        """A tool under coded_tools/<group>/<network>/ is found via context_dir."""
+        tool = tmp_path / "coded_tools" / "basic" / "music_nerd" / "lookup.py"
+        tool.parent.mkdir(parents=True)
+        tool.write_text("class Lookup: pass\n")
+
+        result = _analyzer(tmp_path).resolve_coded_tool_path("lookup.Lookup", context_dir="basic/music_nerd")
+        assert result == "coded_tools/basic/music_nerd/lookup.py"
+
+    def test_resolves_group_level_tool(self, tmp_path: Path) -> None:
+        """A tool at the group level coded_tools/<group>/ is found when not in the network dir.
+
+        Regression for issue #1147: music_nerd_pro's ``accountant.Accountant`` lives at
+        coded_tools/basic/accountant.py, not coded_tools/basic/music_nerd_pro/accountant.py.
+        """
+        tool = tmp_path / "coded_tools" / "basic" / "accountant.py"
+        tool.parent.mkdir(parents=True)
+        tool.write_text("class Accountant: pass\n")
+
+        result = _analyzer(tmp_path).resolve_coded_tool_path(
+            "accountant.Accountant", context_dir="basic/music_nerd_pro"
+        )
+        assert result == "coded_tools/basic/accountant.py"


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description
Mirror neuro-san's runtime resolution (abstract_class_activation._attempt_resolve): walk the context hierarchy from most specific to most general, checking coded_tools/<level>/<module>.py at each step (basic/music_nerd_pro then basic then root), returning the first match.

Fixes #1147

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
