### PR TITLE
Try to load the ToolboxFactory only once during AND

### DIFF
--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -21,6 +21,7 @@ from leaf_common.serialization.interface.dictionary_converter import DictionaryC
 # Reaching into neuro_san internals because we expect to know the gory details here because
 # we are building agent networks.  This is not normally a recommended practice.
 from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
+from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
 from neuro_san.internals.run_context.interfaces.agent_network_inspector import AgentNetworkInspector
 from neuro_san.internals.validation.network.url_network_validator import UrlNetworkValidator
 
@@ -41,7 +42,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
     yet-another format.
     """
 
-    def __init__(self, include_keys: list[str] = None):
+    def __init__(self, include_keys: list[str] = None, toolbox_factory: ContextTypeToolboxFactory = None):
         """
         Constructor
         :param include_keys: A list of keys to include in the conversion
@@ -49,6 +50,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         self.include_keys = include_keys
         if include_keys is None:
             self.include_keys = ["tools", "instructions", "description"]
+        self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
 
     def to_dict(self, obj: Connectivity) -> dict[str, Any]:
         """
@@ -101,7 +103,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
 
         inspector: AgentNetworkInspector = DesignerNetworkInspector(obj_dict_copy)
 
-        reporter: ConnectivityReporter = ConnectivityReporter(inspector)
+        reporter: ConnectivityReporter = ConnectivityReporter(inspector, self.toolbox_factory)
         connectivity = reporter.report_network_connectivity()
 
         # Add any keys that are not already in the connectivity report

--- a/coded_tools/agent_network_editor/constants.py
+++ b/coded_tools/agent_network_editor/constants.py
@@ -39,3 +39,9 @@ SUBNETWORKS: str = "subnetworks"
 
 # Cached dict mapping toolbox tool name to its description.
 TOOLBOX_INFO: str = "toolbox_info"
+
+# Cached ToolboxFactory instance used during ProgressHandler reporting.
+TOOLBOX_FACTORY: str = "toolbox_factory"
+
+# Cached ProgressHandler instance controls AGENT_PROGRESS reporting throttling
+PROGRESS_HANDLER: str = "progress_handler"

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -20,6 +20,8 @@ from typing import Any
 from typing import Dict
 
 from neuro_san.interfaces.agent_progress_reporter import AgentProgressReporter
+from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
+from neuro_san.internals.run_context.factory.master_toolbox_factory import MasterToolboxFactory
 
 from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
@@ -32,7 +34,7 @@ class ProgressHandler:
     Common handler for progress during the building of agent networks
     """
 
-    PROGRESS_THROTTLE_SECONDS: float = 2.0
+    PROGRESS_THROTTLE_SECONDS: float = 5.0
 
     def __init__(self):
         """
@@ -63,10 +65,9 @@ class ProgressHandler:
         :param network_definition: The network definition dictionary
         :param name: The name of the agent network. If None, will not be reported in progress.
         """
-        progress_handler: ProgressHandler = None
         if sly_data is not None:
             async with await SlyDataLock.get_lock(sly_data, "progress_handler_lock"):
-                progress_handler = sly_data.get("progress_handler")
+                progress_handler: ProgressHandler = sly_data.get("progress_handler")
                 if progress_handler is None:
                     progress_handler = ProgressHandler()
                     sly_data["progress_handler"] = progress_handler
@@ -85,8 +86,25 @@ class ProgressHandler:
             # so that agent network progress is converted to connectivity-style data format
             # that it already knows how to render.  Using the different key name allows the AGENT_PROGRESS
             # dictionary to look just like a ConnectivityResponse from the service.
+
+            # Get a cached toolbox factory so we don't have to read info from a file every time
+            toolbox_factory: ContextTypeToolboxFactory = None
+            if sly_data is not None:
+                toolbox_factory: ContextTypeToolboxFactory = sly_data.get("toolbox_factory")
+                if toolbox_factory is None:
+                    async with await SlyDataLock.get_lock(sly_data, "toolbox_factory_lock"):
+                        toolbox_factory: ContextTypeToolboxFactory = sly_data.get("toolbox_factory")
+                        if toolbox_factory is None:
+                            # DEF - not sure if this empty dict is good enough
+                            empty: Dict[str, Any] = {}
+                            toolbox_factory: ContextTypeToolboxFactory = \
+                                MasterToolboxFactory.create_toolbox_factory(empty)
+                            toolbox_factory.load()
+                            sly_data["toolbox_factory"] = toolbox_factory
+
+            # Do the conversion
             use_key: str = "connectivity_info"
-            converter = ConnectivityDictionaryConverter()
+            converter = ConnectivityDictionaryConverter(toolbox_factory=toolbox_factory)
             use_network_definition = converter.from_dict(network_definition)
 
         elif agent_progress_style == "internal":

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -97,8 +97,9 @@ class ProgressHandler:
                         if toolbox_factory is None:
                             # DEF - not sure if this empty dict is good enough
                             empty: Dict[str, Any] = {}
-                            toolbox_factory: ContextTypeToolboxFactory = \
-                                MasterToolboxFactory.create_toolbox_factory(empty)
+                            toolbox_factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory(
+                                empty
+                            )
                             toolbox_factory.load()
                             sly_data["toolbox_factory"] = toolbox_factory
 

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -26,6 +26,8 @@ from neuro_san.internals.run_context.factory.master_toolbox_factory import Maste
 from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
+from coded_tools.agent_network_editor.constants import PROGRESS_HANDLER
+from coded_tools.agent_network_editor.constants import TOOLBOX_FACTORY
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 
@@ -67,10 +69,10 @@ class ProgressHandler:
         """
         if sly_data is not None:
             async with await SlyDataLock.get_lock(sly_data, "progress_handler_lock"):
-                progress_handler: ProgressHandler = sly_data.get("progress_handler")
+                progress_handler: ProgressHandler = sly_data.get(PROGRESS_HANDLER)
                 if progress_handler is None:
                     progress_handler = ProgressHandler()
-                    sly_data["progress_handler"] = progress_handler
+                    sly_data[PROGRESS_HANDLER] = progress_handler
 
                 if not progress_handler.should_report():
                     return
@@ -90,10 +92,10 @@ class ProgressHandler:
             # Get a cached toolbox factory so we don't have to read info from a file every time
             toolbox_factory: ContextTypeToolboxFactory = None
             if sly_data is not None:
-                toolbox_factory: ContextTypeToolboxFactory = sly_data.get("toolbox_factory")
+                toolbox_factory: ContextTypeToolboxFactory = sly_data.get(TOOLBOX_FACTORY)
                 if toolbox_factory is None:
                     async with await SlyDataLock.get_lock(sly_data, "toolbox_factory_lock"):
-                        toolbox_factory: ContextTypeToolboxFactory = sly_data.get("toolbox_factory")
+                        toolbox_factory: ContextTypeToolboxFactory = sly_data.get(TOOLBOX_FACTORY)
                         if toolbox_factory is None:
                             # DEF - not sure if this empty dict is good enough
                             empty: Dict[str, Any] = {}
@@ -101,7 +103,7 @@ class ProgressHandler:
                                 empty
                             )
                             toolbox_factory.load()
-                            sly_data["toolbox_factory"] = toolbox_factory
+                            sly_data[TOOLBOX_FACTORY] = toolbox_factory
 
             # Do the conversion
             use_key: str = "connectivity_info"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Neuro SAN
 leaf-common>=1.2.47
-neuro-san==0.6.82
+neuro-san==0.6.83
 nsflow==0.6.17
 
 # For config parsing


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Try to load the ToolboxFactory only once during the course of any AND session.
In reality this ends up happening twice, I think because of the Middleware's not having sly_data (maybe).
At least this is way better than loading the toolbox from a file every ProgressHandler update.

## Impact

<!-- Brief description of what the consequences of this PR are -->

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Dependency upgrade
- [X] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [X] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
