### PR TITLE
fix: HOCON manifest includes, designer required params, and persistor path splitting

### DIFF
--- a/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
+++ b/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
@@ -47,9 +47,11 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
         self.demo_mode: bool = demo_mode
         self.subdirectory: str = subdirectory.strip("/")
 
-        # Derive output_path from the first file listed in AGENT_MANIFEST_FILE
+        # Derive output_path from the first file listed in AGENT_MANIFEST_FILE.
+        # AGENT_MANIFEST_FILE is colon-separated (like PATH), so split on ":"
+        # rather than whitespace to correctly isolate the first manifest path.
         agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
-        parts: list[str] = agent_manifest_file.split()
+        parts: list[str] = [p.strip() for p in agent_manifest_file.split(":") if p.strip()]
         if parts:
             self.output_path: str = os.path.dirname(parts[0])
             self.main_manifest_path: str = parts[0]

--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -25,13 +25,12 @@
         ]
     },
 
-    include "registries/expertise_scoping_instructions.hocon",
-
     # Load the shared LLM configuration from a single source of truth.
     # This allows users to change the model in one file rather than
     # modifying the configuration for each agent network.
     # Note that the file path here is relative to the root level of the repo.
     include "config/llm_config.hocon",
+    include "config/opus_llm_config.hocon",
     "max_steps": 40000,
     "max_execution_seconds": 6000,
     "error_formatter": "json",
@@ -208,8 +207,9 @@ After this time the network can no longer be counted upon to exist.
                     "required": ["agent_network_definition", "agent_network_hocon_text", "agent_network_name"]
                 }
             },
-            "instructions": ${expertise_scoping_instructions} """
+            "instructions": """
 You are responsible for designing and modifying agent networks based on user requirements.
+Only answer inquiries that are directly within your area of expertise. Do not try to help for other matters. Do not mention what you can NOT do. Only mention what you can do.
 
 Take the following steps. Make sure you don't miss any details and follow the steps carefully.
 
@@ -217,27 +217,38 @@ LOOPABLE WORKFLOW (steps 1–3 can repeat any number of times):
 You may repeat steps 1–3 (create/modify structure, refine instructions, regenerate queries) until the network is ready for finalization.
 
 1) Create or modify the network structure
-- If the user provides a company name or domain description for a new network, generate an agent network definition that mirrors relevant workflows and responsible nodes. Call your `agent_network_editor` tool. Ensure the agent network name is snake case.
-- If the user asks to modify an existing network's structure (add/remove agents, or change up-chains/down-chains), call `agent_network_editor` with the modification instructions.
-- You may call `web_search` to find more details on the company or domain.
+- Determine the mode: use "create" if building a new network, "modify" if changing an existing one.
+- If the user provides a company name or domain description for a new network, call your `agent_network_editor` tool with:
+  - `agent_network_description`: the user's full description of the company, workflow, or use case (copy it verbatim or summarize it faithfully)
+  - `mode`: "create"
+  - Ensure the agent network name will be in snake_case.
+- If the user asks to modify an existing network's structure (add/remove agents, or change up-chains/down-chains), call `agent_network_editor` with:
+  - `agent_network_description`: a clear description of the specific structural change requested
+  - `mode`: "modify"
+- You may call `web_search` to find more details on the company or domain before calling `agent_network_editor`.
 - If the user only asks to modify agent instructions (no structural changes), skip structural edits and go to step 2.
 - Wait for and inspect the response from `agent_network_editor` before proceeding.
 
 2) Create or refine agent instructions
-- Always call `agent_network_instructions_editor` to generate instructions after step 1 if the network structure is created.
-- After structural modification, you may call `agent_network_instructions_editor` to update agents' instructions.
-- You may call `agent_network_instructions_editor` multiple times as you iterate on the network; call it whenever agents are added or when their responsibilities change.
-- You may call `web_search` to find more details on the company or domain.
+- Always call `agent_network_instructions_editor` after step 1 when the network structure is newly created.
+- Call `agent_network_instructions_editor` with:
+  - `agent_network_description`: the user's full description of the company, workflow, or use case (same value used in step 1)
+  - `mode`: "create" when instructions are being written for the first time; "modify" when updating specific agents
+- After structural modification, call `agent_network_instructions_editor` with `mode`: "modify" to update impacted agents.
+- You may call `web_search` to find more details on the company or domain before calling `agent_network_instructions_editor`.
 - Wait for and inspect the response from `agent_network_instructions_editor` before proceeding.
 
 3) Generate sample queries
 - Obtain 3–4 sample queries for the current agent network by calling `agent_network_query_generator`.
+- Call `agent_network_query_generator` with:
+  - `agent_network_description`: the user's full description of the company, workflow, or use case
 - If the sample queries do not match the network or you decide further changes are needed, return to steps 1 or 2, then regenerate queries.
 - You may call `agent_network_query_generator` repeatedly until the queries accurately reflect the network behavior.
 
 Operational notes:
 - Always wait for each tool's response before taking the next action.
 - Iteratively refine the structure, instructions, and queries.
+- IMPORTANT: Every call to `agent_network_editor` and `agent_network_instructions_editor` MUST include both `agent_network_description` and `mode`. Every call to `agent_network_query_generator` MUST include `agent_network_description`. Never call these tools without their required parameters.
 """,
             "allow": {
                 "to_upstream": {
@@ -315,7 +326,10 @@ Operational notes:
 
         {
             "name": "web_search",
-            "toolbox": "ddgs_search"
+            "toolbox": "ddgs_search",
+            "args": {
+                "max_results": 3
+            }
         },
 
     ]

--- a/registries/agent_network_instructions_editor.hocon
+++ b/registries/agent_network_instructions_editor.hocon
@@ -14,13 +14,12 @@
 #
 # END COPYRIGHT
 {
-    include "registries/expertise_scoping_instructions.hocon",
-
     # Load the shared LLM configuration from a single source of truth.
     # This allows users to change the model in one file rather than
     # modifying the configuration for each agent network.
     # Note that the file path here is relative to the root level of the repo.
     include "config/llm_config.hocon",
+    include "config/opus_llm_config.hocon",
     "max_steps": 40000,
     "max_execution_seconds": 6000,
     "error_formatter": "json",
@@ -58,24 +57,42 @@
                     "required": ["agent_network_description", "mode"]
                 }
             },
-            "instructions": ${expertise_scoping_instructions} """
+            "instructions": """
 You are responsible for coordinating the writing of `instructions` and `description` for agents based on the agent network description and definition.
+Only answer inquiries that are directly within your area of expertise. Do not try to help for other matters. Do not mention what you can NOT do. Only mention what you can do.
 
 **Only coordinate writing of `instructions` and `description` for agents that have these fields in the network definition. These are non-function agents.**
 
+**How to call `write_all_instructions`**
+
+`write_all_instructions` requires the `agents` parameter — an array of objects, one per target agent.
+Each object must have `agent_name` (required) and optionally `change_request`.
+
+Example call structure:
+  agents: [
+    {"agent_name": "front_man_agent"},
+    {"agent_name": "another_agent"},
+    {"agent_name": "yet_another_agent"}
+  ]
+
+IMPORTANT: You MUST always pass `agents` when calling `write_all_instructions`. Omitting it is an error.
+
+To identify which agents to include: look at the agent network definition. Any agent that has an
+`instructions` field (or should have one) is a non-function agent and must be included.
+Function agents have no `instructions` — omit those from the list.
+
 Behavior by mode:
-- `create`: Call `write_all_instructions` ONCE with `agents` covering EVERY non-function agent in the network.
-            Pass `agent_network_description` once for shared network-wide context.
-            For each entry, set `change_request` ONLY when the user explicitly stated a directive
-            targeting that specific agent (e.g. 'agent A should handle refunds'). Omit it otherwise.
-            Per-agent directives belong in `change_request`, not in `agent_network_description`.
-- `modify`: Read `agent_network_description` and identify the impacted agents (explicitly named agents, newly added agents, and agents whose responsibilities changed).
-            Call `write_all_instructions` ONCE with `agents` = a list of objects, one per impacted agent.
-            For each entry, set `change_request` ONLY when the user stated a specific change targeting that agent (e.g. 'change agent A to do X'). Omit it otherwise.
-            Pass `agent_network_description` only when there is genuine network-wide context to share; when passed, it applies uniformly to every agent in the call.
-            Do not involve unaffected agents except when they lack `instructions`/`description` or the user explicitly requests broader edits.
+- `create`: Call `write_all_instructions` ONCE with:
+  - `agents`: a list of ALL non-function agents in the network (every agent that has or needs `instructions`)
+  - `agent_network_description`: the full description for shared network-wide context
+  - For each entry, set `change_request` ONLY when the user explicitly stated a directive targeting that specific agent. Omit it otherwise.
+- `modify`: Call `write_all_instructions` ONCE with:
+  - `agents`: a list of ONLY the impacted agents (explicitly named, newly added, or changed agents)
+  - `agent_network_description`: only when there is genuine network-wide context to share
+  - For each entry, set `change_request` ONLY when the user stated a specific change targeting that agent. Omit it otherwise.
 
 Guardrails:
+- ALWAYS include the `agents` parameter when calling `write_all_instructions` — it is required.
 - Only coordinate writing of `instructions` and `description` for agents that have these fields in the network definition.
 - Ensure that each and every non-function agent has both `instructions` and `description` set.
 - Skip agents that are not referenced/affected by the current request.

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -21,19 +21,19 @@
     # For all the grouped registries such as basic, tools, industry, we include the respective manifest file.
 
     # Basic examples
-    include "registries/basic/manifest.hocon",
+    include "basic/manifest.hocon",
 
     # Tool integration examples
-    include "registries/tools/manifest.hocon",
-    
+    include "tools/manifest.hocon",
+
     # Industry use cases
-    include "registries/industry/manifest.hocon",
+    include "industry/manifest.hocon",
 
     # Experimental and research
-    include "registries/experimental/manifest.hocon",
+    include "experimental/manifest.hocon",
 
     # Generated agent networks
-    include "registries/generated/manifest.hocon",
+    include "generated/manifest.hocon",
 
     # Currently we list each hocon file we want to serve as a key with a boolean value.
     # Eventually we might have a dictionary value with server specifications for each.


### PR DESCRIPTION
## Summary

- **`registries/manifest.hocon`**: Fix `include` paths from CWD-relative (`registries/experimental/…`) to file-relative (`experimental/…`). Sub-manifest includes were silently failing when the server was started from a directory other than the package root (e.g. a user project directory). Depends on the companion fix in `neuro-san` ([cognizant-ai-lab/neuro-san#PR](https://github.com/cognizant-ai-lab/neuro-san)) and `leaf-common` ([cognizant-ai-lab/leaf-common#PR](https://github.com/cognizant-ai-lab/leaf-common)).

- **`middleware/…/file_system_agent_network_persistor.py`**: Split `AGENT_MANIFEST_FILE` on `":"` instead of whitespace. The env var is a colon-separated list (like `PATH`); splitting on whitespace treated the entire value as one token, producing a path with a literal `:` in the directory name on macOS and silently saving generated networks to the wrong location.

- **`registries/agent_network_designer.hocon`**: Rewrite step instructions to explicitly name the required parameters (`agent_network_description`, `mode`) for every sub-agent call. The model was generating tool calls with empty `input: {}`, triggering `ValidationError` retries that were never fed back to the model (so retries were useless). Explicit parameter guidance prevents the omission. Also adds `max_results: 3` to `web_search` and includes `config/opus_llm_config.hocon`.

- **`registries/agent_network_instructions_editor.hocon`**: Add explicit `write_all_instructions` call example showing the required `agents` array. Same root cause as the designer fix — model was omitting the required parameter.

## Test plan

- [ ] Start server from a user project directory (not the package root); verify `experimental/` and other sub-manifests load without "Cannot include file" errors
- [ ] Run `agent_network_designer` and ask it to create a network; verify no `ValidationError: agent_network_description field required` / `mode field required` errors
- [ ] Run `agent_network_instructions_editor`; verify no `ValidationError: agents field required` errors
- [ ] Generate a network via designer; verify it saves to `registries/generated/` in the correct directory (not a path containing a literal `:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)