### PR TITLE
Throttle the AND ProgressHandler

### DIFF
--- a/coded_tools/agent_network_editor/add_agent.py
+++ b/coded_tools/agent_network_editor/add_agent.py
@@ -93,7 +93,7 @@ class AddAgent(CodedTool):
         logger.info("The resulting agent network definition: \n %s", str(network_def))
         sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
-        await ProgressHandler.report_progress(args, network_def)
+        await ProgressHandler.report_progress(args, sly_data, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
         return f"Successfully added agent {the_agent_name} to the agent network definition."

--- a/coded_tools/agent_network_editor/create_network.py
+++ b/coded_tools/agent_network_editor/create_network.py
@@ -122,8 +122,9 @@ class CreateNetwork(CodedTool):
         # Put the agent network name in the sly data
         sly_data[AGENT_NETWORK_NAME] = agent_network_name
 
-        await ProgressHandler.report_progress(args, sly_data,
-                                              sly_data[AGENT_NETWORK_DEFINITION], sly_data[AGENT_NETWORK_NAME])
+        await ProgressHandler.report_progress(
+            args, sly_data, sly_data[AGENT_NETWORK_DEFINITION], sly_data[AGENT_NETWORK_NAME]
+        )
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
         return f"Successfully created agent network definition for {agent_network_name}."

--- a/coded_tools/agent_network_editor/create_network.py
+++ b/coded_tools/agent_network_editor/create_network.py
@@ -122,7 +122,8 @@ class CreateNetwork(CodedTool):
         # Put the agent network name in the sly data
         sly_data[AGENT_NETWORK_NAME] = agent_network_name
 
-        await ProgressHandler.report_progress(args, sly_data[AGENT_NETWORK_DEFINITION], sly_data[AGENT_NETWORK_NAME])
+        await ProgressHandler.report_progress(args, sly_data,
+                                              sly_data[AGENT_NETWORK_DEFINITION], sly_data[AGENT_NETWORK_NAME])
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
         return f"Successfully created agent network definition for {agent_network_name}."

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -54,8 +54,9 @@ class ProgressHandler:
         return True
 
     @staticmethod
-    async def report_progress(args: dict[str, Any], sly_data: Dict[str, Any],
-                              network_definition: dict[str, Any], name: str = None):
+    async def report_progress(
+        args: dict[str, Any], sly_data: Dict[str, Any], network_definition: dict[str, Any], name: str = None
+    ):
         """
         Common handler for progress during the building of agent networks
 

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -15,13 +15,16 @@
 # END COPYRIGHT
 
 from os import environ
+from time import perf_counter
 from typing import Any
+from typing import Dict
 
 from neuro_san.interfaces.agent_progress_reporter import AgentProgressReporter
 
 from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
+from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 
 # pylint: disable=too-few-public-methods
@@ -30,8 +33,29 @@ class ProgressHandler:
     Common handler for progress during the building of agent networks
     """
 
+    PROGRESS_THROTTLE_SECONDS: float = 2.0
+
+    def __init__(self):
+        """
+        Constructor
+        """
+        self.last_progress: float = 0.0
+
+    def should_report(self) -> bool:
+        """
+        Should the progress be reported?
+        """
+        now: float = perf_counter()
+        report_me: bool = now - self.last_progress > self.PROGRESS_THROTTLE_SECONDS
+        if not report_me:
+            return False
+
+        self.last_progress = now
+        return True
+
     @staticmethod
-    async def report_progress(args: dict[str, Any], network_definition: dict[str, Any], name: str = None):
+    async def report_progress(args: dict[str, Any], sly_data: Dict[str, Any],
+                              network_definition: dict[str, Any], name: str = None):
         """
         Common handler for progress during the building of agent networks
 
@@ -39,6 +63,17 @@ class ProgressHandler:
         :param network_definition: The network definition dictionary
         :param name: The name of the agent network. If None, will not be reported in progress.
         """
+        progress_handler: ProgressHandler = None
+        if sly_data is not None:
+            async with await SlyDataLock.get_lock(sly_data, "progress_handler_lock"):
+                progress_handler = sly_data.get("progress_handler")
+                if progress_handler is None:
+                    progress_handler = ProgressHandler()
+                    sly_data["progress_handler"] = progress_handler
+
+                if not progress_handler.should_report():
+                    return
+
         progress_reporter: AgentProgressReporter = args.get("progress_reporter")
 
         use_key: str = AGENT_NETWORK_DEFINITION

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -27,7 +27,6 @@ from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 
-# pylint: disable=too-few-public-methods
 class ProgressHandler:
     """
     Common handler for progress during the building of agent networks

--- a/coded_tools/agent_network_editor/remove_agent.py
+++ b/coded_tools/agent_network_editor/remove_agent.py
@@ -81,7 +81,7 @@ class RemoveAgent(CodedTool):
         logger.info("The resulting agent network definition: \n %s", str(network_def))
         sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
-        await ProgressHandler.report_progress(args, network_def)
+        await ProgressHandler.report_progress(args, sly_data, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
         return f"Successfully removed agent {the_agent_name} from the agent network definition."

--- a/coded_tools/agent_network_editor/update_agent.py
+++ b/coded_tools/agent_network_editor/update_agent.py
@@ -99,7 +99,7 @@ class UpdateAgent(CodedTool):
         logger.info("The resulting agent network definition: \n %s", str(network_def))
         sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
-        await ProgressHandler.report_progress(args, network_def)
+        await ProgressHandler.report_progress(args, sly_data, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
         return f"Successfully updated down-chained agents for {the_agent_name} in the agent network definition."

--- a/coded_tools/agent_network_instructions_editor/set_agent_description.py
+++ b/coded_tools/agent_network_instructions_editor/set_agent_description.py
@@ -93,7 +93,7 @@ class SetAgentDescription(CodedTool):
         logger.info("The resulting agent network: \n %s", str(network_def))
         sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
-        await ProgressHandler.report_progress(args, network_def)
+        await ProgressHandler.report_progress(args, sly_data, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
         return f"The description for '{the_agent_name}' has been set in 'agent_network_definition' successfully."

--- a/coded_tools/agent_network_instructions_editor/set_agent_instructions.py
+++ b/coded_tools/agent_network_instructions_editor/set_agent_instructions.py
@@ -90,7 +90,7 @@ class SetAgentInstructions(CodedTool):
         logger.info("The resulting agent network: \n %s", str(network_def))
         sly_data[AGENT_NETWORK_DEFINITION] = network_def
 
-        await ProgressHandler.report_progress(args, network_def)
+        await ProgressHandler.report_progress(args, sly_data, network_def)
 
         logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
         return f"The instructions for '{the_agent_name}' have been set in 'agent_network_definition' successfully."

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -401,8 +401,7 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
         if self.progress_reporter is not None:
             await ProgressHandler.report_progress(
-                {"progress_reporter": self.progress_reporter}, None, 
-                network_def, self.sly_data.get(AGENT_NETWORK_NAME)
+                {"progress_reporter": self.progress_reporter}, None, network_def, self.sly_data.get(AGENT_NETWORK_NAME)
             )
 
         return await handler(request.override(system_message=system_message))

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -401,7 +401,8 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
         if self.progress_reporter is not None:
             await ProgressHandler.report_progress(
-                {"progress_reporter": self.progress_reporter}, network_def, self.sly_data.get(AGENT_NETWORK_NAME)
+                {"progress_reporter": self.progress_reporter}, None, 
+                network_def, self.sly_data.get(AGENT_NETWORK_NAME)
             )
 
         return await handler(request.override(system_message=system_message))


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Throttle the Agent Network Designer's ProgressHandler to report a progress message at most once every 2 secs.
This was causing excessive compute and network traffic, impeding progress of overall AND requests.

## Impact

40-50% speed improvement.

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [X] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
