### PR TITLE
Rename env var in Dockerfile to AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL_SECONDS

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -307,7 +307,7 @@ ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL="0"
 # quiet for approximately the full interval; real message traffic suppresses it.
 # A value of 0 (the default) disables the keep-alive messages entirely.
 # Typical production value is 25-30 (under the 60s defaults of common proxies).
-ENV AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL=0
+ENV AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL_SECONDS=0
 
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -299,15 +299,15 @@ ENV AGENT_HTTP_SERVER_INSTANCES="1"
 # Logging period is specified in seconds.
 ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL="0"
 
-# Interval in seconds between HTTP heartbeat writes sent to streaming clients
+# Interval in seconds between HTTP keep-alive messages sent to streaming clients
 # to keep the connection alive during long quiet periods. This is important
 # when intermediaries (nginx, load balancers, AWS ALB) or clients would otherwise
 # drop an idle HTTP connection (commonly after ~60s) before the agent produces
-# its next streamed message. The heartbeat only fires when the stream has been
-# quiet for the full interval; real message traffic suppresses it.
-# A value of 0 (the default) disables the heartbeat entirely.
+# its next streamed message. The keep-alive message only fires when the stream has been
+# quiet for approximately the full interval; real message traffic suppresses it.
+# A value of 0 (the default) disables the keep-alive messages entirely.
 # Typical production value is 25-30 (under the 60s defaults of common proxies).
-ENV AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL=0
+ENV AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL=0
 
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.


### PR DESCRIPTION

## Description

Renames the variable from AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL
to AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL_SECONDS per agreement in a recent neuro-san PR here:
https://github.com/cognizant-ai-lab/neuro-san/pull/1062

## Impact


## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [X] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
