### PR TITLE
Strengthen SSRF protection in WebFetch by resolving hostnames via DNS

### DIFF
--- a/neuro_san_studio/coded_tools/web_fetch.py
+++ b/neuro_san_studio/coded_tools/web_fetch.py
@@ -171,7 +171,7 @@ class WebFetch(CodedTool):
         # but not "badexample.com".
         hostname: str = raw_hostname.lower()
 
-        await self._validate_hostname_safety(hostname)
+        hostname = await self._validate_hostname_safety(hostname)
 
         allowed_domains: list[str] = self._validate_domain_list(args.get("allowed_domains"), "allowed_domains")
         if allowed_domains and not any(
@@ -187,10 +187,11 @@ class WebFetch(CodedTool):
 
         return url
 
-    async def _validate_hostname_safety(self, hostname: str) -> None:
+    async def _validate_hostname_safety(self, hostname: str) -> str:
         """Reject IP literals in private/loopback/link-local/multicast/reserved ranges and localhost.
 
         Note: non-IP hostnames are not DNS-resolved here; use allowed_domains for stricter control.
+        :return: A safe hostname to use or an exception if the hostname is unsafe.
         """
         if hostname == "localhost" or hostname.endswith(".localhost"):
             raise ValueError(f"url_not_allowed: Host '{hostname}' targets a loopback address.")
@@ -215,9 +216,10 @@ class WebFetch(CodedTool):
                 raise ValueError(f"url_not_allowed: Host '{hostname}' does not resolve to an IP address.")
 
             ip_ok: bool = False
+            ip_string: str = None
             for info in addr_infos:
                 # Loop through all IP addresses resolved for the hostname
-                ip_string: str = info[4][0]
+                ip_string = info[4][0]
                 try:
                     addr = ip_address(ip_string)
                 except ValueError:
@@ -231,12 +233,15 @@ class WebFetch(CodedTool):
                 ip_ok = True
                 break
 
-            if not ip_ok:
+            if not ip_ok or not ip_string:
                 raise ValueError(f"url_not_allowed: Host '{hostname}' does not resolve to a valid IP address.")
-            return
+
+            return ip_string
 
         if not addr.is_global:
             raise ValueError(f"url_not_allowed: IP address '{hostname}' is not a globally routable address.")
+
+        return hostname
 
     def _validate_domain_list(self, value: Any, param_name: str) -> list[str]:
         """Coerce and validate a domain list parameter. Accepts None, list[str], or a single str."""

--- a/neuro_san_studio/coded_tools/web_fetch.py
+++ b/neuro_san_studio/coded_tools/web_fetch.py
@@ -60,8 +60,10 @@ class WebFetch(CodedTool):
     Uses aiohttp for HTTP requests and BeautifulSoup to strip HTML markup from
     the response. PDF URLs are handled via PyPDFLoader.
 
-    Note: IP-literal SSRF protection blocks private/loopback/reserved ranges and localhost, but
-    non-IP hostnames are not DNS-resolved. Use allowed_domains for stricter control.
+    Note: SSRF protection blocks private/loopback/reserved ranges and localhost. Non-IP
+    hostnames are DNS-resolved and every resolved address must be globally routable.
+    DNS rebinding is not mitigated (see _validate_hostname_safety); use allowed_domains
+    for stricter control.
     Redirects are not followed; a 3xx response raises url_not_allowed.
     The byte cap (MAX_RESPONSE_BYTES) is enforced via the Content-Length header only (checked
     before download). A server that lies about or omits Content-Length can still deliver an
@@ -171,8 +173,6 @@ class WebFetch(CodedTool):
         # but not "badexample.com".
         hostname: str = raw_hostname.lower()
 
-        hostname = await self._validate_hostname_safety(hostname)
-
         allowed_domains: list[str] = self._validate_domain_list(args.get("allowed_domains"), "allowed_domains")
         if allowed_domains and not any(
             hostname == domain.lower() or hostname.endswith("." + domain.lower()) for domain in allowed_domains
@@ -185,67 +185,55 @@ class WebFetch(CodedTool):
         ):
             raise ValueError(f"url_not_allowed: Domain '{hostname}' is blocked.")
 
+        # Domain rules run first so rejected URLs never trigger a DNS lookup.
+        await self._validate_hostname_safety(hostname)
+
         return url
 
-    async def _validate_hostname_safety(self, hostname: str) -> str:
-        """Reject IP literals in private/loopback/link-local/multicast/reserved ranges and localhost.
+    async def _validate_hostname_safety(self, hostname: str) -> None:
+        """Reject hosts that are, or resolve to, non-globally-routable IP addresses.
 
-        Note: non-IP hostnames are not DNS-resolved here; use allowed_domains for stricter control.
-        :return: A safe hostname to use or an exception if the hostname is unsafe.
+        IP literals are checked directly. Other hostnames are DNS-resolved, and every
+        resolved address must be globally routable (rejects private/loopback/link-local/
+        multicast/reserved ranges and localhost).
+
+        Warning: this does not prevent DNS rebinding. The HTTP client re-resolves the
+        hostname at connection time, so an attacker-controlled DNS server can return a
+        safe address here and an internal one for the actual fetch. Closing that gap
+        requires pinning the validated addresses into the connection (e.g. a custom
+        resolver on the aiohttp TCPConnector).
         """
         if hostname == "localhost" or hostname.endswith(".localhost"):
             raise ValueError(f"url_not_allowed: Host '{hostname}' targets a loopback address.")
 
-        addr: IPv4Address | IPv6Address = None
+        addresses: list[IPv4Address | IPv6Address]
         try:
-            addr = ip_address(hostname)
-        except ValueError as value_exc:
-            # Not an IP literal;
-            # Try to resolve the hostname to an IP address
+            addresses = [ip_address(hostname)]
+        except ValueError as literal_exc:
+            # Not an IP literal; resolve the hostname and validate every DNS record.
             loop: AbstractEventLoop = get_running_loop()
-
-            # loop.getaddrinfo works like socket.getaddrinfo but is non-blocking
-            # SOCK_STREAM specifies TCP stream configuration
-            addr_infos: list[tuple[str, int, int, str, tuple[str, int]]] = []
             try:
+                # loop.getaddrinfo works like socket.getaddrinfo but is non-blocking
                 addr_infos = await loop.getaddrinfo(hostname, None, type=SOCK_STREAM)
-            except gaierror as exc:
-                raise ValueError(f"url_not_allowed: Host '{hostname}' could not be resolved.") from exc
+            except gaierror as dns_exc:
+                raise ValueError(f"url_not_allowed: Host '{hostname}' could not be resolved.") from dns_exc
 
-            if not addr_infos:
+            addresses = []
+            for info in addr_infos:
+                addresses.append(ip_address(info[4][0]))
+            if not addresses:
                 raise ValueError(
                     f"url_not_allowed: Host '{hostname}' doesn't resolve to an IP address."
-                ) from value_exc
+                ) from literal_exc
 
-            ip_ok: bool = False
-            ip_string: str = None
-            for info in addr_infos:
-                # Loop through all IP addresses resolved for the hostname
-                ip_string = info[4][0]
-                try:
-                    addr = ip_address(ip_string)
-                except ValueError:
-                    # If we can't get an IP address from the string, try the next
-                    continue
-
-                if addr is None or not addr.is_global:
-                    # We only want globally routable IP addresses (not local)
-                    continue
-
-                ip_ok = True
-                break
-
-            if not ip_ok or not ip_string:
+        # Every address must be global: with multiple DNS records the OS may connect
+        # to any of them, so a single non-global record makes the host unsafe.
+        for addr in addresses:
+            if not addr.is_global:
                 raise ValueError(
-                    f"url_not_allowed: Host '{hostname}' doesn't resolve to a valid IP address."
-                ) from value_exc
-
-            return ip_string
-
-        if not addr.is_global:
-            raise ValueError(f"url_not_allowed: IP address '{hostname}' is not a globally routable address.")
-
-        return hostname
+                    f"url_not_allowed: Host '{hostname}' uses IP address '{addr}', "
+                    "which is not a globally routable address."
+                )
 
     def _validate_domain_list(self, value: Any, param_name: str) -> list[str]:
         """Coerce and validate a domain list parameter. Accepts None, list[str], or a single str."""

--- a/neuro_san_studio/coded_tools/web_fetch.py
+++ b/neuro_san_studio/coded_tools/web_fetch.py
@@ -199,7 +199,7 @@ class WebFetch(CodedTool):
         addr: IPv4Address | IPv6Address = None
         try:
             addr = ip_address(hostname)
-        except ValueError:
+        except ValueError as value_exc:
             # Not an IP literal;
             # Try to resolve the hostname to an IP address
             loop: AbstractEventLoop = get_running_loop()
@@ -213,7 +213,7 @@ class WebFetch(CodedTool):
                 raise ValueError(f"url_not_allowed: Host '{hostname}' could not be resolved.") from exc
 
             if not addr_infos:
-                raise ValueError(f"url_not_allowed: Host '{hostname}' does not resolve to an IP address.")
+                raise ValueError(f"url_not_allowed: Host '{hostname}' doesn't resolve to an IP address.") from value_exc
 
             ip_ok: bool = False
             ip_string: str = None
@@ -234,7 +234,7 @@ class WebFetch(CodedTool):
                 break
 
             if not ip_ok or not ip_string:
-                raise ValueError(f"url_not_allowed: Host '{hostname}' does not resolve to a valid IP address.")
+                raise ValueError(f"url_not_allowed: Host '{hostname}' doesn't resolve to a valid IP.") from value_exc
 
             return ip_string
 

--- a/neuro_san_studio/coded_tools/web_fetch.py
+++ b/neuro_san_studio/coded_tools/web_fetch.py
@@ -213,7 +213,9 @@ class WebFetch(CodedTool):
                 raise ValueError(f"url_not_allowed: Host '{hostname}' could not be resolved.") from exc
 
             if not addr_infos:
-                raise ValueError(f"url_not_allowed: Host '{hostname}' doesn't resolve to an IP address.") from value_exc
+                raise ValueError(
+                    f"url_not_allowed: Host '{hostname}' doesn't resolve to an IP address."
+                ) from value_exc
 
             ip_ok: bool = False
             ip_string: str = None
@@ -234,7 +236,9 @@ class WebFetch(CodedTool):
                 break
 
             if not ip_ok or not ip_string:
-                raise ValueError(f"url_not_allowed: Host '{hostname}' doesn't resolve to a valid IP.") from value_exc
+                raise ValueError(
+                    f"url_not_allowed: Host '{hostname}' doesn't resolve to a valid IP address."
+                ) from value_exc
 
             return ip_string
 

--- a/neuro_san_studio/coded_tools/web_fetch.py
+++ b/neuro_san_studio/coded_tools/web_fetch.py
@@ -216,20 +216,23 @@ class WebFetch(CodedTool):
 
             ip_ok: bool = False
             for info in addr_infos:
+                # Loop through all IP addresses resolved for the hostname
                 ip_string: str = info[4][0]
                 try:
                     addr = ip_address(ip_string)
                 except ValueError:
+                    # If we can't get an IP address from the string, try the next
                     continue
 
                 if addr is None or not addr.is_global:
+                    # We only want globally routable IP addresses (not local)
                     continue
 
                 ip_ok = True
                 break
 
             if not ip_ok:
-                raise ValueError(f"url_not_allowed: Host '{hostname}' does not resolve to an IP address.")
+                raise ValueError(f"url_not_allowed: Host '{hostname}' does not resolve to a valid IP address.")
             return
 
         if not addr.is_global:

--- a/neuro_san_studio/coded_tools/web_fetch.py
+++ b/neuro_san_studio/coded_tools/web_fetch.py
@@ -14,7 +14,10 @@
 #
 # END COPYRIGHT
 
-import asyncio
+from asyncio import AbstractEventLoop
+from asyncio import TimeoutError as AsyncTimeoutError
+from asyncio import get_running_loop
+
 from datetime import datetime
 from datetime import timezone
 from http import HTTPStatus
@@ -23,6 +26,8 @@ from ipaddress import IPv6Address
 from ipaddress import ip_address
 from logging import Logger
 from logging import getLogger
+from socket import gaierror
+from socket import SOCK_STREAM
 from typing import Any
 from urllib.parse import ParseResult
 from urllib.parse import urlparse
@@ -104,7 +109,7 @@ class WebFetch(CodedTool):
         :raises aiohttp.ClientResponseError: url_not_accessible / too_many_requests (non-2xx response).
         :raises aiohttp.ClientError: url_not_accessible when PDF or text fetch fails.
         """
-        url: str = self._validate_url(args)
+        url: str = await self._validate_url(args)
         max_chars: int = self._validate_max_content_chars(args)
 
         logger: Logger = getLogger(self.__class__.__name__)
@@ -141,7 +146,7 @@ class WebFetch(CodedTool):
             "retrieved_at": retrieved_at,
         }
 
-    def _validate_url(self, args: dict[str, Any]) -> str:
+    async def _validate_url(self, args: dict[str, Any]) -> str:
         """Validate URL format, length, and domain rules. Returns the cleaned URL."""
         url_value: Any = args.get("url", "")
         if not isinstance(url_value, str):
@@ -167,7 +172,7 @@ class WebFetch(CodedTool):
         # but not "badexample.com".
         hostname: str = raw_hostname.lower()
 
-        self._validate_hostname_safety(hostname)
+        await self._validate_hostname_safety(hostname)
 
         allowed_domains: list[str] = self._validate_domain_list(args.get("allowed_domains"), "allowed_domains")
         if allowed_domains and not any(
@@ -183,7 +188,7 @@ class WebFetch(CodedTool):
 
         return url
 
-    def _validate_hostname_safety(self, hostname: str) -> None:
+    async def _validate_hostname_safety(self, hostname: str) -> None:
         """Reject IP literals in private/loopback/link-local/multicast/reserved ranges and localhost.
 
         Note: non-IP hostnames are not DNS-resolved here; use allowed_domains for stricter control.
@@ -191,10 +196,41 @@ class WebFetch(CodedTool):
         if hostname == "localhost" or hostname.endswith(".localhost"):
             raise ValueError(f"url_not_allowed: Host '{hostname}' targets a loopback address.")
 
+        addr: IPv4Address | IPv6Address = None
         try:
-            addr: IPv4Address | IPv6Address = ip_address(hostname)
+            addr = ip_address(hostname)
         except ValueError:
-            # Not an IP literal; DNS-based checks are out of scope
+            # Not an IP literal;
+            # Try to resolve the hostname to an IP address
+            loop: AbstractEventLoop = get_running_loop()
+
+            # loop.getaddrinfo works like socket.getaddrinfo but is non-blocking
+            # SOCK_STREAM specifies TCP stream configuration
+            addr_infos: list[tuple[str, int, int, str, tuple[str, int]]] = []
+            try:
+                addr_infos = await loop.getaddrinfo(hostname, None, type=SOCK_STREAM)
+            except gaierror as exc:
+                raise ValueError(f"url_not_allowed: Host '{hostname}' could not be resolved.") from exc
+
+            if not addr_infos:
+                raise ValueError(f"url_not_allowed: Host '{hostname}' does not resolve to an IP address.")
+
+            ip_ok: bool = False
+            for info in addr_infos:
+                ip_string: str = info[4][0]
+                try:
+                    addr = ip_address(ip_string)
+                except ValueError:
+                    continue
+
+                if addr is None or not addr.is_global:
+                    continue
+
+                ip_ok = True
+                break
+
+            if not ip_ok:
+                raise ValueError(f"url_not_allowed: Host '{hostname}' does not resolve to an IP address.")
             return
 
         if not addr.is_global:
@@ -276,7 +312,7 @@ class WebFetch(CodedTool):
                 message=f"{prefix}: HTTP {exc.status} for '{url}'.",
                 headers=exc.headers,
             ) from exc
-        except (ClientError, asyncio.TimeoutError) as exc:
+        except (ClientError, AsyncTimeoutError) as exc:
             raise ClientError(f"url_not_accessible: Could not reach '{url}': {exc}") from exc
 
     def _check_content_length(self, content_length_header: str | None, url: str) -> None:
@@ -325,7 +361,7 @@ class WebFetch(CodedTool):
                 message=f"{prefix}: HTTP {exc.status} for '{url}'.",
                 headers=exc.headers,
             ) from exc
-        except (ClientError, asyncio.TimeoutError) as exc:
+        except (ClientError, AsyncTimeoutError) as exc:
             raise ClientError(f"url_not_accessible: Failed to fetch '{url}': {exc}") from exc
 
         return self._parse_raw_text(raw_content)

--- a/neuro_san_studio/coded_tools/web_fetch.py
+++ b/neuro_san_studio/coded_tools/web_fetch.py
@@ -17,7 +17,6 @@
 from asyncio import AbstractEventLoop
 from asyncio import TimeoutError as AsyncTimeoutError
 from asyncio import get_running_loop
-
 from datetime import datetime
 from datetime import timezone
 from http import HTTPStatus
@@ -26,8 +25,8 @@ from ipaddress import IPv6Address
 from ipaddress import ip_address
 from logging import Logger
 from logging import getLogger
-from socket import gaierror
 from socket import SOCK_STREAM
+from socket import gaierror
 from typing import Any
 from urllib.parse import ParseResult
 from urllib.parse import urlparse

--- a/tests/neuro_san_studio/coded_tools/web_fetch/helpers.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/helpers.py
@@ -14,10 +14,28 @@
 #
 # END COPYRIGHT
 
+from socket import AF_INET
+from socket import SOCK_STREAM
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from aiohttp import ClientResponseError
+
+
+def make_dns_patch(outcome: list[str] | Exception):
+    """Patch WebFetch DNS resolution so tests never do live lookups.
+
+    :param outcome: IP strings that getaddrinfo resolves to, or an exception it raises.
+    :return: A patcher usable as a context manager or via start()/stop().
+    """
+    mock_loop = MagicMock()
+    if isinstance(outcome, Exception):
+        mock_loop.getaddrinfo = AsyncMock(side_effect=outcome)
+    else:
+        addr_infos = [(AF_INET, SOCK_STREAM, 6, "", (ip, 0)) for ip in outcome]
+        mock_loop.getaddrinfo = AsyncMock(return_value=addr_infos)
+    return patch("neuro_san_studio.coded_tools.web_fetch.get_running_loop", return_value=mock_loop)
 
 
 def make_request_info(url: str = "http://example.com") -> MagicMock:

--- a/tests/neuro_san_studio/coded_tools/web_fetch/helpers.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/helpers.py
@@ -15,6 +15,7 @@
 # END COPYRIGHT
 
 from socket import AF_INET
+from socket import IPPROTO_TCP
 from socket import SOCK_STREAM
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -33,7 +34,7 @@ def make_dns_patch(outcome: list[str] | Exception):
     if isinstance(outcome, Exception):
         mock_loop.getaddrinfo = AsyncMock(side_effect=outcome)
     else:
-        addr_infos = [(AF_INET, SOCK_STREAM, 6, "", (ip, 0)) for ip in outcome]
+        addr_infos = [(AF_INET, SOCK_STREAM, IPPROTO_TCP, "", (ip, 0)) for ip in outcome]
         mock_loop.getaddrinfo = AsyncMock(return_value=addr_infos)
     return patch("neuro_san_studio.coded_tools.web_fetch.get_running_loop", return_value=mock_loop)
 

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_async_invoke.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_async_invoke.py
@@ -21,6 +21,8 @@ from unittest.mock import patch
 
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
 
+from .helpers import make_dns_patch
+
 
 class TestAsyncInvoke(TestCase):
     """Integration-level tests for WebFetch.async_invoke with mocked helpers."""
@@ -28,6 +30,10 @@ class TestAsyncInvoke(TestCase):
     def setUp(self):
         self.tool = WebFetch()
         self.sly_data: dict = {}
+        # Resolve every hostname to a public IP so tests never do live DNS lookups.
+        dns_patcher = make_dns_patch(["93.184.216.34"])
+        dns_patcher.start()
+        self.addCleanup(dns_patcher.stop)
 
     def test_html_fetch_returns_correct_keys(self):
         """Tests that fetching an HTML page returns a result with url, content, and retrieved_at keys."""

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_async_invoke.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_async_invoke.py
@@ -20,8 +20,7 @@ from unittest.mock import AsyncMock
 from unittest.mock import patch
 
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
-
-from .helpers import make_dns_patch
+from tests.neuro_san_studio.coded_tools.web_fetch.helpers import make_dns_patch
 
 
 class TestAsyncInvoke(TestCase):

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_fetch_text.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_fetch_text.py
@@ -23,9 +23,8 @@ from aiohttp import ClientError
 from aiohttp import ClientResponseError
 
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
-
-from .helpers import make_get_response
-from .helpers import make_response_error
+from tests.neuro_san_studio.coded_tools.web_fetch.helpers import make_get_response
+from tests.neuro_san_studio.coded_tools.web_fetch.helpers import make_response_error
 
 
 class TestFetchText(TestCase):

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_get_content_type.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_get_content_type.py
@@ -24,9 +24,8 @@ from aiohttp import ClientResponseError
 
 from neuro_san_studio.coded_tools.web_fetch import MAX_RESPONSE_BYTES
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
-
-from .helpers import make_head_session
-from .helpers import make_response_error
+from tests.neuro_san_studio.coded_tools.web_fetch.helpers import make_head_session
+from tests.neuro_san_studio.coded_tools.web_fetch.helpers import make_response_error
 
 
 class TestGetContentType(TestCase):

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_hostname_safety.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_hostname_safety.py
@@ -14,14 +14,15 @@
 #
 # END COPYRIGHT
 
-from unittest import TestCase
-
-import pytest
+from socket import gaierror
+from unittest import IsolatedAsyncioTestCase
 
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
 
+from .helpers import make_dns_patch
 
-class TestValidateHostnameSafety(TestCase):
+
+class TestValidateHostnameSafety(IsolatedAsyncioTestCase):
     """Unit tests for WebFetch._validate_hostname_safety."""
 
     def setUp(self):
@@ -31,77 +32,95 @@ class TestValidateHostnameSafety(TestCase):
         """Invoke _validate_hostname_safety with the given hostname."""
         await self.tool._validate_hostname_safety(hostname)  # pylint: disable=protected-access
 
-    @pytest.mark.asyncio
     async def test_public_hostname_allowed(self):
-        """Tests that a public hostname does not raise an error."""
-        self._call("example.com")  # should not raise
+        """Tests that a hostname resolving to a public IP does not raise an error."""
+        with make_dns_patch(["93.184.216.34"]):
+            await self._call("example.com")  # should not raise
 
-    @pytest.mark.asyncio
     async def test_public_ip_allowed(self):
         """Tests that a publicly routable IP address does not raise an error."""
-        self._call("8.8.8.8")  # should not raise
+        await self._call("8.8.8.8")  # should not raise
 
-    @pytest.mark.asyncio
     async def test_localhost_blocked(self):
         """Tests that 'localhost' is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
-            self._call("localhost")
+            await self._call("localhost")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_localhost_subdomain_blocked(self):
         """Tests that a subdomain of localhost is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
-            self._call("app.localhost")
+            await self._call("app.localhost")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_loopback_ipv4_blocked(self):
         """Tests that the IPv4 loopback address 127.0.0.1 is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
-            self._call("127.0.0.1")
+            await self._call("127.0.0.1")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_private_ipv4_blocked(self):
         """Tests that private IPv4 addresses are blocked with url_not_allowed."""
         for ip in ("10.0.0.1", "192.168.1.1", "172.16.0.1"):
             with self.subTest(ip=ip):
                 with self.assertRaises(ValueError) as ctx:
-                    self._call(ip)
+                    await self._call(ip)
                 self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_link_local_blocked(self):
         """Tests that a link-local IP address such as the AWS metadata endpoint is blocked."""
         with self.assertRaises(ValueError) as ctx:
-            self._call("169.254.169.254")  # AWS metadata endpoint
+            await self._call("169.254.169.254")  # AWS metadata endpoint
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_ipv6_loopback_blocked(self):
         """Tests that the IPv6 loopback address ::1 is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
-            self._call("::1")
+            await self._call("::1")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_unspecified_ipv4_blocked(self):
         """Tests that the unspecified IPv4 address 0.0.0.0 is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
-            self._call("0.0.0.0")
+            await self._call("0.0.0.0")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_unspecified_ipv6_blocked(self):
         """Tests that the unspecified IPv6 address :: is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
-            self._call("::")
+            await self._call("::")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_cgnat_blocked(self):
         """Tests that a CGNAT address (100.64.0.0/10) is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
-            self._call("100.64.0.1")
+            await self._call("100.64.0.1")
+        self.assertIn("url_not_allowed", str(ctx.exception))
+
+    async def test_hostname_resolving_to_private_ip_blocked(self):
+        """Tests that a hostname whose DNS record points at a private IP is blocked."""
+        with make_dns_patch(["10.0.0.5"]):
+            with self.assertRaises(ValueError) as ctx:
+                await self._call("internal.example.com")
+        self.assertIn("url_not_allowed", str(ctx.exception))
+
+    async def test_hostname_with_any_non_global_record_blocked(self):
+        """Tests that one non-global record among public ones blocks the host (all records must be global)."""
+        with make_dns_patch(["93.184.216.34", "169.254.169.254"]):
+            with self.assertRaises(ValueError) as ctx:
+                await self._call("mixed.example.com")
+        self.assertIn("url_not_allowed", str(ctx.exception))
+
+    async def test_unresolvable_hostname_blocked(self):
+        """Tests that a hostname that fails DNS resolution is blocked with url_not_allowed."""
+        with make_dns_patch(gaierror("NXDOMAIN")):
+            with self.assertRaises(ValueError) as ctx:
+                await self._call("nonexistent.example.com")
+        self.assertIn("url_not_allowed", str(ctx.exception))
+
+    async def test_hostname_with_no_records_blocked(self):
+        """Tests that a hostname resolving to zero addresses is blocked with url_not_allowed."""
+        with make_dns_patch([]):
+            with self.assertRaises(ValueError) as ctx:
+                await self._call("empty.example.com")
         self.assertIn("url_not_allowed", str(ctx.exception))

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_hostname_safety.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_hostname_safety.py
@@ -14,6 +14,7 @@
 #
 # END COPYRIGHT
 
+import pytest
 from unittest import TestCase
 
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
@@ -25,37 +26,43 @@ class TestValidateHostnameSafety(TestCase):
     def setUp(self):
         self.tool = WebFetch()
 
-    def _call(self, hostname: str):
+    async def _call(self, hostname: str):
         """Invoke _validate_hostname_safety with the given hostname."""
-        self.tool._validate_hostname_safety(hostname)  # pylint: disable=protected-access
+        await self.tool._validate_hostname_safety(hostname)  # pylint: disable=protected-access
 
-    def test_public_hostname_allowed(self):
+    @pytest.mark.asyncio
+    async def test_public_hostname_allowed(self):
         """Tests that a public hostname does not raise an error."""
         self._call("example.com")  # should not raise
 
-    def test_public_ip_allowed(self):
+    @pytest.mark.asyncio
+    async def test_public_ip_allowed(self):
         """Tests that a publicly routable IP address does not raise an error."""
         self._call("8.8.8.8")  # should not raise
 
-    def test_localhost_blocked(self):
+    @pytest.mark.asyncio
+    async def test_localhost_blocked(self):
         """Tests that 'localhost' is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
             self._call("localhost")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_localhost_subdomain_blocked(self):
+    @pytest.mark.asyncio
+    async def test_localhost_subdomain_blocked(self):
         """Tests that a subdomain of localhost is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
             self._call("app.localhost")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_loopback_ipv4_blocked(self):
+    @pytest.mark.asyncio
+    async def test_loopback_ipv4_blocked(self):
         """Tests that the IPv4 loopback address 127.0.0.1 is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
             self._call("127.0.0.1")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_private_ipv4_blocked(self):
+    @pytest.mark.asyncio
+    async def test_private_ipv4_blocked(self):
         """Tests that private IPv4 addresses are blocked with url_not_allowed."""
         for ip in ("10.0.0.1", "192.168.1.1", "172.16.0.1"):
             with self.subTest(ip=ip):
@@ -63,31 +70,36 @@ class TestValidateHostnameSafety(TestCase):
                     self._call(ip)
                 self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_link_local_blocked(self):
+    @pytest.mark.asyncio
+    async def test_link_local_blocked(self):
         """Tests that a link-local IP address such as the AWS metadata endpoint is blocked."""
         with self.assertRaises(ValueError) as ctx:
             self._call("169.254.169.254")  # AWS metadata endpoint
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_ipv6_loopback_blocked(self):
+    @pytest.mark.asyncio
+    async def test_ipv6_loopback_blocked(self):
         """Tests that the IPv6 loopback address ::1 is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
             self._call("::1")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_unspecified_ipv4_blocked(self):
+    @pytest.mark.asyncio
+    async def test_unspecified_ipv4_blocked(self):
         """Tests that the unspecified IPv4 address 0.0.0.0 is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
             self._call("0.0.0.0")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_unspecified_ipv6_blocked(self):
+    @pytest.mark.asyncio
+    async def test_unspecified_ipv6_blocked(self):
         """Tests that the unspecified IPv6 address :: is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
             self._call("::")
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_cgnat_blocked(self):
+    @pytest.mark.asyncio
+    async def test_cgnat_blocked(self):
         """Tests that a CGNAT address (100.64.0.0/10) is blocked with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
             self._call("100.64.0.1")

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_hostname_safety.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_hostname_safety.py
@@ -18,8 +18,7 @@ from socket import gaierror
 from unittest import IsolatedAsyncioTestCase
 
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
-
-from .helpers import make_dns_patch
+from tests.neuro_san_studio.coded_tools.web_fetch.helpers import make_dns_patch
 
 
 class TestValidateHostnameSafety(IsolatedAsyncioTestCase):

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_hostname_safety.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_hostname_safety.py
@@ -14,8 +14,9 @@
 #
 # END COPYRIGHT
 
-import pytest
 from unittest import TestCase
+
+import pytest
 
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
 

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_url.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_url.py
@@ -16,6 +16,8 @@
 
 from unittest import TestCase
 
+import pytest
+
 from neuro_san_studio.coded_tools.web_fetch import MAX_URL_LENGTH
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
 
@@ -26,111 +28,130 @@ class TestValidateUrl(TestCase):
     def setUp(self):
         self.tool = WebFetch()
 
-    def _call(self, args):
+    async def _call(self, args):
         """Invoke _validate_url with the given args dict and return the result."""
         return self.tool._validate_url(args)  # pylint: disable=protected-access
 
-    def test_valid_http_url(self):
+    @pytest.mark.asyncio
+    async def test_valid_http_url(self):
         """Tests that a valid HTTP URL is accepted."""
         self.assertEqual(self._call({"url": "http://example.com/page"}), "http://example.com/page")
 
-    def test_valid_https_url(self):
+    @pytest.mark.asyncio
+    async def test_valid_https_url(self):
         """Tests that a valid HTTPS URL is accepted."""
         self.assertEqual(self._call({"url": "https://example.com"}), "https://example.com")
 
-    def test_strips_whitespace(self):
+    @pytest.mark.asyncio
+    async def test_strips_whitespace(self):
         """Tests that leading and trailing whitespace is stripped from the URL."""
         self.assertEqual(self._call({"url": "  https://example.com  "}), "https://example.com")
 
-    def test_missing_url_key(self):
+    @pytest.mark.asyncio
+    async def test_missing_url_key(self):
         """Tests that a missing 'url' key raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
             self._call({})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    def test_empty_url(self):
+    @pytest.mark.asyncio
+    async def test_empty_url(self):
         """Tests that an empty URL string raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": ""})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    def test_non_string_url(self):
+    @pytest.mark.asyncio
+    async def test_non_string_url(self):
         """Tests that a non-string URL value raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": 42})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    def test_none_url(self):
+    @pytest.mark.asyncio
+    async def test_none_url(self):
         """Tests that a None URL value raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": None})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    def test_ftp_scheme_rejected(self):
+    @pytest.mark.asyncio
+    async def test_ftp_scheme_rejected(self):
         """Tests that an FTP scheme URL is rejected with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": "ftp://example.com"})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    def test_url_too_long(self):
+    @pytest.mark.asyncio
+    async def test_url_too_long(self):
         """Tests that a URL exceeding the maximum length raises ValueError with url_too_long."""
         long_url = "https://example.com/" + "a" * MAX_URL_LENGTH
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": long_url})
         self.assertIn("url_too_long", str(ctx.exception))
 
-    def test_url_at_max_length_is_accepted(self):
+    @pytest.mark.asyncio
+    async def test_url_at_max_length_is_accepted(self):
         """Tests that a URL exactly at the maximum allowed length is accepted."""
         prefix = "https://test.co/"
         url = prefix + "a" * (MAX_URL_LENGTH - len(prefix))
         self.assertEqual(self._call({"url": url}), url)
 
-    def test_missing_hostname(self):
+    @pytest.mark.asyncio
+    async def test_missing_hostname(self):
         """Tests that a URL with no hostname raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": "https:///no-host"})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    def test_allowed_domains_pass(self):
+    @pytest.mark.asyncio
+    async def test_allowed_domains_pass(self):
         """Tests that a URL matching an allowed domain passes validation."""
         url = self._call({"url": "https://api.example.com/data", "allowed_domains": ["example.com"]})
         self.assertEqual(url, "https://api.example.com/data")
 
-    def test_allowed_domains_exact_match(self):
+    @pytest.mark.asyncio
+    async def test_allowed_domains_exact_match(self):
         """Tests that a URL exactly matching an allowed domain passes validation."""
         url = self._call({"url": "https://example.com/", "allowed_domains": ["example.com"]})
         self.assertEqual(url, "https://example.com/")
 
-    def test_allowed_domains_rejects_unrelated(self):
+    @pytest.mark.asyncio
+    async def test_allowed_domains_rejects_unrelated(self):
         """Tests that a URL not matching any allowed domain raises ValueError with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": "https://test-other.com/", "allowed_domains": ["test-example.com"]})
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_allowed_domains_does_not_match_partial_prefix(self):
+    @pytest.mark.asyncio
+    async def test_allowed_domains_does_not_match_partial_prefix(self):
         """Tests that a hostname sharing a suffix but not a domain boundary is rejected."""
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": "https://test-badexample.com/", "allowed_domains": ["test-example.com"]})
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_blocked_domains_rejects(self):
+    @pytest.mark.asyncio
+    async def test_blocked_domains_rejects(self):
         """Tests that a URL exactly matching a blocked domain raises ValueError with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": "https://test-blocked.com/", "blocked_domains": ["test-blocked.com"]})
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_blocked_domains_subdomain_rejected(self):
+    @pytest.mark.asyncio
+    async def test_blocked_domains_subdomain_rejected(self):
         """Tests that a subdomain of a blocked domain is also rejected."""
         with self.assertRaises(ValueError) as ctx:
             self._call({"url": "https://test-sub.blocked.com/", "blocked_domains": ["blocked.com"]})
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    def test_blocked_domains_partial_prefix_not_blocked(self):
+    @pytest.mark.asyncio
+    async def test_blocked_domains_partial_prefix_not_blocked(self):
         """Tests that a domain sharing a suffix with a blocked domain but not a boundary is allowed."""
         url = self._call({"url": "https://test-notblocked.com/", "blocked_domains": ["test-blocked.com"]})
         self.assertEqual(url, "https://test-notblocked.com/")
 
-    def test_url_with_port_matches_domain(self):
+    @pytest.mark.asyncio
+    async def test_url_with_port_matches_domain(self):
         """Tests that a URL with a port number still matches the allowed domain correctly."""
         url = self._call({"url": "https://example.com:8080/path", "allowed_domains": ["example.com"]})
         self.assertEqual(url, "https://example.com:8080/path")

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_url.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_url.py
@@ -14,144 +14,143 @@
 #
 # END COPYRIGHT
 
-from unittest import TestCase
-
-import pytest
+from unittest import IsolatedAsyncioTestCase
 
 from neuro_san_studio.coded_tools.web_fetch import MAX_URL_LENGTH
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
 
+from .helpers import make_dns_patch
 
-class TestValidateUrl(TestCase):
+
+class TestValidateUrl(IsolatedAsyncioTestCase):  # pylint: disable=too-many-public-methods
     """Unit tests for WebFetch._validate_url."""
 
     def setUp(self):
         self.tool = WebFetch()
+        # Resolve every hostname to a public IP so tests never do live DNS lookups.
+        dns_patcher = make_dns_patch(["93.184.216.34"])
+        dns_patcher.start()
+        self.addCleanup(dns_patcher.stop)
 
     async def _call(self, args):
         """Invoke _validate_url with the given args dict and return the result."""
-        return self.tool._validate_url(args)  # pylint: disable=protected-access
+        return await self.tool._validate_url(args)  # pylint: disable=protected-access
 
-    @pytest.mark.asyncio
     async def test_valid_http_url(self):
         """Tests that a valid HTTP URL is accepted."""
-        self.assertEqual(self._call({"url": "http://example.com/page"}), "http://example.com/page")
+        self.assertEqual(await self._call({"url": "http://example.com/page"}), "http://example.com/page")
 
-    @pytest.mark.asyncio
     async def test_valid_https_url(self):
         """Tests that a valid HTTPS URL is accepted."""
-        self.assertEqual(self._call({"url": "https://example.com"}), "https://example.com")
+        self.assertEqual(await self._call({"url": "https://example.com"}), "https://example.com")
 
-    @pytest.mark.asyncio
     async def test_strips_whitespace(self):
         """Tests that leading and trailing whitespace is stripped from the URL."""
-        self.assertEqual(self._call({"url": "  https://example.com  "}), "https://example.com")
+        self.assertEqual(await self._call({"url": "  https://example.com  "}), "https://example.com")
 
-    @pytest.mark.asyncio
     async def test_missing_url_key(self):
         """Tests that a missing 'url' key raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({})
+            await self._call({})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_empty_url(self):
         """Tests that an empty URL string raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": ""})
+            await self._call({"url": ""})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_non_string_url(self):
         """Tests that a non-string URL value raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": 42})
+            await self._call({"url": 42})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_none_url(self):
         """Tests that a None URL value raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": None})
+            await self._call({"url": None})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_ftp_scheme_rejected(self):
         """Tests that an FTP scheme URL is rejected with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": "ftp://example.com"})
+            await self._call({"url": "ftp://example.com"})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_url_too_long(self):
         """Tests that a URL exceeding the maximum length raises ValueError with url_too_long."""
         long_url = "https://example.com/" + "a" * MAX_URL_LENGTH
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": long_url})
+            await self._call({"url": long_url})
         self.assertIn("url_too_long", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_url_at_max_length_is_accepted(self):
         """Tests that a URL exactly at the maximum allowed length is accepted."""
         prefix = "https://test.co/"
         url = prefix + "a" * (MAX_URL_LENGTH - len(prefix))
-        self.assertEqual(self._call({"url": url}), url)
+        self.assertEqual(await self._call({"url": url}), url)
 
-    @pytest.mark.asyncio
     async def test_missing_hostname(self):
         """Tests that a URL with no hostname raises ValueError with invalid_input."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": "https:///no-host"})
+            await self._call({"url": "https:///no-host"})
         self.assertIn("invalid_input", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_allowed_domains_pass(self):
         """Tests that a URL matching an allowed domain passes validation."""
-        url = self._call({"url": "https://api.example.com/data", "allowed_domains": ["example.com"]})
+        url = await self._call({"url": "https://api.example.com/data", "allowed_domains": ["example.com"]})
         self.assertEqual(url, "https://api.example.com/data")
 
-    @pytest.mark.asyncio
     async def test_allowed_domains_exact_match(self):
         """Tests that a URL exactly matching an allowed domain passes validation."""
-        url = self._call({"url": "https://example.com/", "allowed_domains": ["example.com"]})
+        url = await self._call({"url": "https://example.com/", "allowed_domains": ["example.com"]})
         self.assertEqual(url, "https://example.com/")
 
-    @pytest.mark.asyncio
     async def test_allowed_domains_rejects_unrelated(self):
         """Tests that a URL not matching any allowed domain raises ValueError with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": "https://test-other.com/", "allowed_domains": ["test-example.com"]})
+            await self._call({"url": "https://test-other.com/", "allowed_domains": ["test-example.com"]})
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_allowed_domains_does_not_match_partial_prefix(self):
         """Tests that a hostname sharing a suffix but not a domain boundary is rejected."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": "https://test-badexample.com/", "allowed_domains": ["test-example.com"]})
+            await self._call({"url": "https://test-badexample.com/", "allowed_domains": ["test-example.com"]})
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_blocked_domains_rejects(self):
         """Tests that a URL exactly matching a blocked domain raises ValueError with url_not_allowed."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": "https://test-blocked.com/", "blocked_domains": ["test-blocked.com"]})
+            await self._call({"url": "https://test-blocked.com/", "blocked_domains": ["test-blocked.com"]})
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_blocked_domains_subdomain_rejected(self):
         """Tests that a subdomain of a blocked domain is also rejected."""
         with self.assertRaises(ValueError) as ctx:
-            self._call({"url": "https://test-sub.blocked.com/", "blocked_domains": ["blocked.com"]})
+            await self._call({"url": "https://test-sub.blocked.com/", "blocked_domains": ["blocked.com"]})
         self.assertIn("url_not_allowed", str(ctx.exception))
 
-    @pytest.mark.asyncio
     async def test_blocked_domains_partial_prefix_not_blocked(self):
         """Tests that a domain sharing a suffix with a blocked domain but not a boundary is allowed."""
-        url = self._call({"url": "https://test-notblocked.com/", "blocked_domains": ["test-blocked.com"]})
+        url = await self._call({"url": "https://test-notblocked.com/", "blocked_domains": ["test-blocked.com"]})
         self.assertEqual(url, "https://test-notblocked.com/")
 
-    @pytest.mark.asyncio
     async def test_url_with_port_matches_domain(self):
         """Tests that a URL with a port number still matches the allowed domain correctly."""
-        url = self._call({"url": "https://example.com:8080/path", "allowed_domains": ["example.com"]})
+        url = await self._call({"url": "https://example.com:8080/path", "allowed_domains": ["example.com"]})
         self.assertEqual(url, "https://example.com:8080/path")
+
+    async def test_hostname_resolving_to_private_ip_rejected(self):
+        """Tests that a URL whose hostname resolves to a private IP is rejected with url_not_allowed."""
+        with make_dns_patch(["192.168.1.10"]):
+            with self.assertRaises(ValueError) as ctx:
+                await self._call({"url": "https://internal.example.com/"})
+        self.assertIn("url_not_allowed", str(ctx.exception))
+
+    async def test_blocked_domain_rejected_before_dns(self):
+        """Tests that blocked domains are enforced on the hostname, not on a resolved IP."""
+        # Regression test: hostname must not be replaced by its resolved IP before domain checks.
+        with self.assertRaises(ValueError) as ctx:
+            await self._call({"url": "https://test-blocked.com/x", "blocked_domains": ["test-blocked.com"]})
+        self.assertIn("Domain 'test-blocked.com' is blocked", str(ctx.exception))

--- a/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_url.py
+++ b/tests/neuro_san_studio/coded_tools/web_fetch/test_validate_url.py
@@ -18,8 +18,7 @@ from unittest import IsolatedAsyncioTestCase
 
 from neuro_san_studio.coded_tools.web_fetch import MAX_URL_LENGTH
 from neuro_san_studio.coded_tools.web_fetch import WebFetch
-
-from .helpers import make_dns_patch
+from tests.neuro_san_studio.coded_tools.web_fetch.helpers import make_dns_patch
 
 
 class TestValidateUrl(IsolatedAsyncioTestCase):  # pylint: disable=too-many-public-methods

--- a/tests/neuro_san_studio/discovery/test_coded_tool_resolution.py
+++ b/tests/neuro_san_studio/discovery/test_coded_tool_resolution.py
@@ -16,8 +16,6 @@
 
 """Tests for DependencyAnalyzer.resolve_coded_tool_path short-form hierarchy resolution."""
 
-# pylint: disable=protected-access
-
 from pathlib import Path
 
 from neuro_san_studio.discovery.dependency_analyzer import DependencyAnalyzer


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

- Require every DNS record of a hostname to be globally routable, run domain allow/block checks before resolution, and keep the original hostname instead of substituting the resolved IP. 
- Migrate tests to `IsolatedAsyncioTestCase` with mocked DNS so they actually await the async validators and never do live lookups.

Fixes https://github.com/cognizant-ai-lab/neuro-san-studio/security/advisories/GHSA-jp4f-fg56-rqp7

## Known limitation (follow-up)

- DNS rebinding is not yet mitigated: the HTTP client re-resolves the hostname at connection time, so an attacker-controlled DNS server can return a safe address during validation and an internal one for the actual fetch. Closing that gap requires pinning the validated addresses into the connection (e.g. a custom resolver on the aiohttp `TCPConnector`) — will be addressed in a follow-up PR. See the `WebFetch` and `_validate_hostname_safety` docstrings for details. Use `allowed_domains` for stricter control in the meantime.

- See #1234 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
