### PR TITLE
Require less information from env vars in private_llm_config.hocon

### DIFF
--- a/config/private_llm_config.hocon
+++ b/config/private_llm_config.hocon
@@ -32,12 +32,18 @@
                 # "model_name": "gpt-5.2",  # For Azure OpenAI, the model_name is really the deployment_name below.
 
                                                                             # Values below can also come from env vars:
+                # Your dev-ops set up for Azure OpenAI might vary w/rt
+                # the deployment_name. Consult your dev-ops team as to how
+                # they set up the deployment_name for the model of your choice.
                 "deployment_name": "gpt-5-2",                               # AZURE_OPENAI_DEPLOYMENT_NAME
+
+                # This openai_api_version is generally not a secret.
+                "openai_api_version": "2024-10-21",                         # OPENAI_API_VERSION
 
                 # You *will* need to also set these env vars for Azure OpenAI such as:
                 #   AZURE_OPENAI_API_KEY
                 #   AZURE_OPENAI_ENDPOINT
-                #   OPENAI_API_VERSION
+                # ... these will be provided by the dev-ops team that set up your Azure OpenAI instance.
 
                 # You *might also* want to set these optional env vars for your Azure OpenAI such as:
                 #   AZURE_OPENAI_REGION
@@ -45,6 +51,12 @@
                 #   AZURE_OPENAI_MODEL_VERSION
 
                 # Any env var mentioned above has been known to be emitted from TerraForm output (for instance).
+
+                # Note that there are ways to use a regular OpenAI chat class to do these same things,
+                # however that would require setting an "openai_api_key" in this config to use the
+                # AZURE_OPENAI_API_KEY env var, which is not recommended due to security concerns.
+                # You would also need to set  "openai_api_base" in this config to use the
+                # AZURE_OPENAI_ENDPOINT env var + "openai/vi/".
             },
 
             # ... More for different llm + cloud provider combinations as they come

--- a/config/private_llm_config.hocon
+++ b/config/private_llm_config.hocon
@@ -42,7 +42,7 @@
 
                 # You *will* need to also set these env vars for Azure OpenAI such as:
                 #   AZURE_OPENAI_API_KEY
-                #   AZURE_OPENAI_ENDPOINT
+                #   AZURE_OPENAI_ENDPOINT   (you could also set as "azure_endpoint" key in this config)
                 # ... these will be provided by the dev-ops team that set up your Azure OpenAI instance.
 
                 # You *might also* want to set these optional env vars for your Azure OpenAI such as:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Neuro SAN
 leaf-common>=1.2.44
-neuro-san==0.6.64
+neuro-san==0.6.65
 nsflow==0.6.15
 
 # For config parsing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Neuro SAN
 leaf-common>=1.2.44
-neuro-san==0.6.63
+neuro-san==0.6.64
 nsflow==0.6.15
 
 # For config parsing


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

<!-- Brief description of what this PR does and why -->

Slight simplification of env var information required in private_llm_config.hocon

We no longer need OPENAI_API_VERSION as an env var.
We still require AZURE_OPENAI_API_KEY (cuz secret) and AZURE_OPENAI_ENDPOINT (to keep deployment URLs private).

## Impact

<!-- Brief description of what the consequences of this PR are -->

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [X] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
