### PR TITLE
Fix hocon for wolfram and you search

### DIFF
--- a/registries/basic/wolfram_mcp.hocon
+++ b/registries/basic/wolfram_mcp.hocon
@@ -54,6 +54,7 @@ Do not mention what you can NOT do. Only mention what you can do.
             """,
             "function": {
                 "description": "Assist the user with answers from Wolfram."
+            },
             # Only support streamable HTTP(S) protocol
             # For other modes of transport, use coded tool implementation
             # The URL must be a canonical MCP server URI (see

--- a/registries/tools/you_search.hocon
+++ b/registries/tools/you_search.hocon
@@ -94,15 +94,14 @@
                                             "type": "string",
                                             "description": "Authorization header for you.com API access, e.g., 'Bearer <token_value>'."
                                         }
-                                    },
+                                },
                                     "required": ["Authorization"]
-                                }
-                            },
+                            }
+                        },
                             "required": ["https://api.you.com/mcp"]
-                        }
-                    },
+                    }
+                },
                     "required": ["http_headers"]
-                }
             },
 
             "instructions": """


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Wolfram HOCON is missing a `}' while you search has one too many '}'.

Fix #1194 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
