### PR TITLE
Add Wolfram MCP example agent network

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -18,6 +18,7 @@ Here are a few examples ordered by level of complexity.
     - [Music Nerd Pro Sly](#music-nerd-pro-sly)
     - [Music Nerd Pro Sly Local](#music-nerd-pro-sly-local)
     - [Music Nerd LLM Fallbacks](#music-nerd-llm-fallbacks)
+    - [Wolfram MCP](#wolfram-mcp)
     - [Book Recommender with Multiple LLM Configs](#book-recommender-with-multiple-llm-configs)
     - [Coffee Finder](#coffee-finder)
     - [Coffee Finder Advanced](#coffee-finder-advanced)
@@ -142,6 +143,16 @@ a **tool-calling** LLM that runs locally with Ollama.
 its `llm_config` to automatically try another LLM config if the first one fails.
 
 **Tags:** `llm_config` `llm_fallbacks`
+
+### Wolfram MCP
+
+[Wolfram MCP](examples/basic/wolfram_mcp.md) is a single-agent network that connects to the
+Wolfram Cloud MCP server, giving the agent access to Wolfram|Alpha's computational knowledge
+engine and the Wolfram Language for symbolic math, scientific computation, unit conversions,
+and curated factual data. It is the simplest example of wiring an agent to a remote MCP
+server via streamable HTTP.
+
+**Tags:** `basic` `example` `MCP` `Wolfram`
 
 ### Book Recommender with Multiple LLM Configs
 

--- a/docs/examples/basic/wolfram_mcp.md
+++ b/docs/examples/basic/wolfram_mcp.md
@@ -1,0 +1,135 @@
+# Wolfram MCP
+
+The **Wolfram MCP** agent network is a small, single-agent network designed to demonstrate
+how to connect an agent to a remote Model Context Protocol (MCP) server using streamable
+HTTP. It wires a `knowledge_agent` to the Wolfram Cloud MCP server, which exposes
+Wolfram|Alpha's computational knowledge engine and the Wolfram Language evaluator.
+
+---
+
+## File
+
+[wolfram_mcp.hocon](../../../registries/basic/wolfram_mcp.hocon)
+
+---
+
+## Description
+
+This agent network provides one of the simplest possible examples of an agent backed by an
+external MCP server. The single `knowledge_agent` delegates queries to the Wolfram Cloud
+MCP server at `https://agenttools.wolfram.com/mcp`, which exposes three tools:
+
+- `WolframContext` — context retrieval for grounding the conversation.
+- `WolframLanguageEvaluator` — evaluates Wolfram Language expressions for symbolic
+  computation, plotting, and general programmatic queries.
+- `WolframAlpha` — natural-language queries against Wolfram|Alpha's curated knowledgebase
+  covering math, science, geography, demographics, and other factual domains.
+
+Because the tools return computed (not generated) results, the agent is well suited for
+queries that need accurate numbers, formulas, or factual lookups — rather than free-form
+prose generation. The free tier of the Wolfram MCP server is anonymous and requires no
+API key, making this a good starting point for experimenting with remote MCP tools.
+
+---
+
+## Prerequisites
+
+This agent network requires the following setup:
+
+### Python Dependencies
+
+Nothing special.
+
+### Environment Variables
+
+Nothing special. The Wolfram Cloud MCP server's free tier does not require authentication.
+
+---
+
+## Example Conversation
+
+### Human
+
+```text
+Compute the integral of sin(x)^2 from 0 to pi.
+```
+
+### AI
+
+```text
+The definite integral of sin(x)^2 from 0 to pi is pi/2 (approximately 1.5708).
+```
+
+Other sample queries that exercise different Wolfram capabilities:
+
+- `Convert 150 km/h to miles per second`
+- `What is the distance from Earth to Mars today?`
+- `What is the population and GDP of Japan compared to Germany?`
+
+Your mileage will vary — the agent may rephrase or add intermediate steps depending on the
+underlying LLM's choices.
+
+---
+
+## Architecture Overview
+
+### Frontman Agent: knowledge_agent
+
+- Main entry point for user inquiry.
+
+- Interprets natural language queries and forwards them to the Wolfram MCP server, refining
+  the query if the first attempt is ambiguous or incomplete.
+
+- Presents the computed result back to the user, including relevant intermediate steps,
+  formulas, or units when they help understanding.
+
+There are no other agents in this network. The focus is on the simplest possible wiring of
+an agent to a remote MCP server.
+
+### MCP Tool: https://agenttools.wolfram.com/mcp
+
+The agent's `tools` field is a single MCP server URL. neuro-san connects to it via the
+streamable HTTP transport. The URL is a canonical MCP server URI (it contains `mcp` as a
+path segment), so it can be passed as a plain string. For non-canonical URLs, use the
+dictionary form `{"url": "https://example.com"}` instead.
+
+---
+
+## Debugging Hints
+
+When developing or debugging with this network, keep the following in mind:
+
+- **MCP server reachability**: The agent makes outbound HTTPS calls to
+  `agenttools.wolfram.com`. Make sure the host running the agent can reach it (no
+  firewall, proxy, or DNS issues).
+
+- **Streamable HTTP only**: neuro-san's hocon-only MCP wiring supports streamable HTTP(S)
+  transport. For other transports (stdio, SSE), implement the connection inside a coded
+  tool instead.
+
+- **Rate limits**: The free tier of Wolfram Cloud MCP is subject to rate limits and may
+  occasionally return errors under heavy use. Refine the query and retry.
+
+### Common Issues
+
+- **No matching tool / empty results**: Wolfram|Alpha may not understand free-form prose
+  well. The agent instructions encourage rephrasing — if you still get poor results,
+  reword the query to be closer to a computational or factual question.
+
+- **LLM not invoking the tool**: If the agent answers from its own knowledge instead of
+  calling Wolfram, the model may have decided the question didn't need a tool. Strengthen
+  the agent instructions or use a clearer computational prompt.
+
+---
+
+## Resources
+
+- [Agent Network Hocon specification](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md)
+
+- [Wolfram Cloud MCP overview](https://www.wolfram.com/artificial-intelligence/mcp/cloud/)
+  Background on what the Wolfram MCP server exposes and how it differs from a typical
+  web-search-backed tool.
+
+- [Model Context Protocol specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri)
+  Definition of canonical MCP server URIs (relevant to the form of the `tools` URL used
+  in this example).

--- a/neuro_san_studio/mcp/mcp_info.hocon
+++ b/neuro_san_studio/mcp/mcp_info.hocon
@@ -24,6 +24,18 @@
 #     },
 
 {
+    # Wolfram Cloud MCP — connects to Wolfram's computational engine and Wolfram|Alpha
+    # knowledgebase for accurate symbolic math, scientific computation, and curated factual
+    # data (no hallucinated results). Free tier; no API key required.
+    # Docs: https://www.wolfram.com/artificial-intelligence/mcp/cloud/
+    "https://agenttools.wolfram.com/mcp": {
+        "tools": ["WolframContext", "WolframLanguageEvaluator", "WolframAlpha"]
+    },
+
+    # DeepWiki MCP — AI-powered Q&A and documentation access for public GitHub repositories.
+    # Useful for exploring open-source projects without cloning or reading source by hand.
+    # Free, no authentication required. Private repos require Devin's paid tier.
+    # Docs: https://docs.devin.ai/work-with-devin/deepwiki-mcp
     "https://mcp.deepwiki.com/mcp": {
         "tools": ["read_wiki_structure", "ask_question"]
     },

--- a/registries/basic/manifest.hocon
+++ b/registries/basic/manifest.hocon
@@ -38,4 +38,5 @@
     "basic/music_nerd_pro_sly_local.hocon": true,
     "basic/pii_middleware.hocon": true,
     "basic/smart_home.hocon": true,
+    "basic/wolfram_mcp.hocon": true,
 }

--- a/registries/basic/wolfram_mcp.hocon
+++ b/registries/basic/wolfram_mcp.hocon
@@ -53,8 +53,7 @@ Do not try to help for other matters.
 Do not mention what you can NOT do. Only mention what you can do.
             """,
             "function": {
-                "description": "Assist user with answer from Wolfram."
-            },
+                "description": "Assist the user with answers from Wolfram."
             # Only support streamable HTTP(S) protocol
             # For other modes of transport, use coded tool implementation
             # The URL must be a canonical MCP server URI (see

--- a/registries/basic/wolfram_mcp.hocon
+++ b/registries/basic/wolfram_mcp.hocon
@@ -1,0 +1,70 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
+
+{
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network consisting of a single agent and MCP tools",
+        "tags": ["example", "mcp"],
+        "sample_queries": [
+            "Compute the integral of sin(x)^2 from 0 to pi",
+            "Convert 150 km/h to miles per second",
+            "What is the distance from Earth to Mars today?",
+            "What is the population and GDP of Japan compared to Germany?",
+        ]
+    },
+    "llm_config": {
+        "model_name": "gpt-5.2"
+    },
+    "tools": [
+        # These tool definitions do not have to be in any particular order
+        # How they are linked and call each other is defined within their
+        # own specs.  This could be a graph, potentially even with cycles.
+
+        # This first guy is the "Front Man".  He is identified as such because
+        # he is the only one with no parameters in his function definition,
+        # and therefore he needs to talk to the outside world to get things rolling.
+        {
+            "name": "knowledge_agent",
+            "instructions": """You are a knowledge agent backed by the Wolfram MCP server, which provides access to Wolfram|Alpha's computational knowledge engine.
+Use your tool to answer questions involving mathematics (algebra, calculus, equations, statistics), science (physics, chemistry, astronomy, biology),
+engineering, unit conversions, dates and times, geography, demographics, and factual or computational lookups.
+Formulate concise, well-structured queries to your tool. If a result is ambiguous or incomplete, refine the query and try again before giving up.
+Present results clearly to the user: show the computed answer, and include relevant intermediate steps, formulas, or units when they help understanding.
+Only answer inquiries that are directly within your area of expertise.
+Do not try to help for other matters.
+Do not mention what you can NOT do. Only mention what you can do.
+            """,
+            "function": {
+                "description": "Assist user with answer from Wolfram."
+            },
+            # Only support streamable HTTP(S) protocol
+            # For other modes of transport, use coded tool implementation
+            # The URL must be a canonical MCP server URI (see
+            # https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri):
+            # http(s) scheme, no fragment, with "mcp" as a host label (e.g. "mcp.example.com")
+            # or as a path segment (e.g. "/mcp", "/mcp/free", "/server/mcp").
+            # Otherwise, use dictionary format: {"url": "https://example.com"} instead.
+            "tools": ["https://agenttools.wolfram.com/mcp"]
+            
+            # For authentication, see https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#authentication
+        }
+    ]
+}


### PR DESCRIPTION

<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Introduces a single-agent `wolfram_mcp` network demonstrating how to wire an agent to the Wolfram Cloud MCP server (streamable HTTP) for symbolic math, scientific computation, unit conversions, and curated factual lookups via Wolfram|Alpha. Includes:

- registries/basic/wolfram_mcp.hocon and manifest entry
- docs/examples/basic/wolfram_mcp.md walkthrough
- docs/examples.md TOC + section entry under Basic Examples
- Short descriptive comments for the existing Wolfram and DeepWiki entries in mcp_info.hocon


Fixes #1192 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [x] Documentation
- [x] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
