### PR TITLE
Adding mistral to the user_guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@ ANTHROPIC_API_KEY="YOUR_ANTHROPIC_API_KEY"
 # you can get your Google Gemini API key from https://ai.google.dev/gemini-api/docs/api-key
 GOOGLE_API_KEY="YOUR_GOOGLE_GEMINI_API_KEY"
 
+# you can get your Mistral API key from https://admin.mistral.ai/
+# Also requires: pip install langchain-mistralai==1.1.2
+MISTRAL_API_KEY="YOUR_MISTRAL_API_KEY"
+
 # To use Amazon Bedrock models, you must have an AWS account.
 # You can sign up at: https://signin.aws.amazon.com/signup?request_type=register
 # Note: Amazon Bedrock is a paid service. Pricing details are available at: https://aws.amazon.com/bedrock/pricing/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -20,6 +20,9 @@ https://test
 https://www.united.com/
 https://mcp/
 
+# Login-walled pages that redirect through an auth flow lychee can't resolve
+https://admin.mistral.ai/
+
 # URLs whose base path is not browsable (returns 400 or 404)
 https://raw.githubusercontent.com/anthropics/skills/main/skills/internal-comms/
 https://api.anthropic.com/

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -27,6 +27,7 @@
       - [Ollama Configuration](#ollama-configuration)
       - [Using Ollama in Docker or Remote Server](#using-ollama-in-docker-or-remote-server)
       - [Example agent network](#example-agent-network)
+    - [Mistral](#mistral)
     - [Configuring Default Models with Environment Variables](#configuring-default-models-with-environment-variables)
       - [Using Optional Environment Variable Substitution](#using-optional-environment-variable-substitution)
       - [Setting Your Own Default Model](#setting-your-own-default-model)
@@ -704,6 +705,31 @@ See the [./examples/music_nerd_pro_local.md](examples/basic/music_nerd_pro_local
 
 For more information about how to use Ollama with LangChain,
 see [this page](https://python.langchain.com/docs/integrations/chat/ollama/)
+
+### Mistral
+
+Mistral is not one of the built-in providers in the
+[default llm info file](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon),
+so it is configured using the `class` key with the full LangChain chat model path (see
+[Using the `class` Key](#using-the-class-key)).
+
+First, install the LangChain Mistral AI integration:
+
+```shell
+pip install langchain-mistralai==1.1.2
+```
+
+Then set the `MISTRAL_API_KEY` environment variable to your Mistral API key and specify the model
+in the `llm_config` section of an agent network hocon file:
+
+```hocon
+    "llm_config": {
+        "class": "langchain_mistralai.chat_models.ChatMistralAI",
+        "model_name": "mistral-medium-latest",
+    }
+```
+
+Here you can get a Mistral API [key](https://admin.mistral.ai/).
 
 ### Configuring Default Models with Environment Variables
 


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Documents how to configure Mistral AI models in Neuro SAN Studio. Mistral isn't one of the
built-in LLM providers, so it's wired up via the `class` key with the full LangChain chat model
path (`langchain_mistralai.chat_models.ChatMistralAI`), following the same pattern already used
for other custom/non-default providers.

- Added a `### Mistral` section to [docs/user_guide.md](docs/user_guide.md) (with TOC entry),
  covering the `pip install langchain-mistralai==1.1.2` prerequisite, the `MISTRAL_API_KEY`
  environment variable, and an example `llm_config` block using `mistral-medium-latest`.
- Added a `MISTRAL_API_KEY` entry to [.env.example](.env.example), alongside a pointer to the
  required `langchain-mistralai` install and the API key signup page
  (https://admin.mistral.ai/).

Fixes # <!-- Issue number, if applicable -->

## Impact

Documentation-only change. No code paths are modified; users who want to use Mistral models now
have a documented, supported way to configure them via the existing custom-`class` mechanism.

## Screenshots / Logs / Examples (optional)

Example `llm_config` added to the guide:

```hocon
    "llm_config": {
        "class": "langchain_mistralai.chat_models.ChatMistralAI",
        "model_name": "mistral-medium-latest",
    }
```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- Mistral is documented as a custom/non-default provider (via the `class` key), so it is not
added to the main requirements.txt -- users install langchain-mistralai themselves per the guide. -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
