### PR TITLE
Remove mechanical langchain-community references

### DIFF
--- a/coded_tools/tools/agentic_rag/rag.py
+++ b/coded_tools/tools/agentic_rag/rag.py
@@ -21,8 +21,8 @@ from typing import Dict
 from typing import List
 
 from langchain_community.document_loaders import PyPDFLoader
-from langchain_community.vectorstores import InMemoryVectorStore
 from langchain_core.documents import Document
+from langchain_core.vectorstores import InMemoryVectorStore
 from langchain_core.vectorstores.base import VectorStoreRetriever
 from langchain_openai import OpenAIEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -714,11 +714,9 @@ don’t need to redefine it in the agent network — just reference it by name.
 
 ```json
 "tavily_search": {
-  "class": "langchain_community.tools.tavily_search.TavilySearchResults",
+  "class": "langchain_tavily.TavilySearch",
   "args": {
-    "api_wrapper": {
-      "class": "langchain_community.utilities.tavily_search.TavilySearchAPIWrapper"
-    }
+    "max_results": 5
   }
 }
 ```

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1217,25 +1217,21 @@ To use tools from toolbox in your agent network, simply call them with field `to
    - langchain tools
        - Each tool or toolkit must have a `class` key.
        - The specified class must be available in the server's `PYTHONPATH`.
-       - Additional dependencies (outside of `langchain_community`) must be installed separately.
+       - Integration-specific dependencies must be installed separately.
 
         Example:
 
         ```hocon
             "tavily_search": {
                 # Fully qualified class path of the tool to be instantiated.
-                "class": "langchain_community.tools.tavily_search.TavilySearchResults",
+                "class": "langchain_tavily.TavilySearch",
 
                 # (Optional) URL for reference documentation about this tool.
                 "base_tool_info_url": "https://python.langchain.com/docs/integrations/tools/tavily_search/",
 
                 # Arguments for the tool's constructor.
                 "args": {
-                    "api_wrapper": {
-                        # If the argument should be instantiated as a class, specify it using the "class" key.
-                        # This tells the system to create an instance of the provided class instead of passing it as-is.
-                        "class": "langchain_community.utilities.tavily_search.TavilySearchAPIWrapper"
-                    },
+                    "max_results": 5,
                 }
             }
         ```

--- a/neuro_san_studio/coded_tools/base_rag.py
+++ b/neuro_san_studio/coded_tools/base_rag.py
@@ -25,9 +25,9 @@ from typing import Any
 from typing import Literal
 from typing import Optional
 
-from langchain_community.vectorstores import InMemoryVectorStore
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
+from langchain_core.vectorstores import InMemoryVectorStore
 from langchain_core.vectorstores import VectorStore
 from langchain_core.vectorstores.base import VectorStoreRetriever
 from langchain_openai import OpenAIEmbeddings


### PR DESCRIPTION
## Description

Remove the remaining low-risk, mechanical `langchain-community` references covered by #1298.

Fixes #1298

## What changed

- Move `InMemoryVectorStore` imports from `langchain_community.vectorstores` to `langchain_core.vectorstores` in:
  - `neuro_san_studio/coded_tools/base_rag.py`
  - `coded_tools/tools/agentic_rag/rag.py`
- Update the Tavily examples in `docs/tutorial.md` and `docs/user_guide.md` to use `langchain_tavily.TavilySearch`.
- Pass `max_results` directly to the Tavily tool constructor.

## Scope

This PR contains only the mechanical changes tracked by #1298. The remaining integrations are tracked separately under #1299–#1305.