### PR TITLE
NS-709 Adapt AGENT_MANIFEST_FILE to new  path separator

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -169,13 +169,14 @@ ENV PYTHONPATH="${APP_SOURCE}"
 
 # Where to find the tool registry manifest file which lists all the agent hocon
 # files to serve up from this server instance.  To specify multiple manifest files,
-# simply use a space-separated list of manifest files.  Manifest dictionaries will
-# effectively be merged, where content coming from manifests later in the list
-# have precedence.
-# This particular Dockerfile is put together to support a server that hosts multiple users
+# simply use a delimited list of manifest files approriate to the OS
+# (delimiter is ':' on linux, ';' on Windows).  Manifest dictionaries will then effectively
+# be merged, where content coming from manifests later in the list have precedence.
+#
+# This particular Dockerfile is put together to support a linux server that hosts multiple users
 # and so we use the multiple manifest file aspect of the neuro-san server to turn off some networks
 # that are not appropriate for such a deployment. See manifest_multiuser_overlay.hocon for more info.
-ENV AGENT_MANIFEST_FILE="${APP_SOURCE}/registries/manifest.hocon ${APP_SOURCE}/registries/manifest_multiuser_overlay.hocon"
+ENV AGENT_MANIFEST_FILE="${APP_SOURCE}/registries/manifest.hocon:${APP_SOURCE}/registries/manifest_multiuser_overlay.hocon"
 
 # An llm_info hocon file with user-provided llm descriptions that are to be used
 # in addition to the neuro-san defaults.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Neuro SAN
 leaf-common>=1.2.44
-neuro-san==0.6.69
+neuro-san==0.6.70
 nsflow==0.6.16
 
 # For config parsing


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Adopt neuro-san==0.6.70 with new os-specific path separators for AGENT_MANIFEST_FILE (from python's os.pathsep definition).

This is as opposed to the previously brittle space (" ") delimiter that was used before that caused problems for Windows users.

Fixes # <!-- Issue number, if applicable -->

## Impact

<!-- Brief description of what the consequences of this PR are -->

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
