### PR TITLE
PII middleware: address PR #1204 review — env-var detector, named pattern fragments

### DIFF
--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -34,6 +34,42 @@
     "max_execution_seconds": 6000,
     "error_formatter": "json",
     "error_fragments": ["Error:", "Exception:", "Traceback (most recent call last)"],
+
+    # Regex fragments used by the PIIMiddleware detector on the front-man agent below.
+    # Each fragment targets one credential shape; the detector concatenates them into a
+    # single alternation via HOCON substitution. Prefix-anchored patterns use `+` (no
+    # length floor) because the prefix itself is a strong signal — we'd rather redact a
+    # suspiciously-short match than miss a real leak (e.g. `sk-ant-ajdslkfj` should still
+    # be caught).
+    "pii_patterns": {
+        # Anthropic API keys (e.g. sk-ant-api03-...)
+        "anthropic":    "sk-ant-[A-Za-z0-9_-]+",
+        # OpenAI project keys (e.g. sk-proj-...)
+        "openai_proj":  "sk-proj-[A-Za-z0-9_-]+",
+        # OpenAI classic keys (e.g. sk-...)
+        "openai":       "sk-[A-Za-z0-9_-]+",
+        # AWS access key IDs — fixed 20 chars (e.g. AKIAIOSFODNN7EXAMPLE)
+        "aws":          "AKIA[0-9A-Z]{16}",
+        # Google API keys — fixed 39 chars (e.g. AIzaSy...)
+        "google":       "AIza[0-9A-Za-z_-]{35}",
+        # GitHub tokens (ghp_, gho_, ghu_, ghs_, ghr_)
+        "github":       "gh[pousr]_[A-Za-z0-9]+",
+        # Slack tokens (xoxb-, xoxa-, xoxp-, xoxr-, xoxs-)
+        "slack":        "xox[baprs]-[A-Za-z0-9-]+",
+        # GitLab personal access tokens
+        "gitlab":       "glpat-[A-Za-z0-9_-]+",
+        # Stripe secret keys (sk_live_..., sk_test_...)
+        "stripe":       "sk_(?:live|test)_[A-Za-z0-9]+",
+        # Bearer tokens in Authorization-style headers.
+        # Kept at 20+ chars because "Bearer x" is common in prose.
+        "bearer":       "Bearer\\s+[A-Za-z0-9._~+/=-]{20,}",
+        # HOCON env-var substitution attempts, both required ${VAR} and optional ${?VAR}
+        # forms (the `?` falls under `[^}]+`). An agent that emits either into constructed
+        # HOCON would exfiltrate whatever env var the server later resolves — redact
+        # before it can be written to disk.
+        "env_var":      "\\$\\{[^}]+\\}"
+    },
+
     "tools": [
         # This first agent definition is regarded as the "Front Man", which
         # does all the talking to the outside world/client.
@@ -256,30 +292,17 @@ Operational notes:
                 {
                     # See https://docs.langchain.com/oss/python/langchain/middleware/built-in#pii-detection
                     # for details on the specific PII implementation.
-                    # Redacts common API key formats so secrets never reach the LLM, the client,
-                    # or downstream tools. Applied to inputs, outputs, and tool results — the model
-                    # itself should not see a leaked key either (otherwise it could echo, log, or
-                    # summarize it back later).
+                    # Redacts common API key formats and HOCON env-var lookups so secrets never reach
+                    # the LLM, the client, or downstream tools. Applied to inputs, outputs, and tool
+                    # results — the model itself should not see a leaked key either (otherwise it
+                    # could echo, log, or summarize it back later).
                     #
-                    # The `detector` regex is an alternation of provider-specific patterns.
-                    # Prefix-anchored patterns use `+` (no length floor) — the prefix itself is
-                    # a strong signal and we'd rather redact a suspiciously-short match than
-                    # miss a real leak (e.g. `sk-ant-ajdslkfj` should still be caught).
-                    #   sk-ant-[A-Za-z0-9_-]+              Anthropic API keys        (e.g. sk-ant-api03-...)
-                    #   sk-proj-[A-Za-z0-9_-]+             OpenAI project keys       (e.g. sk-proj-...)
-                    #   sk-[A-Za-z0-9_-]+                  OpenAI classic keys       (e.g. sk-...)
-                    #   AKIA[0-9A-Z]{16}                   AWS access key IDs        (fixed length; e.g. AKIAIOSFODNN7EXAMPLE)
-                    #   AIza[0-9A-Za-z_-]{35}              Google API keys           (fixed length; e.g. AIzaSy...)
-                    #   gh[pousr]_[A-Za-z0-9]+             GitHub tokens             (ghp_, gho_, ghu_, ghs_, ghr_)
-                    #   xox[baprs]-[A-Za-z0-9-]+           Slack tokens              (xoxb-, xoxa-, xoxp-, xoxr-, xoxs-)
-                    #   glpat-[A-Za-z0-9_-]+               GitLab personal access tokens
-                    #   sk_(?:live|test)_[A-Za-z0-9]+      Stripe secret keys        (sk_live_..., sk_test_...)
-                    #   Bearer\\s+[A-Za-z0-9._~+/=-]{20,}  Bearer tokens in Authorization-style headers.
-                    #                                      Kept at 20+ chars because 'Bearer x' is common in prose.
+                    # The `detector` regex is an alternation of the fragments defined in the
+                    # top-level `pii_patterns` block above, concatenated here via HOCON substitution.
                     "class": "langchain.agents.middleware.PIIMiddleware",
                     "args": {
                         "pii_type": "api_key",
-                        "detector": "sk-ant-[A-Za-z0-9_-]+|sk-proj-[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]+|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|gh[pousr]_[A-Za-z0-9]+|xox[baprs]-[A-Za-z0-9-]+|glpat-[A-Za-z0-9_-]+|sk_(?:live|test)_[A-Za-z0-9]+|Bearer\\s+[A-Za-z0-9._~+/=-]{20,}",
+                        "detector": ${pii_patterns.anthropic}"|"${pii_patterns.openai_proj}"|"${pii_patterns.openai}"|"${pii_patterns.aws}"|"${pii_patterns.google}"|"${pii_patterns.github}"|"${pii_patterns.slack}"|"${pii_patterns.gitlab}"|"${pii_patterns.stripe}"|"${pii_patterns.bearer}"|"${pii_patterns.env_var},
                         "strategy": "redact",
                         "apply_to_input": true,
                         "apply_to_output": true,


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Follow-up to #1204, implementing the comments @d1donlydfink left on that PR:

- Detect `${...}` env-var substitutions. A designer output that contains `${OPENAI_API_KEY}` (or the optional form `${?OPENAI_API_KEY}`) gets resolved by the server at HOCON load time if it's later saved into a constructed agent's config — so an agent can exfiltrate any env var the server can see. Adds a new env_var fragment `\$\{[^}]+\}` that catches both forms (? is swept up by [^}]+).

- Refactor the detector for readability. The single monster regex string is replaced with a named pii_patterns block — one per provider (anthropic, openai_proj, openai, aws, google, github, slack, gitlab, stripe, bearer, env_var) — each on its own line with a comment explaining what it catches. The middleware's detector argument is assembled via HOCON substitution: `${pii_patterns.anthropic}"|"${pii_patterns.openai_proj}"|"....`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
