### PR TITLE
#1119 Add ns chat to quickly test agent networks from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,15 +277,15 @@ See [`docs/cli/export.md`](docs/cli/export.md) for details.
 
 <!-- pyml disable line-length -->
 
-| Command             | Purpose                                          | Key flags                                                                                              |
-|---------------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `ns init`           | Scaffold a starter project in the current dir.   | `--providers openai,anthropic,google`                                                                  |
-| `ns run`            | Start the Neuro SAN server and nsflow UI.        | `--server-host`, `--server-http-port`, `--nsflow-port`, `--log-level`, `--client-only`, `--server-only` |
-| `ns import`         | Import agent networks into the current project.  | Positional: space-separated group names, network names, or `all`; or local `.hocon` / `.zip` paths (don't mix the two). `--force` to overwrite. Omit args for interactive mode. |
-| `ns export`         | Bundle a network from the current project into a shareable file. | Positional: network name (e.g. `music_nerd` or `basic/music_nerd`). `-o` / `--output` to set the output path. Omit args for interactive picker. |
-| `ns check-llm-keys` | Validate LLM API keys / env vars.                | `--tier 1` (placeholder), `--tier 2` (format), `--tier 3` (live API call, default)                     |
-| `ns chat`           | Chat with an agent network directly (no server needed). | Positional: agent name (default: `esp_decision_assistant`). `--connection`, `--host`, `--port`, `--one-shot`, `--list`. |
-| `ns check-config`   | Validate the LLM configurations in a HOCON file. | `--hocon-path` (defaults to `config/llm_config.hocon`)                                                 |
+| Command             | Purpose                                                          | Key flags                                                                                                                                                                       |
+|---------------------|------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ns init`           | Scaffold a starter project in the current dir.                   | `--providers openai,anthropic,google`                                                                                                                                           |
+| `ns run`            | Start the Neuro SAN server and nsflow UI.                        | `--server-host`, `--server-http-port`, `--nsflow-port`, `--log-level`, `--client-only`, `--server-only`                                                                         |
+| `ns chat`           | Chat with an agent network directly (no server needed).          | Positional: agent name, `--connection`,  `--host`, `--port`, `--one-shot`, `--list`.                                                                                            |
+| `ns import`         | Import agent networks into the current project.                  | Positional: space-separated group names, network names, or `all`; or local `.hocon` / `.zip` paths (don't mix the two). `--force` to overwrite. Omit args for interactive mode. |
+| `ns export`         | Bundle a network from the current project into a shareable file. | Positional: network name (e.g. `music_nerd` or `basic/music_nerd`). `-o` / `--output` to set the output path. Omit args for interactive picker.                                 |
+| `ns check-llm-keys` | Validate LLM API keys / env vars.                                | `--tier 1` (placeholder), `--tier 2` (format), `--tier 3` (live API call, default)                                                                                              |
+| `ns check-config`   | Validate the LLM configurations in a HOCON file.                 | `--hocon-path` (defaults to `config/llm_config.hocon`)                                                                                                                          |
 
 <!-- pyml enable line-length -->
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ See [`docs/cli/export.md`](docs/cli/export.md) for details.
 | `ns import`         | Import agent networks into the current project.  | Positional: space-separated group names, network names, or `all`; or local `.hocon` / `.zip` paths (don't mix the two). `--force` to overwrite. Omit args for interactive mode. |
 | `ns export`         | Bundle a network from the current project into a shareable file. | Positional: network name (e.g. `music_nerd` or `basic/music_nerd`). `-o` / `--output` to set the output path. Omit args for interactive picker. |
 | `ns check-llm-keys` | Validate LLM API keys / env vars.                | `--tier 1` (placeholder), `--tier 2` (format), `--tier 3` (live API call, default)                     |
+| `ns chat`           | Chat with an agent network directly (no server needed). | Positional: agent name (default: `esp_decision_assistant`). `--connection`, `--host`, `--port`, `--one-shot`, `--list`. |
 | `ns check-config`   | Validate the LLM configurations in a HOCON file. | `--hocon-path` (defaults to `config/llm_config.hocon`)                                                 |
 
 <!-- pyml enable line-length -->

--- a/docs/cli/chat.md
+++ b/docs/cli/chat.md
@@ -1,10 +1,10 @@
 # chat
 
-Chat with an agent network directly from the command line, without starting the full nsflow server.
+Chat with an agent network directly from the command line, without starting neuro-san and nsflow servers.
 This command delegates to neuro-san's `AgentCli` (also available as `python -m neuro_san.client.agent_cli`).
 
 By default it uses a **direct** (in-process library) connection, meaning no server needs to be running. For remote
-agents, specify `--connection http` with `--host` and `--port`.
+agents, specify `--connection https` with `--host` and `--port`.
 
 Under the hood this command delegates to neuro-san's `AgentCli`, so it stays in sync with the library's capabilities.
 
@@ -12,22 +12,22 @@ Under the hood this command delegates to neuro-san's `AgentCli`, so it stays in 
 
 ```bash
 # Interactive chat with an agent (direct/library connection, no server needed)
-ns chat music_nerd
+ns chat basic/music_nerd
 
 # One-shot mode: send a prompt from a file and exit
-ns chat music_nerd --one-shot --first_prompt_file prompt.txt
+ns chat basic/music_nerd --one-shot --first_prompt_file prompt.txt
 
 # Connect to a running neuro-san server
-ns chat music_nerd --connection http --host localhost --port 8080
+ns chat basic/music_nerd --connection http --host localhost --port 8080
 
 # List all available agents
 ns chat --list
 
 # List agents filtered by tag
-ns chat --tag demo
+ns chat --tag tool
 
 # Test connectivity of an agent network
-ns chat music_nerd --connectivity
+ns chat basic/music_nerd --connectivity
 ```
 
 The command exits with code `0` on normal completion (including user-initiated Ctrl+C) and `1` on error.
@@ -69,7 +69,7 @@ Use `python -m neuro_san.client.agent_cli --help` for the full reference.
 ### Direct connection (no server needed)
 
 ```bash
-ns chat music_nerd
+ns chat basic/music_nerd
 ```
 
 This starts an interactive chat loop. The agent's description is printed first, then you
@@ -78,12 +78,12 @@ are prompted for input. Type `quit` to exit, or press Ctrl+C.
 ### Scripted one-shot usage
 
 ```bash
-echo "What are the best jazz albums?" > /tmp/prompt.txt
+echo "Who wrote Little Black Submarines?" > /tmp/prompt.txt
 ns chat music_nerd --one-shot --first_prompt_file /tmp/prompt.txt
 ```
 
 ### Remote server connection
 
 ```bash
-ns chat music_nerd --connection http --host my-server.example.com --port 8080
+ns chat basic/music_nerd --connection https --host my-server.example.com --port 443
 ```

--- a/docs/cli/chat.md
+++ b/docs/cli/chat.md
@@ -1,0 +1,89 @@
+# chat
+
+Chat with an agent network directly from the command line, without starting the full nsflow server.
+This command delegates to neuro-san's `AgentCli` (also available as `python -m neuro_san.client.agent_cli`).
+
+By default it uses a **direct** (in-process library) connection, meaning no server needs to be running. For remote
+agents, specify `--connection http` with `--host` and `--port`.
+
+Under the hood this command delegates to neuro-san's `AgentCli`, so it stays in sync with the library's capabilities.
+
+## Usage
+
+```bash
+# Interactive chat with an agent (direct/library connection, no server needed)
+ns chat music_nerd
+
+# One-shot mode: send a prompt from a file and exit
+ns chat music_nerd --one-shot --first_prompt_file prompt.txt
+
+# Connect to a running neuro-san server
+ns chat music_nerd --connection http --host localhost --port 8080
+
+# List all available agents
+ns chat --list
+
+# List agents filtered by tag
+ns chat --tag demo
+
+# Test connectivity of an agent network
+ns chat music_nerd --connectivity
+```
+
+The command exits with code `0` on normal completion (including user-initiated Ctrl+C) and `1` on error.
+
+## Options
+
+| Option | Description |
+|---|---|
+| `AGENT` | Name of the agent network to chat with (positional, default: `esp_decision_assistant`). |
+| `--connection` | Connection type: `direct` (library call, default), `http`, or `https`. |
+| `--host` | Hostname of the neuro-san server (for http/https connections). |
+| `--port` | Port of the neuro-san server. |
+| `--one-shot` | Send one prompt and exit (non-interactive mode). |
+| `--list` | List all available agents and exit (ignores AGENT argument). |
+
+## Advanced options
+
+These options are forwarded directly to `AgentCli` and do not appear in `ns chat --help`.
+Use `python -m neuro_san.client.agent_cli --help` for the full reference.
+
+| Option | Description |
+|---|---|
+| `--first_prompt_file FILE` | File containing the first user prompt. |
+| `--sly_data JSON` | JSON string with out-of-band data for the agent. |
+| `--minimal` | Receive only minimal messages from the server. |
+| `--maximal` | Receive all messages (default). |
+| `--connectivity` | Test network connectivity instead of chatting. |
+| `--tokens` | Print token accounting with every response. |
+| `--thinking_file FILE` | Path for agent thinking output (default: `/tmp/agent_thinking.txt`). |
+| `--no_thinking_file` | Disable thinking file output entirely. |
+| `--tag TAG` | List agents matching a specific tag. |
+| `--tags` | List all available tags. |
+| `--max_input N` | Maximum rounds of input before exiting. |
+| `--timeout SECONDS` | Connection timeout in seconds. |
+| `--response_output_file FILE` | File to capture the agent's response. |
+
+## Examples
+
+### Direct connection (no server needed)
+
+```bash
+ns chat music_nerd
+```
+
+This starts an interactive chat loop. The agent's description is printed first, then you
+are prompted for input. Type `quit` to exit, or press Ctrl+C.
+
+### Scripted one-shot usage
+
+```bash
+echo "What are the best jazz albums?" > /tmp/prompt.txt
+ns chat music_nerd --one-shot --first_prompt_file /tmp/prompt.txt
+```
+
+### Remote server connection
+
+```bash
+ns chat music_nerd --connection http --host my-server.example.com --port 8080
+```

--- a/neuro_san_studio/commands/chat.py
+++ b/neuro_san_studio/commands/chat.py
@@ -27,11 +27,14 @@ uses a direct (in-process library) connection, so no server needs to be running.
 It can also connect to an already-running neuro-san server via HTTP or HTTPS.
 """
 
+import os
 import sys
 from typing import List
 from typing import Optional
 
 from neuro_san.client.agent_cli import AgentCli
+
+from neuro_san_studio.commands.project_environment import ProjectEnvironment
 
 EXIT_OK = 0
 EXIT_ERROR = 1
@@ -97,6 +100,11 @@ class ChatCommand:  # pylint: disable=too-few-public-methods
 
     def run(self) -> int:
         """Delegate to AgentCli and return a normalized exit code (0 ok, 1 problem)."""
+        # Point neuro-san at this project's agents/coded tools before chatting. A direct
+        # session runs in-process, so without this it falls back to neuro-san's bundled
+        # library manifest and can't find the project's own networks.
+        ProjectEnvironment(os.getcwd()).apply()
+
         saved_argv: List[str] = sys.argv
         try:
             sys.argv = self._build_argv()

--- a/neuro_san_studio/commands/chat.py
+++ b/neuro_san_studio/commands/chat.py
@@ -1,0 +1,112 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Implementation of the `neuro-san-studio chat` command.
+
+Runs an interactive (or one-shot) chat with an agent network by delegating to
+neuro-san's ``AgentCli`` (the tool also exposed as
+``python -m neuro_san.client.agent_cli``). Studio stays a thin wrapper: it
+marshals the command options into the arguments that ``AgentCli`` expects,
+runs it, and normalizes the exit code to studio's 0/1 convention.
+
+Unlike ``run``, this command does NOT start any server processes. By default it
+uses a direct (in-process library) connection, so no server needs to be running.
+It can also connect to an already-running neuro-san server via HTTP or HTTPS.
+"""
+
+import sys
+from typing import List
+from typing import Optional
+
+from neuro_san.client.agent_cli import AgentCli
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+
+
+class ChatCommand:  # pylint: disable=too-few-public-methods
+    """Chat with an agent network via the CLI.
+
+    Thin wrapper around neuro-san's ``AgentCli``. Returns exit code 0
+    on normal completion and 1 on error.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        agent: str,
+        *,
+        connection: str = "direct",
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        one_shot: bool = False,
+        list_agents: bool = False,
+        extra_args: Optional[List[str]] = None,
+    ):
+        """Initialize the command.
+
+        Args:
+            agent: Name of the agent network to chat with.
+            connection: Connection type (direct, http, or https).
+            host: Hostname of the neuro-san server (for http/https).
+            port: Port of the neuro-san server (for http/https).
+            one_shot: When True, send one prompt then exit.
+            list_agents: When True, list available agents and exit.
+            extra_args: Additional arguments forwarded to AgentCli.
+        """
+        self.agent = agent
+        self.connection = connection
+        self.host = host
+        self.port = port
+        self.one_shot = one_shot
+        self.list_agents = list_agents
+        self.extra_args = extra_args or []
+
+    def _build_argv(self) -> List[str]:
+        """Marshal the command options into an argv list for AgentCli."""
+        argv: List[str] = ["agent_cli"]
+
+        if self.list_agents:
+            argv.append("--list")
+        else:
+            argv.extend(["--agent", self.agent])
+
+        argv.extend(["--connection", self.connection])
+
+        if self.host is not None:
+            argv.extend(["--host", self.host])
+        if self.port is not None:
+            argv.extend(["--port", str(self.port)])
+        if self.one_shot:
+            argv.append("--one_shot")
+
+        argv.extend(self.extra_args)
+        return argv
+
+    def run(self) -> int:
+        """Delegate to AgentCli and return a normalized exit code (0 ok, 1 problem)."""
+        saved_argv: List[str] = sys.argv
+        try:
+            sys.argv = self._build_argv()
+            AgentCli().main()
+            return EXIT_OK
+        except KeyboardInterrupt:
+            print()
+            return EXIT_OK
+        except Exception as exception:  # pylint: disable=broad-except
+            print(f"Error: {exception}", file=sys.stderr)
+            return EXIT_ERROR
+        finally:
+            sys.argv = saved_argv

--- a/neuro_san_studio/commands/chat.py
+++ b/neuro_san_studio/commands/chat.py
@@ -16,7 +16,7 @@
 
 """Implementation of the `neuro-san-studio chat` command.
 
-Runs an interactive (or one-shot) chat with an agent network by delegating to
+Runs an interactive or one-shot chat with an agent network by delegating to
 neuro-san's ``AgentCli`` (the tool also exposed as
 ``python -m neuro_san.client.agent_cli``). Studio stays a thin wrapper: it
 marshals the command options into the arguments that ``AgentCli`` expects,
@@ -46,7 +46,7 @@ class ChatCommand:  # pylint: disable=too-few-public-methods
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        agent: str,
+        agent: Optional[str],
         *,
         connection: str = "direct",
         host: Optional[str] = None,
@@ -58,7 +58,7 @@ class ChatCommand:  # pylint: disable=too-few-public-methods
         """Initialize the command.
 
         Args:
-            agent: Name of the agent network to chat with.
+            agent: Name of the agent network to chat with (None when listing).
             connection: Connection type (direct, http, or https).
             host: Hostname of the neuro-san server (for http/https).
             port: Port of the neuro-san server (for http/https).
@@ -80,7 +80,7 @@ class ChatCommand:  # pylint: disable=too-few-public-methods
 
         if self.list_agents:
             argv.append("--list")
-        else:
+        elif self.agent is not None:
             argv.extend(["--agent", self.agent])
 
         argv.extend(["--connection", self.connection])

--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -224,6 +224,64 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
         raise typer.Exit(code=CheckConfigCommand(hocon_path=hocon_path).run())
 
     @staticmethod
+    @app.command(
+        "chat",
+        help="Chat with an agent network directly (without starting nsflow).",
+        context_settings={
+            "allow_extra_args": True,
+            "ignore_unknown_options": True,
+        },
+    )
+    def _chat_command(  # pylint: disable=too-many-arguments
+        ctx: typer.Context,
+        agent: str = typer.Argument(
+            "esp_decision_assistant",
+            help="Name of the agent network to chat with.",
+        ),
+        *,
+        connection: str = typer.Option(
+            "direct",
+            "--connection",
+            help="Connection type: 'direct' (library call, default), 'http', or 'https'.",
+        ),
+        host: Optional[str] = typer.Option(
+            None,
+            "--host",
+            help="Hostname of the neuro-san server (for http/https connections).",
+        ),
+        port: Optional[int] = typer.Option(
+            None,
+            "--port",
+            help="Port of the neuro-san server.",
+        ),
+        one_shot: bool = typer.Option(
+            False,
+            "--one-shot",
+            help="Send one prompt and exit (non-interactive mode).",
+        ),
+        list_agents: bool = typer.Option(
+            False,
+            "--list",
+            help="List all available agents and exit.",
+        ),
+    ) -> None:
+        """Chat with an agent network, forwarding extra options to AgentCli."""
+        # pylint: disable-next=import-outside-toplevel
+        from neuro_san_studio.commands.chat import ChatCommand
+
+        raise typer.Exit(
+            code=ChatCommand(
+                agent=agent,
+                connection=connection,
+                host=host,
+                port=port,
+                one_shot=one_shot,
+                list_agents=list_agents,
+                extra_args=ctx.args,
+            ).run()
+        )
+
+    @staticmethod
     @app.command("validate", help="Validate the structure of an agent network HOCON file.")
     def _validate_command(
         hocon_path: str = typer.Argument(

--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -226,7 +226,10 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
     @staticmethod
     @app.command(
         "chat",
-        help="Chat with an agent network directly (without starting nsflow).\n\nUsage: ns chat AGENT [OPTIONS]",
+        help=(
+            "Chat with an agent network directly (without starting nsflow).\n\n"
+            "Pass the agent name as AGENT, e.g. ns chat music_nerd"
+        ),
         no_args_is_help=True,
         context_settings={
             "allow_extra_args": True,

--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -234,10 +234,6 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
     )
     def _chat_command(  # pylint: disable=too-many-arguments
         ctx: typer.Context,
-        agent: str = typer.Argument(
-            "esp_decision_assistant",
-            help="Name of the agent network to chat with.",
-        ),
         *,
         connection: str = typer.Option(
             "direct",
@@ -269,6 +265,11 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
         # pylint: disable-next=import-outside-toplevel
         from neuro_san_studio.commands.chat import ChatCommand
 
+        extra = list(ctx.args)
+        agent = None
+        if extra and not extra[0].startswith("--"):
+            agent = extra.pop(0)
+
         raise typer.Exit(
             code=ChatCommand(
                 agent=agent,
@@ -277,7 +278,7 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
                 port=port,
                 one_shot=one_shot,
                 list_agents=list_agents,
-                extra_args=ctx.args,
+                extra_args=extra,
             ).run()
         )
 

--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -226,7 +226,7 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
     @staticmethod
     @app.command(
         "chat",
-        help="Chat with an agent network directly (without starting nsflow).",
+        help="Chat with an agent network directly (without starting nsflow).\n\nUsage: ns chat AGENT [OPTIONS]",
         context_settings={
             "allow_extra_args": True,
             "ignore_unknown_options": True,

--- a/neuro_san_studio/commands/cli.py
+++ b/neuro_san_studio/commands/cli.py
@@ -227,6 +227,7 @@ class NeuroSanStudioCli:  # pylint: disable=too-few-public-methods
     @app.command(
         "chat",
         help="Chat with an agent network directly (without starting nsflow).\n\nUsage: ns chat AGENT [OPTIONS]",
+        no_args_is_help=True,
         context_settings={
             "allow_extra_args": True,
             "ignore_unknown_options": True,

--- a/neuro_san_studio/commands/project_environment.py
+++ b/neuro_san_studio/commands/project_environment.py
@@ -21,8 +21,10 @@ from dotenv import load_dotenv
 
 from neuro_san_studio import mcp as _mcp_pkg
 
-# The mcp_info.hocon shipped inside the neuro_san_studio package. Resolving via the
-# imported package keeps it correct both in-repo and after `pip install`.
+# Path to the mcp_info.hocon that ships inside the neuro_san_studio package.
+# Resolving via the imported package's __file__ works both in-repo (where
+# neuro_san_studio/ is just a folder on sys.path) and after `pip install`
+# (where it lives in site-packages), on every supported platform.
 _BUNDLED_MCP_INFO_FILE = Path(_mcp_pkg.__file__).parent / "mcp_info.hocon"
 
 

--- a/neuro_san_studio/commands/project_environment.py
+++ b/neuro_san_studio/commands/project_environment.py
@@ -1,0 +1,122 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from neuro_san_studio import mcp as _mcp_pkg
+
+# The mcp_info.hocon shipped inside the neuro_san_studio package. Resolving via the
+# imported package keeps it correct both in-repo and after `pip install`.
+_BUNDLED_MCP_INFO_FILE = Path(_mcp_pkg.__file__).parent / "mcp_info.hocon"
+
+
+class ProjectEnvironment:
+    """Resolve and export the env vars neuro-san needs to serve a project's networks."""
+
+    def __init__(self, root_dir: str):
+        """Initialize for a project rooted at root_dir.
+
+        Args:
+            root_dir: The project root, typically the current working directory.
+        """
+        self.root_dir = Path(root_dir)
+
+    def apply(self) -> None:
+        """Load the project .env and export the agent env vars (without clobbering overrides).
+
+        This is the in-process entry point used by `ns chat`: after it runs, a direct
+        neuro-san session in this process resolves the project's own networks.
+        """
+        self.load_env_file()
+        self.set_pythonpath()
+        self._setdefault_env("AGENT_MANIFEST_FILE", self.resolve_manifest_file())
+        self._setdefault_env("AGENT_TOOL_PATH", self.resolve_tool_path())
+        self._setdefault_env("MCP_SERVERS_INFO_FILE", self.resolve_mcp_info_file())
+        toolbox_file = self.resolve_toolbox_info_file()
+        if toolbox_file:
+            self._setdefault_env("AGENT_TOOLBOX_INFO_FILE", toolbox_file)
+
+    def resolve_manifest_file(self) -> str:
+        """Resolve AGENT_MANIFEST_FILE: the env var if set, else <root>/registries/manifest.hocon."""
+        return os.getenv("AGENT_MANIFEST_FILE") or str(self.root_dir / "registries" / "manifest.hocon")
+
+    def resolve_tool_path(self) -> str:
+        """Resolve AGENT_TOOL_PATH: the env var if set, else <root>/coded_tools."""
+        return os.getenv("AGENT_TOOL_PATH") or str(self.root_dir / "coded_tools")
+
+    def resolve_mcp_info_file(self) -> str:
+        """Resolve the MCP servers info file path.
+
+        Precedence:
+          1. MCP_SERVERS_INFO_FILE env var (used verbatim if non-empty).
+          2. <root>/mcp/mcp_info.hocon if it exists (what `init` scaffolds into a project).
+          3. The mcp_info.hocon shipped inside the neuro_san_studio package.
+        """
+        env_value = os.getenv("MCP_SERVERS_INFO_FILE")
+        if env_value:
+            return env_value
+        scaffolded_path = self.root_dir / "mcp" / "mcp_info.hocon"
+        if scaffolded_path.is_file():
+            return str(scaffolded_path)
+        return str(_BUNDLED_MCP_INFO_FILE)
+
+    def resolve_toolbox_info_file(self) -> str:
+        """Resolve the toolbox info file path, or "" if it should not be exported.
+
+        A project toolbox is purely an override on top of neuro-san's built-in default
+        toolbox. Only return a path when the user opted in via the env var, or when the
+        conventional <root>/neuro_san_studio/toolbox/toolbox_info.hocon exists. Otherwise
+        return "" so the env var stays unset and the framework uses its built-in default.
+        """
+        env_value = os.getenv("AGENT_TOOLBOX_INFO_FILE")
+        if env_value is not None:
+            return env_value
+        default_path = self.root_dir / "neuro_san_studio" / "toolbox" / "toolbox_info.hocon"
+        if default_path.is_file():
+            return str(default_path)
+        return ""
+
+    def load_env_file(self) -> None:
+        """Load a project-root .env file (if any) so API keys and other settings are available."""
+        env_path = self.root_dir / ".env"
+        if env_path.exists():
+            load_dotenv(env_path)
+            print(f"Loaded environment variables from: {env_path}")
+        else:
+            print(f"No .env file found at {env_path}. \nUsing defaults.\n")
+
+    def set_pythonpath(self) -> None:
+        """Add the project root to PYTHONPATH (idempotently) so coded_tools.* resolves.
+
+        neuro-san reads PYTHONPATH at runtime to map an absolute AGENT_TOOL_PATH to a module
+        path, so setting it here works for both `ns run`'s server subprocess and an in-process
+        `ns chat`. A no-op when the root is already present.
+        """
+        existing: str = os.environ.get("PYTHONPATH", "")
+        root = str(self.root_dir)
+        normalized_root = self.root_dir.resolve()
+        if any(Path(path).resolve() == normalized_root for path in existing.split(os.pathsep) if path):
+            return
+        os.environ["PYTHONPATH"] = existing + os.pathsep + root if existing else root
+
+    @staticmethod
+    def _setdefault_env(name: str, value: str) -> None:
+        """Export value under name only if the user has not already set that env var."""
+        if not os.environ.get(name):
+            os.environ[name] = value

--- a/neuro_san_studio/commands/run.py
+++ b/neuro_san_studio/commands/run.py
@@ -22,14 +22,14 @@ import socket
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import Tuple
 
-from dotenv import load_dotenv
 from timedinput import timedinput
 
-from neuro_san_studio import mcp as _mcp_pkg
+from neuro_san_studio.commands.project_environment import ProjectEnvironment
 from neuro_san_studio.interfaces.process_logger_interface import ProcessLoggerInterface
 from neuro_san_studio.plugins.plugin_loader import PluginLoader
 from neuro_san_studio.runner.simple_process_logger import SimpleProcessLogger
@@ -37,12 +37,6 @@ from neuro_san_studio.runner.simple_process_logger import SimpleProcessLogger
 # Long enough to never bite a real user; finite so timedinput is happy and so a
 # detached terminal can't hang the process forever.
 INPUT_TIMEOUT_SECONDS = 300
-
-# Path to the mcp_info.hocon that ships inside the neuro_san_studio package.
-# Resolving via the imported package's __file__ works both in-repo (where
-# neuro_san_studio/ is just a folder on sys.path) and after `pip install`
-# (where it lives in site-packages), on every supported platform.
-_BUNDLED_MCP_INFO_FILE = os.path.join(os.path.dirname(_mcp_pkg.__file__), "mcp_info.hocon")
 
 
 class NeuroSanRunner:
@@ -53,13 +47,16 @@ class NeuroSanRunner:
         """Initialize configuration and parse CLI arguments."""
         self._logger = logging.getLogger(self.__class__.__name__)
         self.is_windows = os.name == "nt"
-        self.root_dir = os.getcwd()
-        self.logs_dir = os.path.join(self.root_dir, "logs")
-        self.thinking_file = os.path.join(self.logs_dir, "agent_thinking.txt")
-        self.thinking_dir = os.path.join(self.logs_dir, "thinking_dir")
+        self.root_dir = Path.cwd()
+        self.logs_dir = self.root_dir / "logs"
+        self.thinking_file = self.logs_dir / "agent_thinking.txt"
+        self.thinking_dir = self.logs_dir / "thinking_dir"
         print(f"Root directory: {self.root_dir}")
-        # Load environment variables from .env file
-        self.load_env_variables()
+        # Shared project-resource resolution (manifest, tool path, mcp, toolbox, .env),
+        # also used by `ns chat` so the two commands resolve a project identically.
+        self.project_env = ProjectEnvironment(self.root_dir)
+        # Load environment variables from the project .env file (if any)
+        self.project_env.load_env_file()
 
         plugins_file = PluginLoader.resolve_plugins_file(self.root_dir)
         self.plugin_classes = PluginLoader.load_plugin_classes(plugins_file)
@@ -77,21 +74,19 @@ class NeuroSanRunner:
             "log_level": os.getenv("LOG_LEVEL", "info"),
             "vite_api_protocol": os.getenv("VITE_API_PROTOCOL", "http"),
             "vite_ws_protocol": os.getenv("VITE_WS_PROTOCOL", "ws"),
-            "thinking_file": os.getenv("THINKING_FILE", self.thinking_file),
-            "thinking_dir": os.getenv("THINKING_DIR", self.thinking_dir),
+            "thinking_file": os.getenv("THINKING_FILE", str(self.thinking_file)),
+            "thinking_dir": os.getenv("THINKING_DIR", str(self.thinking_dir)),
             # Ensure all paths are resolved relative to `self.root_dir`
-            "agent_manifest_file": os.getenv(
-                "AGENT_MANIFEST_FILE", os.path.join(self.root_dir, "registries", "manifest.hocon")
-            ),
-            "agent_tool_path": os.getenv("AGENT_TOOL_PATH", os.path.join(self.root_dir, "coded_tools")),
-            "agent_toolbox_info_file": self._resolve_toolbox_info_file(),
-            "mcp_servers_info_file": self._resolve_mcp_info_file(),
-            "logs_dir": self.logs_dir,
+            "agent_manifest_file": self.project_env.resolve_manifest_file(),
+            "agent_tool_path": self.project_env.resolve_tool_path(),
+            "agent_toolbox_info_file": self.project_env.resolve_toolbox_info_file(),
+            "mcp_servers_info_file": self.project_env.resolve_mcp_info_file(),
+            "logs_dir": str(self.logs_dir),
         }
 
         # Ensure logs directory exists
-        os.makedirs(self.logs_dir, exist_ok=True)
-        os.makedirs(self.thinking_dir, exist_ok=True)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self.thinking_dir.mkdir(parents=True, exist_ok=True)
 
         # Instantiate plugins now that args are fully built
         self.plugins = [cls(self.args) for cls in self.plugin_classes]
@@ -121,51 +116,6 @@ class NeuroSanRunner:
             print(f"AGENT_TOOLBOX_INFO_FILE set to: {toolbox_file}")
         else:
             print("AGENT_TOOLBOX_INFO_FILE: (not set — using built-in default toolbox)")
-
-    def _resolve_toolbox_info_file(self) -> str:
-        """Resolve the toolbox info file path, or return "" if it should not be exported.
-
-        A user-provided toolbox is purely an override on top of the neuro-san framework's
-        built-in default toolbox. Only set AGENT_TOOLBOX_INFO_FILE when the user has
-        opted in explicitly via the env var, or when the conventional
-        `<root>/neuro_san_studio/toolbox/toolbox_info.hocon` actually exists. Otherwise return "" so the
-        env var stays unset and the framework uses its built-in default only.
-        """
-        env_value = os.getenv("AGENT_TOOLBOX_INFO_FILE")
-        if env_value is not None:
-            return env_value
-        default_path = os.path.join(self.root_dir, "neuro_san_studio", "toolbox", "toolbox_info.hocon")
-        if os.path.isfile(default_path):
-            return default_path
-        return ""
-
-    # TODO: This duplicates GetMcpTool.get_mcp_info_file in
-    # coded_tools/agent_network_editor/get_mcp_tool.py. Refactor to call that
-    # method instead of maintaining a second copy of the resolver.
-    def _resolve_mcp_info_file(self) -> str:
-        """Resolve the MCP servers info file path.
-
-        Precedence (matches GetMcpTool.get_mcp_info_file):
-          1. MCP_SERVERS_INFO_FILE env var (used verbatim if non-empty).
-          2. <root>/mcp/mcp_info.hocon if it exists (what `init` scaffolds into a user project).
-          3. The mcp_info.hocon shipped inside the neuro_san_studio package.
-        """
-        env_value = os.getenv("MCP_SERVERS_INFO_FILE")
-        if env_value:
-            return env_value
-        scaffolded_path = os.path.join(self.root_dir, "mcp", "mcp_info.hocon")
-        if os.path.isfile(scaffolded_path):
-            return scaffolded_path
-        return _BUNDLED_MCP_INFO_FILE
-
-    def load_env_variables(self):
-        """Load .env file from project root and set variables."""
-        env_path = os.path.join(self.root_dir, ".env")
-        if os.path.exists(env_path):
-            load_dotenv(env_path)
-            print(f"Loaded environment variables from: {env_path}")
-        else:
-            print(f"No .env file found at {env_path}. \nUsing defaults.\n")
 
     def parse_args(self):
         """Parses command-line arguments for configuration."""
@@ -223,31 +173,12 @@ class NeuroSanRunner:
 
         return vars(args)
 
-    def set_pythonpath(self):
-        """
-        Sets the PYTHONPATH environment variable to include the project root directory.
-        """
-        existing: str = os.environ.get("PYTHONPATH", "")
-
-        # Check to see if the root_dir is already in PYTHONPATH. If so, don't add it again.
-        # This block below was suggested by Copilot.
-        normalized_root_dir = os.path.normcase(os.path.abspath(self.root_dir))
-        existing_paths = [path for path in existing.split(os.pathsep) if path]
-        if any(os.path.normcase(os.path.abspath(path)) == normalized_root_dir for path in existing_paths):
-            return
-
-        # Add the root_dir to PYTHONPATH differently depending on existing value
-        new_path: str = self.root_dir
-        if existing:
-            new_path = existing + os.pathsep + self.root_dir
-        os.environ["PYTHONPATH"] = new_path
-
     def set_environment_variables(self):
         """Set required environment variables, optionally using neuro-san defaults."""
         print("\n" + "=" * 50 + "\n")
         print("Setting environment variables...\n")
         # Common env variables
-        self.set_pythonpath()
+        self.project_env.set_pythonpath()
         os.environ["AGENT_MANIFEST_FILE"] = self.args["agent_manifest_file"]
         os.environ["AGENT_TOOL_PATH"] = self.args["agent_tool_path"]
         self._apply_toolbox_env()
@@ -532,7 +463,7 @@ class NeuroSanRunner:
             plugin.pre_server_start_action()
 
         # Ensure logs directory exists
-        os.makedirs("logs", exist_ok=True)
+        Path("logs").mkdir(parents=True, exist_ok=True)
 
         # Set up signal handling for termination
         signal.signal(signal.SIGINT, self.signal_handler)  # Handle Ctrl+C
@@ -557,7 +488,7 @@ class NeuroSanRunner:
                 ("nsflow", self.nsflow_process),
             ]:
                 if proc is not None:
-                    log_file = os.path.join(self.logs_dir, f"{name.lower()}.log")
+                    log_file = str(self.logs_dir / f"{name.lower()}.log")
                     simple_logger.attach_process_logger(proc, name, log_file)
 
         print("\n" + "=" * 50 + "\n")

--- a/tests/neuro_san_studio/commands/test_chat.py
+++ b/tests/neuro_san_studio/commands/test_chat.py
@@ -82,11 +82,27 @@ class TestChatCommandRun(TestCase):
 
         with patch(f"{_MODULE}.AgentCli") as mock_cli:
             mock_cli.return_value.main.side_effect = fake_main
-            ChatCommand("music_nerd", list_agents=True).run()
+            ChatCommand(None, list_agents=True).run()
 
         argv = captured["argv"]
         assert "--list" in argv
         assert "--agent" not in argv
+
+    def test_none_agent_without_list_skips_agent_flag(self):
+        """When agent is None and list is False, --agent is not emitted."""
+        captured = {}
+
+        def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = fake_main
+            ChatCommand(None, extra_args=["--tag", "demo"]).run()
+
+        argv = captured["argv"]
+        assert "--agent" not in argv
+        assert "--tag" in argv
+        assert "demo" in argv
 
     def test_extra_args_forwarded(self):
         """Extra arguments from the Typer context are appended to argv."""

--- a/tests/neuro_san_studio/commands/test_chat.py
+++ b/tests/neuro_san_studio/commands/test_chat.py
@@ -1,0 +1,135 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import sys
+from unittest import TestCase
+from unittest.mock import patch
+
+from neuro_san_studio.commands.chat import ChatCommand
+
+_MODULE = "neuro_san_studio.commands.chat"
+
+
+class TestChatCommandRun(TestCase):
+    """Tests for ChatCommand.run - a thin wrapper over AgentCli."""
+
+    def test_normal_return_gives_zero(self):
+        """When AgentCli.main() returns normally, run() returns 0."""
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.return_value = None
+            assert ChatCommand("music_nerd").run() == 0
+
+    def test_exception_returns_one(self):
+        """When AgentCli.main() raises, run() returns 1."""
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = ValueError("agent not found")
+            assert ChatCommand("music_nerd").run() == 1
+
+    def test_keyboard_interrupt_returns_zero(self):
+        """Ctrl+C during interactive chat is a normal exit (code 0)."""
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = KeyboardInterrupt()
+            assert ChatCommand("music_nerd").run() == 0
+
+    def test_builds_argv_with_all_options(self):
+        """All explicit options are marshaled into the argv passed to AgentCli."""
+        captured = {}
+
+        def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = fake_main
+            ChatCommand(
+                "music_nerd",
+                connection="http",
+                host="myhost",
+                port=9090,
+                one_shot=True,
+            ).run()
+
+        argv = captured["argv"]
+        assert argv[0] == "agent_cli"
+        assert "--agent" in argv
+        assert "music_nerd" in argv
+        assert "--connection" in argv
+        assert "http" in argv
+        assert "--host" in argv
+        assert "myhost" in argv
+        assert "--port" in argv
+        assert "9090" in argv
+        assert "--one_shot" in argv
+
+    def test_list_mode_skips_agent_flag(self):
+        """When list_agents is True, --agent is not emitted."""
+        captured = {}
+
+        def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = fake_main
+            ChatCommand("music_nerd", list_agents=True).run()
+
+        argv = captured["argv"]
+        assert "--list" in argv
+        assert "--agent" not in argv
+
+    def test_extra_args_forwarded(self):
+        """Extra arguments from the Typer context are appended to argv."""
+        captured = {}
+
+        def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = fake_main
+            ChatCommand("music_nerd", extra_args=["--tokens", "--minimal"]).run()
+
+        argv = captured["argv"]
+        assert "--tokens" in argv
+        assert "--minimal" in argv
+
+    def test_default_connection_is_direct(self):
+        """The default connection type is 'direct'."""
+        captured = {}
+
+        def fake_main():
+            captured["argv"] = list(sys.argv)
+
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = fake_main
+            ChatCommand("music_nerd").run()
+
+        argv = captured["argv"]
+        idx = argv.index("--connection")
+        assert argv[idx + 1] == "direct"
+
+    def test_sys_argv_restored_after_success(self):
+        """sys.argv is restored after a normal run."""
+        before = list(sys.argv)
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.return_value = None
+            ChatCommand("music_nerd").run()
+        assert sys.argv == before
+
+    def test_sys_argv_restored_after_exception(self):
+        """sys.argv is restored even when AgentCli raises."""
+        before = list(sys.argv)
+        with patch(f"{_MODULE}.AgentCli") as mock_cli:
+            mock_cli.return_value.main.side_effect = RuntimeError("boom")
+            ChatCommand("music_nerd").run()
+        assert sys.argv == before

--- a/tests/neuro_san_studio/commands/test_chat.py
+++ b/tests/neuro_san_studio/commands/test_chat.py
@@ -149,3 +149,14 @@ class TestChatCommandRun(TestCase):
             mock_cli.return_value.main.side_effect = RuntimeError("boom")
             ChatCommand("music_nerd").run()
         assert sys.argv == before
+
+    def test_applies_project_environment_before_chat(self):
+        """run() sets up the project env (manifest, tool path, etc.) before delegating.
+
+        A direct chat is in-process, so without this neuro-san falls back to its bundled
+        library manifest and cannot find the project's own agents.
+        """
+        with patch(f"{_MODULE}.AgentCli") as mock_cli, patch(f"{_MODULE}.ProjectEnvironment") as mock_env:
+            mock_cli.return_value.main.return_value = None
+            ChatCommand("music_nerd").run()
+        mock_env.return_value.apply.assert_called_once()

--- a/tests/neuro_san_studio/commands/test_project_environment.py
+++ b/tests/neuro_san_studio/commands/test_project_environment.py
@@ -147,7 +147,7 @@ class TestToolboxApply:
         assert os.environ["AGENT_TOOLBOX_INFO_FILE"] == str(toolbox / "toolbox_info.hocon")
 
 
-class TestEnvFile:
+class TestEnvFile:  # pylint: disable=too-few-public-methods
     """apply() loads a project-root .env so API keys are available."""
 
     def test_loads_dotenv(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/neuro_san_studio/commands/test_project_environment.py
+++ b/tests/neuro_san_studio/commands/test_project_environment.py
@@ -1,0 +1,159 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import os
+from pathlib import Path
+
+import pytest
+
+from neuro_san_studio.commands.project_environment import ProjectEnvironment
+
+_AGENT_VARS = ("AGENT_MANIFEST_FILE", "AGENT_TOOL_PATH", "MCP_SERVERS_INFO_FILE")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test from a clean slate for the env vars under test."""
+    for var in (*_AGENT_VARS, "AGENT_TOOLBOX_INFO_FILE", "PYTHONPATH"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _project(tmp_path: Path) -> Path:
+    """Lay out a minimal scaffolded project (manifest, coded_tools, mcp_info)."""
+    (tmp_path / "registries").mkdir()
+    (tmp_path / "registries" / "manifest.hocon").write_text("{}\n")
+    (tmp_path / "coded_tools").mkdir()
+    (tmp_path / "mcp").mkdir()
+    (tmp_path / "mcp" / "mcp_info.hocon").write_text("{}\n")
+    return tmp_path
+
+
+class TestApply:
+    """ProjectEnvironment.apply() sets the agent env vars from the project layout."""
+
+    def test_sets_manifest_to_project_registries(self, tmp_path: Path) -> None:
+        """AGENT_MANIFEST_FILE points at <root>/registries/manifest.hocon."""
+        root = _project(tmp_path)
+        ProjectEnvironment(str(root)).apply()
+        assert os.environ["AGENT_MANIFEST_FILE"] == str(root / "registries" / "manifest.hocon")
+
+    def test_sets_tool_path_to_project_coded_tools(self, tmp_path: Path) -> None:
+        """AGENT_TOOL_PATH points at <root>/coded_tools."""
+        root = _project(tmp_path)
+        ProjectEnvironment(str(root)).apply()
+        assert os.environ["AGENT_TOOL_PATH"] == str(root / "coded_tools")
+
+    def test_sets_mcp_info_to_scaffolded_file(self, tmp_path: Path) -> None:
+        """MCP_SERVERS_INFO_FILE points at the project's mcp/mcp_info.hocon when present."""
+        root = _project(tmp_path)
+        ProjectEnvironment(str(root)).apply()
+        assert os.environ["MCP_SERVERS_INFO_FILE"] == str(root / "mcp" / "mcp_info.hocon")
+
+    def test_adds_project_root_to_pythonpath(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The project root joins PYTHONPATH so neuro-san maps an absolute AGENT_TOOL_PATH to a module."""
+        monkeypatch.delenv("PYTHONPATH", raising=False)
+        root = _project(tmp_path)
+        ProjectEnvironment(str(root)).apply()
+        assert str(root) in os.environ["PYTHONPATH"].split(os.pathsep)
+
+
+class TestRespectsExistingValues:
+    """A user-provided env var is an override and must not be clobbered."""
+
+    def test_keeps_existing_manifest(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An already-set AGENT_MANIFEST_FILE survives apply()."""
+        root = _project(tmp_path)
+        monkeypatch.setenv("AGENT_MANIFEST_FILE", "/custom/manifest.hocon")
+        ProjectEnvironment(str(root)).apply()
+        assert os.environ["AGENT_MANIFEST_FILE"] == "/custom/manifest.hocon"
+
+    def test_keeps_existing_tool_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An already-set AGENT_TOOL_PATH survives apply()."""
+        root = _project(tmp_path)
+        monkeypatch.setenv("AGENT_TOOL_PATH", "/custom/tools")
+        ProjectEnvironment(str(root)).apply()
+        assert os.environ["AGENT_TOOL_PATH"] == "/custom/tools"
+
+
+class TestResolveMcpInfoFile:
+    """resolve_mcp_info_file precedence: env var, then scaffolded file, then bundled."""
+
+    def test_env_var_takes_precedence(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An explicit MCP_SERVERS_INFO_FILE is used verbatim, ignoring the filesystem."""
+        monkeypatch.setenv("MCP_SERVERS_INFO_FILE", "/custom/path/mcp_info.hocon")
+        assert ProjectEnvironment(str(tmp_path)).resolve_mcp_info_file() == "/custom/path/mcp_info.hocon"
+
+    def test_scaffolded_path_used_when_file_exists(self, tmp_path: Path) -> None:
+        """With no env var, prefer <root>/mcp/mcp_info.hocon (what `init` scaffolds) over the bundled file."""
+        root = _project(tmp_path)
+        assert ProjectEnvironment(str(root)).resolve_mcp_info_file() == str(root / "mcp" / "mcp_info.hocon")
+
+    def test_falls_back_to_bundled_when_no_env_and_no_scaffold(self, tmp_path: Path) -> None:
+        """With no env var and no scaffolded file, fall back to the mcp_info.hocon shipped in the package."""
+        result = ProjectEnvironment(str(tmp_path)).resolve_mcp_info_file()
+        assert os.path.isfile(result)
+        assert result.endswith(os.path.join("neuro_san_studio", "mcp", "mcp_info.hocon"))
+
+
+class TestResolveToolboxInfoFile:
+    """resolve_toolbox_info_file is a pure override: a path only when env-set or a file exists."""
+
+    def test_env_var_takes_precedence(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An explicit AGENT_TOOLBOX_INFO_FILE is used verbatim, ignoring the filesystem."""
+        monkeypatch.setenv("AGENT_TOOLBOX_INFO_FILE", "/custom/path/toolbox.hocon")
+        assert ProjectEnvironment(str(tmp_path)).resolve_toolbox_info_file() == "/custom/path/toolbox.hocon"
+
+    def test_default_path_used_when_file_exists(self, tmp_path: Path) -> None:
+        """With no env var, fall back to <root>/neuro_san_studio/toolbox/toolbox_info.hocon if it exists."""
+        toolbox = tmp_path / "neuro_san_studio" / "toolbox"
+        toolbox.mkdir(parents=True)
+        (toolbox / "toolbox_info.hocon").write_text("{}\n")
+        assert ProjectEnvironment(str(tmp_path)).resolve_toolbox_info_file() == str(toolbox / "toolbox_info.hocon")
+
+    def test_empty_when_no_env_and_no_file(self, tmp_path: Path) -> None:
+        """With no env var and no file on disk, return "" so the env var stays unset."""
+        assert ProjectEnvironment(str(tmp_path)).resolve_toolbox_info_file() == ""
+
+
+class TestToolboxApply:
+    """apply() exports the toolbox var only when resolution yields a real path."""
+
+    def test_unset_when_no_toolbox_file(self, tmp_path: Path) -> None:
+        """No toolbox file and no env var means AGENT_TOOLBOX_INFO_FILE stays unset."""
+        root = _project(tmp_path)
+        ProjectEnvironment(str(root)).apply()
+        assert "AGENT_TOOLBOX_INFO_FILE" not in os.environ
+
+    def test_set_when_toolbox_file_present(self, tmp_path: Path) -> None:
+        """A scaffolded toolbox file is exported."""
+        root = _project(tmp_path)
+        toolbox = root / "neuro_san_studio" / "toolbox"
+        toolbox.mkdir(parents=True)
+        (toolbox / "toolbox_info.hocon").write_text("{}\n")
+        ProjectEnvironment(str(root)).apply()
+        assert os.environ["AGENT_TOOLBOX_INFO_FILE"] == str(toolbox / "toolbox_info.hocon")
+
+
+class TestEnvFile:
+    """apply() loads a project-root .env so API keys are available."""
+
+    def test_loads_dotenv(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Keys defined in <root>/.env are loaded into the environment."""
+        root = _project(tmp_path)
+        (root / ".env").write_text("NS_TEST_ENV_KEY=from_dotenv\n")
+        monkeypatch.delenv("NS_TEST_ENV_KEY", raising=False)
+        ProjectEnvironment(str(root)).apply()
+        assert os.environ.get("NS_TEST_ENV_KEY") == "from_dotenv"

--- a/tests/neuro_san_studio/commands/test_run.py
+++ b/tests/neuro_san_studio/commands/test_run.py
@@ -27,6 +27,7 @@ from pytest import CaptureFixture
 from pytest import MonkeyPatch
 
 from neuro_san_studio.commands import run as run_module
+from neuro_san_studio.commands.project_environment import ProjectEnvironment
 from neuro_san_studio.commands.run import NeuroSanRunner
 
 
@@ -83,60 +84,6 @@ class TestNeuroSanRunner:
         monkeypatch.setattr(run_module, "timedinput", self._scripted_input(["bad", "yes"]))
         assert self._make_runner()._validate_yes_no_input("prompt: ", max_attempts=2) is True
 
-    def test_toolbox_env_var_takes_precedence(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-        """Explicit AGENT_TOOLBOX_INFO_FILE should be used verbatim, ignoring the filesystem."""
-        monkeypatch.setenv("AGENT_TOOLBOX_INFO_FILE", "/custom/path/toolbox.hocon")
-        runner = self._make_runner()
-        runner.root_dir = str(tmp_path)
-        assert runner._resolve_toolbox_info_file() == "/custom/path/toolbox.hocon"
-
-    def test_toolbox_default_path_used_when_file_exists(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-        """With no env var, fall back to <root>/neuro_san_studio/toolbox/toolbox_info.hocon if it exists."""
-        monkeypatch.delenv("AGENT_TOOLBOX_INFO_FILE", raising=False)
-        toolbox_dir = tmp_path / "neuro_san_studio" / "toolbox"
-        toolbox_dir.mkdir(parents=True)
-        toolbox_file = toolbox_dir / "toolbox_info.hocon"
-        toolbox_file.write_text("{}\n", encoding="utf-8")
-        runner = self._make_runner()
-        runner.root_dir = str(tmp_path)
-        assert runner._resolve_toolbox_info_file() == str(toolbox_file)
-
-    def test_toolbox_unset_when_no_env_and_no_file(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-        """With no env var and no file on disk, return "" so the env var stays unset."""
-        monkeypatch.delenv("AGENT_TOOLBOX_INFO_FILE", raising=False)
-        runner = self._make_runner()
-        runner.root_dir = str(tmp_path)
-        assert runner._resolve_toolbox_info_file() == ""
-
-    def test_mcp_env_var_takes_precedence(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-        """Explicit MCP_SERVERS_INFO_FILE should be used verbatim, ignoring the filesystem."""
-        monkeypatch.setenv("MCP_SERVERS_INFO_FILE", "/custom/path/mcp_info.hocon")
-        runner = self._make_runner()
-        runner.root_dir = str(tmp_path)
-        assert runner._resolve_mcp_info_file() == "/custom/path/mcp_info.hocon"
-
-    def test_mcp_scaffolded_path_used_when_file_exists(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-        """With no env var, prefer <root>/mcp/mcp_info.hocon (what `init` scaffolds) over the bundled file."""
-        monkeypatch.delenv("MCP_SERVERS_INFO_FILE", raising=False)
-        mcp_dir = tmp_path / "mcp"
-        mcp_dir.mkdir()
-        mcp_file = mcp_dir / "mcp_info.hocon"
-        mcp_file.write_text("{}\n", encoding="utf-8")
-        runner = self._make_runner()
-        runner.root_dir = str(tmp_path)
-        assert runner._resolve_mcp_info_file() == str(mcp_file)
-
-    def test_mcp_falls_back_to_bundled_when_no_env_and_no_scaffold(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> None:
-        """With no env var and no scaffolded file, fall back to the mcp_info.hocon shipped in the package."""
-        monkeypatch.delenv("MCP_SERVERS_INFO_FILE", raising=False)
-        runner = self._make_runner()
-        runner.root_dir = str(tmp_path)
-        result = runner._resolve_mcp_info_file()
-        assert os.path.isfile(result)
-        assert result.endswith(os.path.join("neuro_san_studio", "mcp", "mcp_info.hocon"))
-
     def test_set_environment_variables_skips_empty_toolbox(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, capsys: CaptureFixture[str]
     ) -> None:
@@ -145,6 +92,7 @@ class TestNeuroSanRunner:
         monkeypatch.delenv("AGENT_TOOLBOX_INFO_FILE", raising=False)
         runner = self._make_runner()
         runner.root_dir = str(tmp_path)
+        runner.project_env = ProjectEnvironment(runner.root_dir)
         runner.args = {
             "agent_manifest_file": str(tmp_path / "manifest.hocon"),
             "agent_tool_path": str(tmp_path / "coded_tools"),
@@ -172,6 +120,7 @@ class TestNeuroSanRunner:
         monkeypatch.delenv("AGENT_TOOLBOX_INFO_FILE", raising=False)
         runner = self._make_runner()
         runner.root_dir = str(tmp_path)
+        runner.project_env = ProjectEnvironment(runner.root_dir)
         runner.args = {
             "agent_manifest_file": str(tmp_path / "manifest.hocon"),
             "agent_tool_path": str(tmp_path / "coded_tools"),


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Adds a `chat` command to neuro-san-studio.
Delegates to underlying Neuro SAN's `neuro_san.client.agent_cli`.

Fixes #1119 
## Impact

Quickly interact with an agent network, in command line, with
```
ns chat basic/music_nerd
```

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
