### PR TITLE
Cap agent network designer validation retries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,11 +69,11 @@ AZURE_OPENAI_DEPLOYMENT_NAME="<Your Azure OpenAI deployment name>"
 # While appropriate for single-user development, the false setting is not recommended
 # for multi-user production use.
 # Defaults to "false" if not set.
-ENV AGENT_NETWORK_DESIGNER_USE_RESERVATIONS="false"
+AGENT_NETWORK_DESIGNER_USE_RESERVATIONS="false"
 #
 # Time in seconds that any Reservation from the Agent Network Designer will be valid.
 # Typically 3 days.  259200 = 3 days * 24 hr/day * 60 min/hour * 60 sec/min
-ENV AGENT_NETWORK_DESIGNER_RESERVATIONS_LIFETIME_IN_SECONDS="259200"
+AGENT_NETWORK_DESIGNER_RESERVATIONS_LIFETIME_IN_SECONDS="259200"
 #
 # Progress style for the Agent Network Designer.
 # By default an internal representation is sent for AGENT_PROGRESS updated.
@@ -81,34 +81,34 @@ ENV AGENT_NETWORK_DESIGNER_RESERVATIONS_LIFETIME_IN_SECONDS="259200"
 # For multi-user deployments, we use the connectivity style, meaning the progress reports that
 # are sent are in the same format at the Connectivity() API for neuro-san.
 # Defaults to "internal" if not set.
-ENV AGENT_NETWORK_DESIGNER_PROGRESS_STYLE="internal"
+AGENT_NETWORK_DESIGNER_PROGRESS_STYLE="internal"
 #
 # Controls whether the Agent Network Designer runs in demo mode.
 # In demo mode, generated agents simulate grounded behavior without connecting to real systems.
 # Set to "false" once agents are wired to real APIs, databases, or tools via Toolbox or MCP.
 # Defaults to "true" if not set.
-ENV AGENT_NETWORK_DESIGNER_DEMO_MODE="true"
+AGENT_NETWORK_DESIGNER_DEMO_MODE="true"
 #
 # Subdirectory under the output path (registries/) where generated networks are saved.
 # Also determines where the manifest.hocon for generated networks is located.
 # Defaults to "generated" if not set.
 # Note: If using Reservations for temporary deployment, this subdirectory is not used, and
 # make sure to git ignore the generated directory if using file-system based deployment to avoid committing generated agents to source control.
-ENV AGENT_NETWORK_DESIGNER_SUBDIRECTORY="generated"
+AGENT_NETWORK_DESIGNER_SUBDIRECTORY="generated"
 #
 # Manifest file(s) providing available external agents for the Agent Network Designer to choose from.
 # Defaults to "registries/manifest_and.hocon" if not set.
-ENV AGENT_NETWORK_DESIGNER_MANIFEST_FILE="registries/manifest_and.hocon"
+AGENT_NETWORK_DESIGNER_MANIFEST_FILE="registries/manifest_and.hocon"
 #
 # Toolbox info file providing available tools for the Agent Network Designer to choose from.
 # Defaults to "neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon" if not set.
-ENV AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE="neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon"
+AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE="neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon"
 #
 # Maximum number of validation retry rounds before the persistence middleware gives up and
 # ends the session without persisting. Prevents runaway loops when the model cannot fix
 # validation errors (e.g., a required tool was unavailable during session setup).
 # Defaults to "3" if not set.
-ENV AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS="3"
+AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS="3"
 
 # Intranet Agents With Tools environment variables
 # For HCM API documentation refer to https://docs.oracle.com/en/cloud/saas/human-resources/25b/farws/index.html

--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,12 @@ ENV AGENT_NETWORK_DESIGNER_MANIFEST_FILE="registries/manifest_and.hocon"
 # Toolbox info file providing available tools for the Agent Network Designer to choose from.
 # Defaults to "neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon" if not set.
 ENV AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE="neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon"
+#
+# Maximum number of validation retry rounds before the persistence middleware gives up and
+# ends the session without persisting. Prevents runaway loops when the model cannot fix
+# validation errors (e.g., a required tool was unavailable during session setup).
+# Defaults to "3" if not set.
+ENV AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS="3"
 
 # Intranet Agents With Tools environment variables
 # For HCM API documentation refer to https://docs.oracle.com/en/cloud/saas/human-resources/25b/farws/index.html

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -459,4 +459,10 @@ ENV AGENT_NETWORK_DESIGNER_MANIFEST_FILE="registries/manifest_and.hocon"
 # Defaults to "neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon" if not set.
 ENV AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE="neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon"
 
+# Maximum number of validation retry rounds before the persistence middleware gives up and
+# ends the session without persisting. Prevents runaway loops when the model cannot fix
+# validation errors (e.g., a required tool was unavailable during session setup).
+# Defaults to "3" if not set.
+ENV AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS="3"
+
 ENTRYPOINT ["/bin/bash", "-c", "exec ${APP_ENTRYPOINT}"]

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -61,7 +61,15 @@ SUBDIRECTORY: str = environ.get("AGENT_NETWORK_DESIGNER_SUBDIRECTORY", DEFAULT_S
 # the middleware stops looping the agent back to the model and lets the session end without
 # persisting. Prevents runaway sessions when a tool the agent needs is unavailable (e.g.,
 # `agent_network_instructions_editor` dropped from the tools array under load).
-MAX_VALIDATION_ATTEMPTS: int = int(environ.get("AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS", "3"))
+_raw_max_validation_attempts: str = environ.get("AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS", "3")
+try:
+    MAX_VALIDATION_ATTEMPTS: int = max(0, int(_raw_max_validation_attempts))
+except ValueError:
+    getLogger(__name__).warning(
+        "Invalid AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS=%r; falling back to 3.",
+        _raw_max_validation_attempts,
+    )
+    MAX_VALIDATION_ATTEMPTS = 3
 
 
 class AgentNetworkPersistenceMiddleware(AgentMiddleware):

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -57,6 +57,12 @@ DEMO_MODE: bool = environ.get("AGENT_NETWORK_DESIGNER_DEMO_MODE", "true").lower(
 # Subdirectory under registries directory where networks are saved when using file persistence.
 SUBDIRECTORY: str = environ.get("AGENT_NETWORK_DESIGNER_SUBDIRECTORY", DEFAULT_SUBDIRECTORY)
 
+# Maximum number of validation retry rounds. After this many consecutive validation failures,
+# the middleware stops looping the agent back to the model and lets the session end without
+# persisting. Prevents runaway sessions when a tool the agent needs is unavailable (e.g.,
+# `agent_network_instructions_editor` dropped from the tools array under load).
+MAX_VALIDATION_ATTEMPTS: int = int(environ.get("AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS", "3"))
+
 
 class AgentNetworkPersistenceMiddleware(AgentMiddleware):
     """
@@ -100,6 +106,8 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.logger: Logger = getLogger(self.__class__.__name__)
         self.reservationist = reservationist
         self.sly_data = sly_data
+        # Counts validation rounds that failed in this session, used to cap retries.
+        self._validation_attempts: int = 0
 
     # Reenter the agent loop at the model node if validation fails.
     # If no agent network definition is present, return None to let the agent respond freely.
@@ -137,7 +145,22 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             structure_errors, instructions_errors = await self._validate_network(network_def)
             if structure_errors or instructions_errors:
                 self.logger.warning("Validation errors: %s", structure_errors + instructions_errors)
-                self.logger.warning("Invoking agent network designer to fix the issues.")
+                # Bail out if we've already retried MAX_VALIDATION_ATTEMPTS times. Returning None
+                # ends the session without persisting; the agent's last message reaches the user.
+                # Prevents runaway loops when the model can't fix the errors (e.g., the required
+                # tool was silently dropped from the tools array under load).
+                if self._validation_attempts >= MAX_VALIDATION_ATTEMPTS:
+                    self.logger.warning(
+                        "Reached max validation attempts (%d); ending without persisting.",
+                        MAX_VALIDATION_ATTEMPTS,
+                    )
+                    return None
+                self._validation_attempts += 1
+                self.logger.warning(
+                    "Invoking agent network designer to fix the issues (attempt %d/%d).",
+                    self._validation_attempts,
+                    MAX_VALIDATION_ATTEMPTS,
+                )
                 message_parts: list[str] = []
                 if structure_errors:
                     message_parts.append(

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -187,6 +187,10 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
                     )
                 return self._error_response(" ".join(message_parts))
 
+            # Validation succeeded. Reset the counter so a later turn in the same session
+            # (e.g., a follow-up modification) gets its own full retry budget.
+            self._validation_attempts = 0
+
             sample_queries: list[str] = self.sly_data.get(AGENT_NETWORK_QUERIES, [])
 
             await self._assemble_and_persist(network_def, agent_network_name, sample_queries)


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Add `MAX_VALIDATION_ATTEMPTS` (env var, default 3) to the persistence middleware so sessions stop looping when validation cannot be fixed. Previously, if a required tool was unavailable during session setup (e.g., dropped from the LLM's tools array under load), the session would retry indefinitely until `max_execution_seconds`=6000s.

Adds the env var to `.env.example` and `deploy/Dockerfile`.

Fixes #828 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
