### PR TITLE
Bump build-common to 1.0.8

### DIFF
--- a/.github/workflows/agent_network_designer.yml
+++ b/.github/workflows/agent_network_designer.yml
@@ -12,8 +12,8 @@ jobs:
   agent-network-designer-test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san-studio'
-    # cognizant-ai-lab/build-common 1.0.7
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
+    # cognizant-ai-lab/build-common 1.0.8
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.13'
       # Required by build_scripts/server_start.sh:

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -22,8 +22,8 @@ jobs:
                   fetch-depth: 0
 
             - name: Run Checkmarx One scan
-              # build-common 1.0.7
-              uses: cognizant-ai-lab/build-common/actions/checkmarx-one@3ead7f681f92044709ffc3a533f41c3f48230cfd
+              # build-common 1.0.8
+              uses: cognizant-ai-lab/build-common/actions/checkmarx-one@30321843331e00848309b34e08b839e1f6490ba2
               with:
                   base-uri: ${{ vars.CX_BASE_URI }}
                   cx-tenant: ${{ vars.CX_TENANT }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   test:
-    # cognizant-ai-lab/build-common 1.0.7
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
+    # cognizant-ai-lab/build-common 1.0.8
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.13'
       # No lint steps in the original workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python environment
-        # 1.0.7
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        # 1.0.8
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@30321843331e00848309b34e08b839e1f6490ba2
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -41,8 +41,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.7
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        # 1.0.8
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@30321843331e00848309b34e08b839e1f6490ba2
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    # 1.0.7
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
+    # 1.0.8
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.13'
       run-hadolint: true


### PR DESCRIPTION
## Description

Bumps all `cognizant-ai-lab/build-common` references from 1.0.7 (`3ead7f6`) to 1.0.8 (`3032184`). Updates SHA pins and version comments in `tests.yml`, `integration.yml`, `agent_network_designer.yml`, `publish.yml`, and `checkmarx.yml`.

## Type of Change

- [x] Dependency upgrade

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt`

Link to Devin session: https://app.devin.ai/sessions/aad527cb16b14184a12c5ff5c362cccf
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/1162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->