### PR TITLE
Reject external/invalid agent names as agent network definition node keys

### DIFF
--- a/coded_tools/agent_network_editor/add_agent.py
+++ b/coded_tools/agent_network_editor/add_agent.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from neuro_san.interfaces.coded_tool import CodedTool
 
+from coded_tools.agent_network_editor.agent_name_guard import AgentNameGuard
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.progress_handler import ProgressHandler
 
@@ -71,6 +72,11 @@ class AddAgent(CodedTool):
         the_agent_name: str = args.get("agent_name", "")
         if the_agent_name == "":
             return "Error: No agent_name provided."
+        # External references must live inside a tools list, not as a node, and local
+        # names must be valid tool names (letters/digits/underscore/hyphen only).
+        name_error: str = AgentNameGuard.agent_name_error(the_agent_name)
+        if name_error:
+            return name_error
         is_tool: bool = args.get("is_tool")
         if is_tool is None:
             return "Error: No is_tool provided."

--- a/coded_tools/agent_network_editor/add_agent.py
+++ b/coded_tools/agent_network_editor/add_agent.py
@@ -74,7 +74,7 @@ class AddAgent(CodedTool):
             return "Error: No agent_name provided."
         # External references must live inside a tools list, not as a node, and local
         # names must be valid tool names (letters/digits/underscore/hyphen only).
-        name_error: str = AgentNameGuard.agent_name_error(the_agent_name)
+        name_error: str | None = AgentNameGuard.agent_name_error(the_agent_name)
         if name_error:
             return name_error
         is_tool: bool = args.get("is_tool")

--- a/coded_tools/agent_network_editor/agent_name_guard.py
+++ b/coded_tools/agent_network_editor/agent_name_guard.py
@@ -1,0 +1,73 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import re
+from typing import Any
+
+from neuro_san.internals.validation.network.tool_name_network_validator import ToolNameNetworkValidator
+from neuro_san.internals.validation.network.url_network_validator import UrlNetworkValidator
+
+
+# pylint: disable=too-few-public-methods
+class AgentNameGuard:
+    """
+    Guard that validates an agent-node name (a key in the agent network definition).
+
+    Two rules are enforced, both about the node *key* — not tool references, which
+    legitimately may point at external agents inside a `tools` list:
+
+    1. External agent/subnetwork/MCP references — names starting with "/", "http://",
+       or "https://" — are only legal as tool references, never as top-level nodes
+       (where they would carry the instructions/description/tools that an external
+       agent/subnetwork cannot have). This case is reported with an actionable message.
+    2. Any remaining name must match the same pattern the framework enforces on tool
+       names (ToolNameNetworkValidator.TOOL_NAME_PATTERN — letters, digits, underscore,
+       and hyphen only) so a node name can never become an illegal langchain tool name.
+
+    This shared guard keeps the checks (and their messages) identical across the tools
+    that create or edit node keys (create_network, add_agent, update_agent).
+    """
+
+    @staticmethod
+    def agent_name_error(agent_name: Any) -> str | None:
+        """
+        Return an error message if `agent_name` is not a valid local agent-node name,
+        or None if it is valid.
+
+        :param agent_name: The candidate agent-node name (dict key) to check
+        :return: An "Error: ..." string if the name is invalid, else None
+        """
+        if not isinstance(agent_name, str):
+            return f"Error: agent name must be a string, got {type(agent_name).__name__}."
+
+        # Check the more specific external-reference case first so the model gets an
+        # actionable message rather than a generic "invalid characters" one.
+        if UrlNetworkValidator.is_url_or_path(agent_name):
+            return (
+                f"Error: '{agent_name}' is an external agent/subnetwork/MCP reference and "
+                "cannot be a node in the network. Reference it inside another agent's tools "
+                "list instead. External agents/subnetworks cannot have instructions, "
+                "description, or tools."
+            )
+
+        if not re.match(ToolNameNetworkValidator.TOOL_NAME_PATTERN, agent_name):
+            return (
+                f"Error: '{agent_name}' is not a valid agent name. Agent names may contain "
+                "only letters, digits, underscores, and hyphens "
+                f"(must match the regex '{ToolNameNetworkValidator.TOOL_NAME_PATTERN}')."
+            )
+
+        return None

--- a/coded_tools/agent_network_editor/create_network.py
+++ b/coded_tools/agent_network_editor/create_network.py
@@ -73,12 +73,22 @@ class CreateNetwork(CodedTool):
         agent_network_name: str = args.get("agent_network_name")
         if not agent_network_name:
             return "Error: No agent_network_name provided."
+        # Type-check before len()/iteration: a non-list (str/dict) or wrong element types
+        # would otherwise be iterated per-character/per-key and build a bogus network.
         agent_names: list[str] = args.get("agent_names")
-        if not agent_names:
-            return "Error: No agent_names provided."
+        if (
+            not agent_names
+            or not isinstance(agent_names, list)
+            or not all(isinstance(name, str) for name in agent_names)
+        ):
+            return "Error: agent_names must be a non-empty list of strings."
         is_tool_list: list[bool] = args.get("is_tool_list")
-        if not is_tool_list:
-            return "Error: No is_tool_list provided."
+        if (
+            not is_tool_list
+            or not isinstance(is_tool_list, list)
+            or not all(isinstance(flag, bool) for flag in is_tool_list)
+        ):
+            return "Error: is_tool_list must be a non-empty list of booleans."
         if len(agent_names) != len(is_tool_list):
             return "Error: The length of agent_names and is_tool_list must be the same."
         # Validate all node names before mutating sly_data, so an invalid name doesn't
@@ -88,7 +98,7 @@ class CreateNetwork(CodedTool):
         # valid tool names.
         name_errors: list[str] = []
         for agent_name in agent_names:
-            name_error: str = AgentNameGuard.agent_name_error(agent_name)
+            name_error: str | None = AgentNameGuard.agent_name_error(agent_name)
             if name_error:
                 name_errors.append(name_error)
         if name_errors:

--- a/coded_tools/agent_network_editor/create_network.py
+++ b/coded_tools/agent_network_editor/create_network.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from neuro_san.interfaces.coded_tool import CodedTool
 
+from coded_tools.agent_network_editor.agent_name_guard import AgentNameGuard
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
 from coded_tools.agent_network_editor.progress_handler import ProgressHandler
@@ -69,7 +70,6 @@ class CreateNetwork(CodedTool):
                 a text string of an error message in the format:
                 "Error: <error message>"
         """
-        sly_data[AGENT_NETWORK_DEFINITION] = {}
         agent_network_name: str = args.get("agent_network_name")
         if not agent_network_name:
             return "Error: No agent_network_name provided."
@@ -81,9 +81,23 @@ class CreateNetwork(CodedTool):
             return "Error: No is_tool_list provided."
         if len(agent_names) != len(is_tool_list):
             return "Error: The length of agent_names and is_tool_list must be the same."
+        # Validate all node names before mutating sly_data, so an invalid name doesn't
+        # leave a partially-created network. Collect every offending name so the caller
+        # can fix them all in one pass rather than one per turn. External references must
+        # be referenced inside a tools list, not created as nodes; local names must be
+        # valid tool names.
+        name_errors: list[str] = []
+        for agent_name in agent_names:
+            name_error: str = AgentNameGuard.agent_name_error(agent_name)
+            if name_error:
+                name_errors.append(name_error)
+        if name_errors:
+            return "\n".join(name_errors)
 
         logger = logging.getLogger(self.__class__.__name__)
         logger.info(">>>>>>>>>>>>>>>>>>Create New Agent Netwrok Definiton for %s>>>>>>>>>>>>>>>>>", agent_network_name)
+        # Reset/overwrite any existing network only after all inputs validate.
+        sly_data[AGENT_NETWORK_DEFINITION] = {}
         for i, agent_name in enumerate(agent_names):
             logger.info(">>>>>>>>>>>>>>>>>>>Adding Agent>>>>>>>>>>>>>>>>>>")
             logger.info("Agent Name: %s", agent_name)

--- a/coded_tools/agent_network_editor/update_agent.py
+++ b/coded_tools/agent_network_editor/update_agent.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from neuro_san.interfaces.coded_tool import CodedTool
 
+from coded_tools.agent_network_editor.agent_name_guard import AgentNameGuard
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.progress_handler import ProgressHandler
 
@@ -35,6 +36,7 @@ class UpdateAgent(CodedTool):
     - a list of down-chain agents (agents reporting to it)
     """
 
+    # pylint: disable=too-many-return-statements
     async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any] | str:
         """
          :param args: An argument dictionary whose keys are the parameters
@@ -72,6 +74,13 @@ class UpdateAgent(CodedTool):
         the_agent_name: str = args.get("agent_name")
         if not the_agent_name:
             return "Error: No agent_name provided."
+        # Guard the target node key only. An external reference (e.g. a malformed input
+        # network that already contains a "/subnetwork" node) must not receive tools.
+        # new_down_chains is intentionally NOT guarded: external references are valid
+        # there, since that is how a subnetwork is referenced.
+        name_error: str = AgentNameGuard.agent_name_error(the_agent_name)
+        if name_error:
+            return name_error
         if the_agent_name not in network_def:
             return "Error: agent_name not in the agent network"
 

--- a/coded_tools/agent_network_editor/update_agent.py
+++ b/coded_tools/agent_network_editor/update_agent.py
@@ -78,7 +78,7 @@ class UpdateAgent(CodedTool):
         # network that already contains a "/subnetwork" node) must not receive tools.
         # new_down_chains is intentionally NOT guarded: external references are valid
         # there, since that is how a subnetwork is referenced.
-        name_error: str = AgentNameGuard.agent_name_error(the_agent_name)
+        name_error: str | None = AgentNameGuard.agent_name_error(the_agent_name)
         if name_error:
             return name_error
         if the_agent_name not in network_def:


### PR DESCRIPTION


<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

External agent/subnetwork/MCP references (names starting with "/", "http://", "https://") are only legal as tool references inside a `tools` list — never as top-level nodes, where they'd carry the instructions/description/tools that an external agent cannot have. The node-creating tools accepted any name, so the designer could create e.g. "/generated/fitness_gym_ops" as a full node and it slipped through validation.

Add a shared AgentNameGuard.agent_name_error() that rejects a node key when it is an external reference, or when it doesn't match the framework tool-name pattern (^[a-zA-Z0-9_-]+$), reusing ToolNameNetworkValidator.TOOL_NAME_PATTERN so the two stay in sync.

Wire it into the tools that create or edit node keys:
- create_network: validate every name up front, collecting all bad names in one message; move the sly_data reset to after validation so an invalid input no longer wipes the existing network.
- add_agent: guard agent_name before creating the node.
- update_agent: guard the target key only; new_down_chains is left unguarded because external references are valid there (that is how a subnetwork is referenced).

Partial Fixes #1202 
This is the studio-side half of the fix; the framework-side gap (StructureNetworkValidator does no node-name validation, and ToolNameNetworkValidator will crashes on the name->spec format) is tracked separately in neuro-san. https://github.com/cognizant-ai-lab/neuro-san/issues/1099


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
