### PR TITLE
Tweak Dockerfile and cluster_llm_config

### DIFF
--- a/config/cluster_llm_config.hocon
+++ b/config/cluster_llm_config.hocon
@@ -55,13 +55,13 @@
             },
             {
                 # Fall back to Anthropic Claude if OpenAI is unavailable.
-                "class": "anthropic",
+                # Let neuro-san figure out the latest version of the model
                 "model_name": "claude-sonnet",
                 "max_retries": 1,
             },
             {
                 # Fall back to Google Gemini if both OpenAI and Anthropic are unavailable.
-                "class": "gemini",
+                # Let neuro-san figure out the latest version of the model
                 "model_name": "gemini-3-flash",
                 "max_retries": 1,
             }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -299,6 +299,16 @@ ENV AGENT_HTTP_SERVER_INSTANCES="1"
 # Logging period is specified in seconds.
 ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL="0"
 
+# Interval in seconds between HTTP heartbeat writes sent to streaming clients
+# to keep the connection alive during long quiet periods. This is important
+# when intermediaries (nginx, load balancers, AWS ALB) or clients would otherwise
+# drop an idle HTTP connection (commonly after ~60s) before the agent produces
+# its next streamed message. The heartbeat only fires when the stream has been
+# quiet for the full interval; real message traffic suppresses it.
+# A value of 0 (the default) disables the heartbeat entirely.
+# Typical production value is 25-30 (under the 60s defaults of common proxies).
+ENV AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL=0
+
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.
 ENV AGENT_EXTERNAL_SERVER_URL=""

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -219,7 +219,7 @@ ENV AGENT_FORWARDED_REQUEST_METADATA="request_id user_id"
 # for it on your docker run command line.
 ENV AGENT_HTTP_PORT="8080"
 
-# Maximm number of requests that can be served at the same time
+# Maximum number of requests that can be served at the same time
 ENV AGENT_MAX_CONCURRENT_REQUESTS="50"
 
 # Number of requests served before the server shuts down in an orderly fashion.
@@ -246,17 +246,6 @@ ENV AGENT_MANIFEST_UPDATE_PERIOD_SECONDS="0"
 # after a colon, like this: "my_repo:1.2.3".
 # You can combine these too, like this: "langchain openai my_repo:1.2.3"
 ENV AGENT_VERSION_LIBS=""
-
-# A reference to a Python class that can be used to log per-user request information.
-# This class must have a no-args constructor and implement the
-# neuro_san.interfaces.usage_logger.UsageLogger interface.
-# When not set, this defaults to a null implementation.
-ENV AGENT_USAGE_LOGGER=""
-
-# A space-delimited list of http metadata request keys to forward to the AGENT_USAGE_LOGGER
-# described above. When not set, this defaults to the value provided by
-# AGENT_FORWARDED_REQUEST_METADATA
-ENV AGENT_USAGE_LOGGER_METADATA=""
 
 # A space-delimited list of http metadata request keys to forward to tracing/Observability
 # infrastructure. When not set, this defaults to the value provided by
@@ -310,17 +299,6 @@ ENV AGENT_HTTP_SERVER_INSTANCES="1"
 # Logging period is specified in seconds.
 ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL="0"
 
-# If this value is specified and >0,
-# it will enable dynamic temporary network updates of the server agents
-# allowing CodedTools to reserve temporary networks via the Reservationist
-# interface, if the agent network hocon file specifically allows it for the tool.
-# Update will be done every AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS seconds;
-# if value is not specified or <= 0, no such dynamic updates will be executed.
-# This particular sample deployment turns this on to 5 seconds to be able to show off the feature
-# in a multi-user environment, however most Neuro SAN deployments will want this set to 0
-# to disable the feature for safety.
-ENV AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS="5"
-
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.
 ENV AGENT_EXTERNAL_SERVER_URL=""
@@ -339,6 +317,19 @@ ENV AGENT_EXTERNAL_RESERVATIONS_STORAGE=""
 # to use for cross-pod reservations storage.
 ENV AGENT_RESERVATIONS_S3_BUCKET=""
 
+# If AGENT_EXTERNAL_RESERVATIONS_STORAGE is set,
+# then this parameter specifies the period in seconds for checking the external storage for expired reservations.
+# Value of 0 means no periodic checks will be performed by the service,
+# in this case it is expected that the external storage itself will handle expired reservations,
+# or it will be done on demand by other tools.
+ENV AGENT_RESERVATIONS_EXTERNAL_STORAGE_CHECK_PERIOD_SECONDS="0"
+
+# The maximum number of temporary agent networks that will be kept internally
+# in service memory at the same time. If this limit is reached,
+# the oldest temporary networks (by access time) will be evicted.
+# 0 or negative value means unlimited.
+ENV AGENT_MAX_TEMP_NETWORKS="0"
+
 # A hocon file with MCP servers information to be used by LangChainMcpAdapter
 # for connecting to external MCP servers with authentication and tool filtering.
 ENV MCP_SERVERS_INFO_FILE="${APP_SOURCE}/neuro_san_studio/mcp/mcp_info.hocon"
@@ -352,10 +343,20 @@ ENV AGENT_MCP_ENABLE="true"
 # while disabling neuro-san own http API.
 ENV AGENT_MCP_ONLY="false"
 
+#
+# Server Hardening
+#
+
 # When set to "true", this parameter requires https for internal agent session communication.
-# The default is "false", to allow developers to work locally without acquiring certificates.
-# Strongly consider turning this on for production deployments.
-ENV AGENT_SESSION_REQUIRE_HTTPS="false"
+# The default is "true". Developers should set this to false to work locally without acquiring certificates.
+# Strongly consider keeping this on for production deployments.
+ENV AGENT_SESSION_REQUIRE_HTTPS="true"
+
+# When set to "false", this parameter will squelch the logging of sensitive information
+# as flagged by static analysis (SAST) tools.
+# The default is "false". Developers should set this to true to work locally with reasonable failure information.
+# Strongly consider keeping this off for production deployments.
+ENV LEAF_LOG_SENSITIVE="false"
 
 #
 # Authorization

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -76,6 +76,8 @@ function run() {
         -e LANGFUSE_HOST \
         -e AGENT_RESERVATIONS_S3_BUCKET \
         -e AGENT_EXTERNAL_RESERVATIONS_STORAGE \
+        -e AGENT_SESSION_REQUIRE_HTTPS="false" \
+        -e LEAF_LOG_SENSITIVE="true" \
         -e TOOL_REGISTRY_FILE=$1 \
         -p $SERVICE_HTTP_PORT:$SERVICE_HTTP_PORT \
             neuro-san/${SERVICE_TAG}:$CONTAINER_VERSION"

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -76,8 +76,8 @@ function run() {
         -e LANGFUSE_HOST \
         -e AGENT_RESERVATIONS_S3_BUCKET \
         -e AGENT_EXTERNAL_RESERVATIONS_STORAGE \
-        -e AGENT_SESSION_REQUIRE_HTTPS='false' \
-        -e LEAF_LOG_SENSITIVE='true' \
+        -e AGENT_SESSION_REQUIRE_HTTPS=false \
+        -e LEAF_LOG_SENSITIVE=true \
         -e TOOL_REGISTRY_FILE=$1 \
         -p $SERVICE_HTTP_PORT:$SERVICE_HTTP_PORT \
             neuro-san/${SERVICE_TAG}:$CONTAINER_VERSION"

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -76,8 +76,8 @@ function run() {
         -e LANGFUSE_HOST \
         -e AGENT_RESERVATIONS_S3_BUCKET \
         -e AGENT_EXTERNAL_RESERVATIONS_STORAGE \
-        -e AGENT_SESSION_REQUIRE_HTTPS="false" \
-        -e LEAF_LOG_SENSITIVE="true" \
+        -e AGENT_SESSION_REQUIRE_HTTPS='false' \
+        -e LEAF_LOG_SENSITIVE='true' \
         -e TOOL_REGISTRY_FILE=$1 \
         -p $SERVICE_HTTP_PORT:$SERVICE_HTTP_PORT \
             neuro-san/${SERVICE_TAG}:$CONTAINER_VERSION"


### PR DESCRIPTION
## Description

@donn-leaf is primary

* Sync the Dockerfile with new env vars from neuro-san repo.
* Make the defaults in the Dockerfile enforce security-by-default.
* Let the developer-centric run.sh soften the https and sensitive logging requirements for sanity
* Remove class definitions for anthropic and gemini in cluster_llm_config.hocon

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [X] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
