### PR TITLE
Remove obsolete AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS references (fix copy_cat)

### DIFF
--- a/.github/workflows/agent_network_designer.yml
+++ b/.github/workflows/agent_network_designer.yml
@@ -40,7 +40,6 @@ jobs:
         source venv/bin/activate
         export AGENT_TOOL_PATH="coded_tools/"
         export AGENT_MANIFEST_FILE="registries/manifest.hocon"
-        export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5
         export PYTHONPATH=".:${PYTHONPATH:-}"
         build_scripts/server_start.sh
         if ! pytest --capture=no --verbose \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,6 @@ jobs:
         export OPENAI_API_VERSION="${{ vars.OPENAI_API_VERSION }}" &&
         export AGENT_TOOL_PATH="coded_tools/" &&
         export AGENT_MANIFEST_FILE="registries/manifest.hocon" &&
-        export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5 &&
         export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}." &&
         pytest --capture=no -m "integration"
     secrets:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,6 @@ test-integration: install
 	export PYTHONPATH=`pwd` && \
 	export AGENT_TOOL_PATH=coded_tools/ && \
 	export AGENT_MANIFEST_FILE=registries/manifest.hocon && \
-	export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5 && \
 	pytest -s -m "integration" --timer-top-n 100
 
 # Test the Agent Network Designer (AND)
@@ -108,7 +107,6 @@ test-designer: install
 	export PYTHONPATH=`pwd` && \
 	export AGENT_TOOL_PATH=coded_tools/ && \
 	export AGENT_MANIFEST_FILE=registries/manifest.hocon && \
-	export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5 && \
 	pytest --capture=no --verbose -m "integration_agent_network_designer" --timer-top-n 100
 
 help: ## Show this help message and exit

--- a/coded_tools/experimental/copy_cat/copyist.py
+++ b/coded_tools/experimental/copy_cat/copyist.py
@@ -14,7 +14,6 @@
 #
 # END COPYRIGHT
 
-from os import environ
 from typing import Any
 from typing import Dict
 
@@ -71,14 +70,6 @@ class Copyist(BranchActivation, CodedTool):
                 adding the data is not invoke()-ed more than once.
         :return: A return value that goes into the chat stream.
         """
-        if environ.get("AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS") is None:
-            return """
-The copy_cat network requires the neuro-san server to be configured with the
-AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS environment variable.
-Try doing this in your environment:
-    export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5
-"""
-
         copy_agent: str = args.get("agent_name")
         if copy_agent is None or len(copy_agent) == 0:
             return "Need a non-empty value for copy_agent"

--- a/docs/examples/experimental/copy_cat.md
+++ b/docs/examples/experimental/copy_cat.md
@@ -50,13 +50,8 @@ Nothing special.
 
 ### Environment Variables
 
-```bash
-export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5
-```
-
-This environment variable controls the frequency that the server will check for
-new and/or expired temporary networks. The default is 0, implying that temporary networks
-are not allowed on the server (a reasonable precaution for most servers).
+No special environment variables are required. Temporary network processing is
+enabled automatically by the server.
 
 ---
 
@@ -164,8 +159,6 @@ When developing or debugging with OpenAI models, keep the following in mind:
 
 - **Rate Limits**: Be aware of API rate limits that may affect LLM calling frequency.
 
-- **Turn on server processing of temporary networks**: Set `AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS` as above.
-
 ### Common Issues
 
 - **Import Errors**: Ensure langchain-openai is installed
@@ -173,8 +166,6 @@ When developing or debugging with OpenAI models, keep the following in mind:
 - **Authentication Failures**: Verify API key is set and valid
 
 - **Model Errors**: Confirm the specified GPT model is accessible
-
-- **AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS not set Errors**: Ensure the environment variable is set as described above
 
 - **Agent network .hocon file not found Errors**: Look for typos in your network name you wanted to copy.
   Be sure the .hocon file exists in the filesystem.  If you have copy/pasted this example be sure the

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -47,8 +47,7 @@ from middleware.agent_network_designer.validation.agent_network_structure_valida
     AgentNetworkStructureValidationMiddleware,
 )
 
-# To use reservations, turn this environment variable to true and also
-# export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5
+# To use reservations, turn this environment variable to true
 WRITE_TO_FILE: bool = environ.get("AGENT_NETWORK_DESIGNER_USE_RESERVATIONS", "false").lower() != "true"
 
 # Set this to False if the agents are grounded and don't need demo mode instructions


### PR DESCRIPTION
## Description

neuro-san removed `AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS` in [da2ebc6a](https://github.com/cognizant-ai-lab/neuro-san/commit/da2ebc6a5948f23f0f93b52a478625a68983213c) — `TempNetworkStorageUpdater` now runs independently via queues and no longer needs a periodic poll interval setting.

neuro-san-studio still had stale references to this env var, most critically a guard check in `copyist.py` that blocks the copy_cat network from working when the var is unset. After neuro-san-deploy renamed away from this var in [c50308a9](https://github.com/cognizant-ai-lab/neuro-san-deploy/commit/c50308a9d091edc5996f4c91f9bcb8ca5f7fa131), the copy_cat network stopped working entirely.

Changes:
- `coded_tools/experimental/copy_cat/copyist.py`: Remove the env var guard check and unused `environ` import
- `Makefile`: Remove from `test-integration` and `test-designer` targets
- `.github/workflows/integration.yml`: Remove from test command
- `.github/workflows/agent_network_designer.yml`: Remove from test command
- `docs/examples/experimental/copy_cat.md`: Remove env var prerequisites and related debugging hints
- `middleware/.../agent_network_persistence_middleware.py`: Remove stale comment referencing the env var

## Impact

Fixes the copy_cat network, which was broken because the guard in `copyist.py` returned an error when the now-removed env var was not set.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/8769d54da6084c3a8cda0ec98fe45f0b
Requested by: @donn-leaf