### PR TITLE
Add sly_data schema to you_search and introduce free-tier variant

### DIFF
--- a/registries/manifest_multiuser_overlay.hocon
+++ b/registries/manifest_multiuser_overlay.hocon
@@ -34,6 +34,7 @@
     #   4. Requires use of external services not readily deployed by the average bear
     #      (like databases)
     #   5. Have-a or is-a dependency on a particular agent network that has one of the above issues.
+    #   6. Requires per-user authentication credentials (e.g. OAuth bearer token or API key)
     #
     # To use this file, we simply add a reference to it at the end of our existing
     # AGENT_MANIFEST_FILE specification # like this:
@@ -47,6 +48,7 @@
     "tools/agentforce.hocon": false,                    # Reason #2
     "tools/openai_image_generation.hocon": false,       # Reason #1
     "tools/persistent_memory_local.hocon": false,       # Reason #1
+    "tools/you_search.hocon": false,                    # Reason #6
 
     # Experimental and research
     "agent_network_designer.hocon": true,               # Reason #1. Needs AGENT_NETWORK_DESIGNER_USE_RESERVATIONS=true

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -151,6 +151,8 @@
     # Wikimedia media search
     "tools/wikimedia_search.hocon": true,
 
-    # Requires YDC_API_KEY. See docs/search_tools.md and neuro_san_studio/mcp/mcp_info.hocon for setup.
-    "tools/you_search.hocon": false,
+    # Requires YDC_API_KEY or OAuth Authentication. See docs/search_tools.md and neuro_san_studio/mcp/mcp_info.hocon for setup.
+    "tools/you_search.hocon": true,
+    # Free version of you_search that does not require API key but has limited capabilities via the you.com MCP server.
+    "tools/you_search_free.hocon": true,
 }

--- a/registries/tools/you_search.hocon
+++ b/registries/tools/you_search.hocon
@@ -89,8 +89,7 @@
                             "properties": {
                                 "https://api.you.com/mcp": {
                                     "type": "object",
-                                    "description": "URL for GitHub MCP server.",
-                                    "properties": {
+                                    "description": "URL for You.com MCP server.",
                                         "Authorization": {
                                             "type": "string",
                                             "description": "Authorization header for you.com API access, e.g., 'Bearer <token_value>'."

--- a/registries/tools/you_search.hocon
+++ b/registries/tools/you_search.hocon
@@ -14,11 +14,20 @@
 #
 # END COPYRIGHT
 
-# Requirement to use this agent network:
-    # - neuro-san>=0.6.24
-    # - YDC_API_KEY
-    # - Get a free API key with $100 in credits (no credit card required) at https://you.com/platform
-    # - Use MCP_SERVERS_INFO_FILE for authentication. See ../../neuro_san_studio/mcp/mcp_info.hocon and ../../docs/user_guide.md#authentication
+# Requirements to use this agent network:
+#   - neuro-san >= 0.6.24
+#   - Credentials for the you.com MCP server: either a YDC_API_KEY or a bearer token.
+#     you.com offers a free tier; use the `you_search_free` agent network to access it.
+#
+# Supported authentication methods:
+#   1. OAuth token exchange in the client application. Pass the resulting bearer token
+#      via the sly data "http_headers" input, following the schema in the agent function
+#      definition below.
+#   2. MCP_SERVERS_INFO_FILE. See ../../neuro_san_studio/mcp/mcp_info.hocon and
+#      ../../docs/user_guide.md#authentication.
+#
+# Note: when `sly_data_schema` is defined, nsflow requires the bearer token to be passed
+# as sly data even if an API key is already configured in the MCP info file.
 
 {
     # Optional metadata describing this agent network
@@ -60,6 +69,40 @@
                         },
                     },
                     "required": ["user_inquiry"]
+                },
+
+                # You can optionally specify the schema needed for any sly_data as input.
+                # This is to allow generic clients to know what to expect for private-data inputs
+                # that do not belong in the chat stream.
+                #
+                # Note: this block is required only for the OAuth bearer-token flow. If you are
+                # authenticating via YDC_API_KEY (or via MCP_SERVERS_INFO_FILE), comment out or
+                # remove the entire "sly_data_schema" block below — otherwise nsflow will still
+                # expect a bearer token to be passed in as sly data.
+                "sly_data_schema": {
+                    "type": "object",
+                    "properties": {
+                        # This tells the client to pass the necessary authentication info for accessing the you.com MCP server via sly data.
+                        "http_headers": {
+                            "type": "object",
+                            "description": "HTTP headers to be sent with MCP tool requests.",
+                            "properties": {
+                                "https://api.you.com/mcp": {
+                                    "type": "object",
+                                    "description": "URL for GitHub MCP server.",
+                                    "properties": {
+                                        "Authorization": {
+                                            "type": "string",
+                                            "description": "Authorization header for you.com API access, e.g., 'Bearer <token_value>'."
+                                        }
+                                    },
+                                    "required": ["Authorization"]
+                                }
+                            },
+                            "required": ["https://api.you.com/mcp"]
+                        }
+                    },
+                    "required": ["http_headers"]
                 }
             },
 

--- a/registries/tools/you_search_free.hocon
+++ b/registries/tools/you_search_free.hocon
@@ -1,0 +1,71 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# Requirements to use this agent network:
+#   - neuro-san >= 0.6.24
+#   - This network targets the you.com MCP server's free tier (?profile=free).
+#     For authenticated/paid usage, see the `you_search` agent network instead.
+
+{
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent that can use You.com MCP server for web search, content extraction, and AI research.",
+        "tags": ["tool", "you_search"]
+        "sample_queries": [
+            "Search the web for the latest news on AI agents.",
+            "Extract the content from https://docs.you.com/search/overview in Markdown format.",
+            "Research the current state of MCP server adoption and give me a summary with citations."
+        ]
+    },
+
+    include "config/llm_config.hocon",
+
+    "tools": [
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
+        #
+        # Besides the first agent being the front man, these tool definitions
+        # do not have to be in any particular order. How they are linked and
+        # call each other is defined within their own specs.
+        # This could be a graph, potentially even with cycles.
+        {
+            "name": "web_searcher",
+
+            "function": {
+                "description": "Assist caller with searching the web, extracting page content, and performing AI research using You.com.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "user_inquiry": {
+                            "type": "string",
+                            "description": "An inquiry from a user."
+                        },
+                    },
+                    "required": ["user_inquiry"]
+                }
+            },
+
+            "instructions": """
+Use your tools to respond to the inquiry.
+""",
+            "tools": ["https://api.you.com/mcp?profile=free"]
+        },
+    ]
+}


### PR DESCRIPTION


<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

- you_search.hocon: add sly_data_schema so clients can supply an OAuth bearer token via sly data; document OAuth and MCP-info-file auth methods in the header.
- you_search_free.hocon: new agent network targeting the you.com free tier via ?profile=free, no credentials required.
- tools/manifest.hocon: enable you_search by default and register the new free variant.
- manifest_multiuser_overlay.hocon: keep you_search out of multi-user deployments under a new Reason #6 — requires per-user OAuth or API key that the multi-user client/server pair can't supply yet.

Fixes #1157

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [x] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
