### PR TITLE
AND: Move Parsing of max validation retries env var in persistence middleware from module to class level

### DIFF
--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -105,7 +105,9 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.sly_data = sly_data
         # Maximum number of validation retry rounds before bailing without persisting.
         # Parsed per-instance so a bad env var degrades this one session, not the whole server.
-        raw_max: str = environ.get("AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS", str(DEFAULT_MAX_VALIDATION_ATTEMPTS))
+        raw_max: str = environ.get(
+            "AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS", str(DEFAULT_MAX_VALIDATION_ATTEMPTS)
+        )
         try:
             self.max_validation_attempts: int = max(0, int(raw_max))
         except ValueError:

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -57,19 +57,8 @@ DEMO_MODE: bool = environ.get("AGENT_NETWORK_DESIGNER_DEMO_MODE", "true").lower(
 # Subdirectory under registries directory where networks are saved when using file persistence.
 SUBDIRECTORY: str = environ.get("AGENT_NETWORK_DESIGNER_SUBDIRECTORY", DEFAULT_SUBDIRECTORY)
 
-# Maximum number of validation retry rounds. After this many consecutive validation failures,
-# the middleware stops looping the agent back to the model and lets the session end without
-# persisting. Prevents runaway sessions when a tool the agent needs is unavailable (e.g.,
-# `agent_network_instructions_editor` dropped from the tools array under load).
-_raw_max_validation_attempts: str = environ.get("AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS", "3")
-try:
-    MAX_VALIDATION_ATTEMPTS: int = max(0, int(_raw_max_validation_attempts))
-except ValueError:
-    getLogger(__name__).warning(
-        "Invalid AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS=%r; falling back to 3.",
-        _raw_max_validation_attempts,
-    )
-    MAX_VALIDATION_ATTEMPTS = 3
+# Default number of validation retry rounds when the env var is unset or unparseable.
+DEFAULT_MAX_VALIDATION_ATTEMPTS: int = 3
 
 
 class AgentNetworkPersistenceMiddleware(AgentMiddleware):
@@ -114,6 +103,18 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.logger: Logger = getLogger(self.__class__.__name__)
         self.reservationist = reservationist
         self.sly_data = sly_data
+        # Maximum number of validation retry rounds before bailing without persisting.
+        # Parsed per-instance so a bad env var degrades this one session, not the whole server.
+        raw_max: str = environ.get("AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS", str(DEFAULT_MAX_VALIDATION_ATTEMPTS))
+        try:
+            self.max_validation_attempts: int = max(0, int(raw_max))
+        except ValueError:
+            self.logger.warning(
+                "Invalid AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS=%r; falling back to %d.",
+                raw_max,
+                DEFAULT_MAX_VALIDATION_ATTEMPTS,
+            )
+            self.max_validation_attempts = DEFAULT_MAX_VALIDATION_ATTEMPTS
         # Counts validation rounds that failed in this session, used to cap retries.
         self._validation_attempts: int = 0
 
@@ -153,21 +154,21 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             structure_errors, instructions_errors = await self._validate_network(network_def)
             if structure_errors or instructions_errors:
                 self.logger.warning("Validation errors: %s", structure_errors + instructions_errors)
-                # Bail out if we've already retried MAX_VALIDATION_ATTEMPTS times. Returning None
+                # Bail out if we've already retried the max number of times. Returning None
                 # ends the session without persisting; the agent's last message reaches the user.
                 # Prevents runaway loops when the model can't fix the errors (e.g., the required
                 # tool was silently dropped from the tools array under load).
-                if self._validation_attempts >= MAX_VALIDATION_ATTEMPTS:
+                if self._validation_attempts >= self.max_validation_attempts:
                     self.logger.warning(
                         "Reached max validation attempts (%d); ending without persisting.",
-                        MAX_VALIDATION_ATTEMPTS,
+                        self.max_validation_attempts,
                     )
                     return None
                 self._validation_attempts += 1
                 self.logger.warning(
                     "Invoking agent network designer to fix the issues (attempt %d/%d).",
                     self._validation_attempts,
-                    MAX_VALIDATION_ATTEMPTS,
+                    self.max_validation_attempts,
                 )
                 message_parts: list[str] = []
                 if structure_errors:


### PR DESCRIPTION


<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Move parsing of AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS from module load into __init__ so a malformed value degrades a single session via the existing fallback instead of crashing the server at import time.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
