### PR TITLE
Bump build-common to 1.0.8

### DIFF
--- a/.github/workflows/agent_network_designer.yml
+++ b/.github/workflows/agent_network_designer.yml
@@ -12,8 +12,8 @@ jobs:
   agent-network-designer-test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san-studio'
-    # cognizant-ai-lab/build-common 1.0.7
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
+    # cognizant-ai-lab/build-common 1.0.8
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.13'
       # Required by build_scripts/server_start.sh:

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -22,8 +22,8 @@ jobs:
                   fetch-depth: 0
 
             - name: Run Checkmarx One scan
-              # build-common 1.0.7
-              uses: cognizant-ai-lab/build-common/actions/checkmarx-one@3ead7f681f92044709ffc3a533f41c3f48230cfd
+              # build-common 1.0.8
+              uses: cognizant-ai-lab/build-common/actions/checkmarx-one@30321843331e00848309b34e08b839e1f6490ba2
               with:
                   base-uri: ${{ vars.CX_BASE_URI }}
                   cx-tenant: ${{ vars.CX_TENANT }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   test:
-    # cognizant-ai-lab/build-common 1.0.7
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
+    # cognizant-ai-lab/build-common 1.0.8
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.13'
       # No lint steps in the original workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Setup Python environment
         # 1.0.7
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@30321843331e00848309b34e08b839e1f6490ba2
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -42,7 +42,7 @@ jobs:
       - name: Notify Slack
         if: ${{ !cancelled() }}
         # 1.0.7
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@30321843331e00848309b34e08b839e1f6490ba2
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python environment
-        # 1.0.7
+        # 1.0.8
         uses: cognizant-ai-lab/build-common/actions/setup-python-env@30321843331e00848309b34e08b839e1f6490ba2
         with:
           python-version: '3.10'
@@ -41,7 +41,7 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.7
+        # 1.0.8
         uses: cognizant-ai-lab/build-common/actions/slack-notify@30321843331e00848309b34e08b839e1f6490ba2
         with:
           status: ${{ job.status }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
     # 1.0.7
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.13'
       run-hadolint: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    # 1.0.7
+    # 1.0.8
     uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.13'


### PR DESCRIPTION
## Description

Bumps all `cognizant-ai-lab/build-common` workflow references from 1.0.7 (`3ead7f6`) to 1.0.8 (`3032184`).

## Impact

CI workflows will use the latest build-common actions and reusable workflows.

## Type of Change

- [x] Dependency upgrade

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/b8cc15641cd146e8bcfdb8ecef917779
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/1185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->