### PR TITLE
Private LLM fallbacks to multiple instancesDef private fallbacks

### DIFF
--- a/config/private_llm_config.hocon
+++ b/config/private_llm_config.hocon
@@ -57,6 +57,35 @@
                 # AZURE_OPENAI_API_KEY env var, which is not recommended due to security concerns.
                 # You would also need to set  "openai_api_base" in this config to use the
                 # AZURE_OPENAI_ENDPOINT env var + "openai/vi/".
+
+                # Try this one first, but move on to the next at any hint of a problem.
+                "max_retries": 0
+            },
+            {
+                # A 2nd private LLM instance to handle overflow load.
+                "class": "azure-openai",
+
+                # Your dev-ops set up for Azure OpenAI might vary w/rt
+                # the deployment_name. Consult your dev-ops team as to how
+                # they set up the deployment_name for the model of your choice.
+                "deployment_name": "gpt-5-2-instance-2",                    # AZURE_OPENAI_DEPLOYMENT_NAME
+                "openai_api_version": "2024-10-21",                         # OPENAI_API_VERSION
+
+                # Try this one next, but move on to the next at any hint of a problem.
+                "max_retries": 0
+            },
+            {
+                # A 3rd private LLM instance to handle overflow load.
+                "class": "azure-openai",
+
+                # Your dev-ops set up for Azure OpenAI might vary w/rt
+                # the deployment_name. Consult your dev-ops team as to how
+                # they set up the deployment_name for the model of your choice.
+                "deployment_name": "gpt-5-2-instance-3",                    # AZURE_OPENAI_DEPLOYMENT_NAME
+                "openai_api_version": "2024-10-21",                         # OPENAI_API_VERSION
+
+                # No max_retries here.
+                # If this one fails, there's nowhere else to go and you need more LLM instances.
             },
 
             # ... More for different llm + cloud provider combinations as they come

--- a/config/private_llm_config.hocon
+++ b/config/private_llm_config.hocon
@@ -62,30 +62,17 @@
                 "max_retries": 0
             },
             {
-                # A 2nd private LLM instance to handle overflow load.
-                # If you don't need this for your projected load, or don't have another LLM to fall back on,
-                # you can remove this entire block.
+                # A private fallback LLM used if the default LLM is unavailable or cannot
+                # complete a request. If you don't need a fallback provider, you can remove
+                # this entire block.
                 "class": "azure-openai",
 
                 # Your dev-ops set up for Azure OpenAI might vary w/rt
                 # the deployment_name. Consult your dev-ops team as to how
                 # they set up the deployment_name for the model of your choice.
-                "deployment_name": "gpt-5-2-instance-2",                    # AZURE_OPENAI_DEPLOYMENT_NAME
-                "openai_api_version": "2024-10-21",                         # OPENAI_API_VERSION
+                "deployment_name": "gpt-5-2-b",                             # AZURE_OPENAI_DEPLOYMENT_NAME
 
-                # Try this one next, but move on to the next at any hint of a problem.
-                "max_retries": 0
-            },
-            {
-                # A 3rd private LLM instance to handle overflow load.
-                # If you don't need this for your projected load, or don't have another LLM to fall back on,
-                # you can remove this entire block.
-                "class": "azure-openai",
-
-                # Your dev-ops set up for Azure OpenAI might vary w/rt
-                # the deployment_name. Consult your dev-ops team as to how
-                # they set up the deployment_name for the model of your choice.
-                "deployment_name": "gpt-5-2-instance-3",                    # AZURE_OPENAI_DEPLOYMENT_NAME
+                # This openai_api_version is generally not a secret.
                 "openai_api_version": "2024-10-21",                         # OPENAI_API_VERSION
 
                 # No max_retries here.

--- a/config/private_llm_config.hocon
+++ b/config/private_llm_config.hocon
@@ -63,6 +63,8 @@
             },
             {
                 # A 2nd private LLM instance to handle overflow load.
+                # If you don't need this for your projected load, or don't have another LLM to fall back on,
+                # you can remove this entire block.
                 "class": "azure-openai",
 
                 # Your dev-ops set up for Azure OpenAI might vary w/rt
@@ -76,6 +78,8 @@
             },
             {
                 # A 3rd private LLM instance to handle overflow load.
+                # If you don't need this for your projected load, or don't have another LLM to fall back on,
+                # you can remove this entire block.
                 "class": "azure-openai",
 
                 # Your dev-ops set up for Azure OpenAI might vary w/rt


### PR DESCRIPTION
Note: This is Dan's change. I am helping him work around his blocker while he has no access to GitHub.

## Description

Add fallback entries to `config/private_llm_config.hocon` so a private LLM
Deployment can fail over across multiple Azure OpenAI instances.

The first instance now sets `max_retries: 0` so it moves on immediately
at any hint of a problem. The last entry will act as a fallback and omits `max_retries` because there is 
nowhere else to fall back to.

Each additional block is optional — users who only have one LLM instance
can remove it.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
