### PR TITLE
Fix progress throttle final flush

### DIFF
--- a/coded_tools/agent_network_editor/constants.py
+++ b/coded_tools/agent_network_editor/constants.py
@@ -45,3 +45,9 @@ TOOLBOX_FACTORY: str = "toolbox_factory"
 
 # Cached ProgressHandler instance controls AGENT_PROGRESS reporting throttling
 PROGRESS_HANDLER: str = "progress_handler"
+
+# Names of the sly_data locks (see SlyDataLock.get_lock) guarding the entries above.
+# Defined here because SlyDataLock creates a fresh lock for any unknown name —
+# a typo'd literal would silently hand out a second, independent lock.
+PROGRESS_HANDLER_LOCK: str = "progress_handler_lock"
+TOOLBOX_FACTORY_LOCK: str = "toolbox_factory_lock"

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -14,6 +14,7 @@
 #
 # END COPYRIGHT
 
+import logging
 from os import environ
 from time import perf_counter
 from typing import Any
@@ -23,11 +24,14 @@ from neuro_san.interfaces.agent_progress_reporter import AgentProgressReporter
 from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
 from neuro_san.internals.run_context.factory.master_toolbox_factory import MasterToolboxFactory
 
+from coded_tools.agent_network_editor.and_logger import AndLogger
 from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
 from coded_tools.agent_network_editor.constants import PROGRESS_HANDLER
+from coded_tools.agent_network_editor.constants import PROGRESS_HANDLER_LOCK
 from coded_tools.agent_network_editor.constants import TOOLBOX_FACTORY
+from coded_tools.agent_network_editor.constants import TOOLBOX_FACTORY_LOCK
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 
@@ -96,18 +100,22 @@ class ProgressHandler:
         Reports are throttled to at most one per PROGRESS_THROTTLE_SECONDS per
         sly_data instance. A report suppressed by the throttle is not lost for
         good: its reporter is stashed on the ProgressHandler and the latest
-        network state is sent by flush_pending() at the end of the agent run
-        (from AgentNetworkDefinitionMiddleware.aafter_agent()). Without that,
-        a build whose last edit lands inside the throttle window would leave
-        the client's progress view permanently one or two edits stale.
+        network state is sent by flush_pending() when the agent loop exits
+        normally (from AgentNetworkDefinitionMiddleware.aafter_agent()).
+        Without that, a build whose last edit lands inside the throttle window
+        would leave the client's progress view one or two edits stale.
+
+        Sending is best-effort: a failure inside the send is logged and the
+        reporter is re-stashed for the end-of-run flush, so a broken progress
+        report can never fail the tool or model call that triggered it.
 
         :param args: The arguments dictionary for the calling CodedTool.
-                Expected to contain a "progress_reporter" entry.
+                Expected to contain a "progress_reporter" entry; without one
+                there is nothing to send through and the call is a no-op.
         :param sly_data: The sly_data dictionary on which the throttling state
                 (ProgressHandler) and the ToolboxFactory cache are kept.
-                May be None, in which case the report is sent unthrottled and
-                without any caching. This is a defensive fallback only — all
-                current callers pass a real sly_data.
+                Required — every caller has one, and reporting without it would
+                silently skip both the throttle and the cache.
         :param network_definition: The network definition dictionary
         :param name: The name of the agent network. If None, will not be reported in progress.
         :param force: When True, bypass the throttle and always send.
@@ -119,42 +127,66 @@ class ProgressHandler:
                 before each designer model call.
         """
         progress_reporter: AgentProgressReporter = args.get("progress_reporter")
+        if progress_reporter is None:
+            # Nothing to send through. Checked before any throttle bookkeeping so
+            # a reporter-less call can never consume the throttle slot or clobber
+            # a stashed pending reporter. (neuro-san always injects a reporter
+            # into coded tool args, so this is unreachable today.)
+            return
 
-        if sly_data is not None:
-            async with await SlyDataLock.get_lock(sly_data, "progress_handler_lock"):
-                progress_handler: ProgressHandler = sly_data.get(PROGRESS_HANDLER)
-                if progress_handler is None:
-                    progress_handler = ProgressHandler()
-                    sly_data[PROGRESS_HANDLER] = progress_handler
+        async with await SlyDataLock.get_lock(sly_data, PROGRESS_HANDLER_LOCK):
+            progress_handler: ProgressHandler = sly_data.get(PROGRESS_HANDLER)
+            if progress_handler is None:
+                progress_handler = ProgressHandler()
+                sly_data[PROGRESS_HANDLER] = progress_handler
 
-                if not progress_handler.should_report(force=force):
-                    # Throttled. Remember the reporter so flush_pending() can send
-                    # the final state at the end of the run. The payload is *not*
-                    # remembered — flush_pending() re-reads the latest definition
-                    # from sly_data (see comment in __init__).
+            if not progress_handler.should_report(force=force):
+                # Throttled. Remember the reporter so flush_pending() can send
+                # the final state at the end of the run. The payload is *not*
+                # remembered — flush_pending() re-reads the latest definition
+                # from sly_data (see comment in __init__).
+                progress_handler.pending_reporter = progress_reporter
+                return
+
+            # We are sending now, so any previously suppressed report is
+            # superseded by this one (which carries same-or-newer state).
+            progress_handler.pending_reporter = None
+
+        try:
+            await ProgressHandler._send_report(progress_reporter, sly_data, network_definition, name)
+        except Exception as exception:  # pylint: disable=broad-exception-caught
+            # Best-effort telemetry: a failed send (toolbox file I/O, connectivity
+            # conversion, journal write on a closed stream) must not fail the tool
+            # or model call that triggered it. Re-stash the reporter so the
+            # end-of-run flush retries with the freshest state; last_progress
+            # stays advanced so the throttle window is respected either way.
+            logger = AndLogger(logging.getLogger(ProgressHandler.__name__))
+            logger.error("Progress report failed; deferring to end-of-run flush: %s", exception)
+            async with await SlyDataLock.get_lock(sly_data, PROGRESS_HANDLER_LOCK):
+                progress_handler = sly_data.get(PROGRESS_HANDLER)
+                # Only re-stash if nothing newer was stashed (or sent) meanwhile.
+                if progress_handler is not None and progress_handler.pending_reporter is None:
                     progress_handler.pending_reporter = progress_reporter
-                    return
-
-                # We are sending now, so any previously suppressed report is
-                # superseded by this one (which carries same-or-newer state).
-                progress_handler.pending_reporter = None
-
-        await ProgressHandler._send_report(progress_reporter, sly_data, network_definition, name)
 
     @staticmethod
     async def flush_pending(sly_data: Dict[str, Any]):
         """
         Send the last throttled progress report, if any.
 
-        Called at the end of an agent run (AgentNetworkDefinitionMiddleware.aafter_agent())
-        while the request — and therefore the stashed reporter's journal — is still alive.
-        This guarantees the client always ends up seeing the final network state, even
-        when the report for the last edit fell inside the throttle window and was dropped.
+        Called when the agent loop exits normally
+        (AgentNetworkDefinitionMiddleware.aafter_agent()) while the request — and
+        therefore the stashed reporter's journal — is still alive. This ensures
+        the client ends up seeing the final network state even when the report
+        for the last edit fell inside the throttle window and was dropped.
+        Note the limit of that guarantee: if the run aborts on an unhandled
+        error, the after-agent hooks never execute and a throttled final report
+        stays dropped — same as the pre-throttle-fix behavior.
 
-        The report goes out through the reporter stashed from the suppressed tool call,
-        so from the client's perspective it originates from the same tool as every other
-        progress report. This is what lets the (by design) reporter-less subnetwork
-        middleware flush without creating a duplicate progress stream of its own.
+        The report goes out through the reporter stashed from the suppressed tool
+        call, so from the client's perspective it originates from the same tool as
+        every other progress report. This is what lets the (by design)
+        reporter-less subnetwork middleware flush without creating a duplicate
+        progress stream of its own.
 
         :param sly_data: The sly_data dictionary holding the throttling state.
                 May be None, in which case there is nothing to flush.
@@ -163,7 +195,7 @@ class ProgressHandler:
             return
 
         pending_reporter: AgentProgressReporter = None
-        async with await SlyDataLock.get_lock(sly_data, "progress_handler_lock"):
+        async with await SlyDataLock.get_lock(sly_data, PROGRESS_HANDLER_LOCK):
             progress_handler: ProgressHandler = sly_data.get(PROGRESS_HANDLER)
             if progress_handler is None or progress_handler.pending_reporter is None:
                 # Either nothing was ever reported on this sly_data, or the most
@@ -172,22 +204,36 @@ class ProgressHandler:
 
             pending_reporter = progress_handler.pending_reporter
             progress_handler.pending_reporter = None
-            # Count the flush as a send so later reports on the same sly_data
-            # (e.g. a follow-up request within the same session) throttle
-            # relative to it.
+            # Count the flush as a send to keep the throttle bookkeeping
+            # consistent for any later reports on this sly_data.
             progress_handler.last_progress = perf_counter()
 
         # Re-read the freshest state from sly_data rather than replaying the payload
         # of the suppressed call: several edits may have been throttled since the
         # reporter was stashed, and we only want to pay for one conversion/report
         # carrying the final state.
+        #
+        # Only a dict is sendable. An empty dict is a legitimate final state
+        # (e.g. the last agent was just removed) and MUST go out — dropping it
+        # would leave the client showing agents that no longer exist. A missing
+        # definition or a non-dict shape (the persistence middleware can rewrite
+        # this sly_data key to a connectivity-style list at end of run) cannot be
+        # converted and is skipped.
         network_definition: dict[str, Any] = sly_data.get(AGENT_NETWORK_DEFINITION)
-        if not network_definition:
+        if not isinstance(network_definition, dict):
             return
 
-        await ProgressHandler._send_report(
-            pending_reporter, sly_data, network_definition, sly_data.get(AGENT_NETWORK_NAME)
-        )
+        try:
+            await ProgressHandler._send_report(
+                pending_reporter, sly_data, network_definition, sly_data.get(AGENT_NETWORK_NAME)
+            )
+        except Exception as exception:  # pylint: disable=broad-exception-caught
+            # Best-effort: this hook runs as a langgraph node, and an exception
+            # escaping it would replace the run's real final answer with an error
+            # message after the network was already successfully built (e.g. when
+            # the client disconnected and the outgoing queue is already shut down).
+            logger = AndLogger(logging.getLogger(ProgressHandler.__name__))
+            logger.error("Final progress flush failed: %s", exception)
 
     @staticmethod
     async def _send_report(
@@ -200,20 +246,15 @@ class ProgressHandler:
         Format the network definition per AGENT_NETWORK_DESIGNER_PROGRESS_STYLE and send it.
 
         This is the unthrottled sending path shared by report_progress() and
-        flush_pending(). Throttling decisions are made by the callers.
+        flush_pending(). Throttling decisions and error containment are the
+        callers' responsibility; both callers guarantee a non-None reporter
+        and sly_data.
 
         :param progress_reporter: The AgentProgressReporter to send the progress through
-        :param sly_data: The sly_data dictionary used for the ToolboxFactory cache.
-                May be None, in which case no caching happens and ConnectivityReporter
-                falls back to creating (and loading) its own factory for this report.
+        :param sly_data: The sly_data dictionary used for the ToolboxFactory cache
         :param network_definition: The network definition dictionary
         :param name: The name of the agent network. If None, will not be reported in progress.
         """
-        if progress_reporter is None:
-            # Defensive: neuro-san always injects a progress_reporter into coded
-            # tool args, but without one there is nothing to send through.
-            return
-
         use_key: str = AGENT_NETWORK_DEFINITION
         use_network_definition: dict[str, Any] | list[dict[str, Any]] = network_definition
 
@@ -225,20 +266,16 @@ class ProgressHandler:
             # dictionary to look just like a ConnectivityResponse from the service.
 
             # Get a cached toolbox factory so we don't have to read info from a file every time
-            toolbox_factory: ContextTypeToolboxFactory = None
-            if sly_data is not None:
-                toolbox_factory: ContextTypeToolboxFactory = sly_data.get(TOOLBOX_FACTORY)
-                if toolbox_factory is None:
-                    async with await SlyDataLock.get_lock(sly_data, "toolbox_factory_lock"):
-                        toolbox_factory: ContextTypeToolboxFactory = sly_data.get(TOOLBOX_FACTORY)
-                        if toolbox_factory is None:
-                            # DEF - not sure if this empty dict is good enough
-                            empty: Dict[str, Any] = {}
-                            toolbox_factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory(
-                                empty
-                            )
-                            toolbox_factory.load()
-                            sly_data[TOOLBOX_FACTORY] = toolbox_factory
+            toolbox_factory: ContextTypeToolboxFactory = sly_data.get(TOOLBOX_FACTORY)
+            if toolbox_factory is None:
+                async with await SlyDataLock.get_lock(sly_data, TOOLBOX_FACTORY_LOCK):
+                    toolbox_factory: ContextTypeToolboxFactory = sly_data.get(TOOLBOX_FACTORY)
+                    if toolbox_factory is None:
+                        # DEF - not sure if this empty dict is good enough
+                        empty: Dict[str, Any] = {}
+                        toolbox_factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory(empty)
+                        toolbox_factory.load()
+                        sly_data[TOOLBOX_FACTORY] = toolbox_factory
 
             # Do the conversion
             use_key: str = "connectivity_info"

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -42,15 +42,41 @@ class ProgressHandler:
         """
         Constructor
         """
-        self.last_progress: float = 0.0
+        # Timestamp (per perf_counter()) of the last progress report actually sent.
+        # Initialized to -inf so the very first report is always allowed through:
+        # perf_counter()'s epoch is unspecified (on most platforms it is "seconds
+        # since boot"), so initializing to 0.0 could wrongly throttle the first
+        # report of a process that starts less than PROGRESS_THROTTLE_SECONDS
+        # after that epoch.
+        self.last_progress: float = float("-inf")
 
-    def should_report(self) -> bool:
+        # When the throttle suppresses a report, we stash the reporter that would
+        # have been used so the final state can still be flushed at the end of the
+        # agent run (see flush_pending()). None means nothing is pending.
+        #
+        # Only the reporter is stashed, not the report payload: at flush time the
+        # latest AGENT_NETWORK_DEFINITION is re-read from sly_data, so the flush
+        # always sends the freshest state and the (potentially expensive)
+        # connectivity conversion is paid only once no matter how many reports
+        # were suppressed in between.
+        self.pending_reporter: AgentProgressReporter = None
+
+    def should_report(self, force: bool = False) -> bool:
         """
         Should the progress be reported?
+
+        This is a "leading edge" throttle: a report arriving inside the throttle
+        window is dropped, not delayed. Callers that get False back are expected
+        to record the drop on pending_reporter so that flush_pending() can send
+        the final state at the end of the run.
+
+        :param force: When True, bypass the throttle window entirely.
+                The send time is still recorded so subsequent throttled callers
+                back off relative to this send.
+        :return: True if the report should be sent
         """
         now: float = perf_counter()
-        report_me: bool = now - self.last_progress > self.PROGRESS_THROTTLE_SECONDS
-        if not report_me:
+        if not force and now - self.last_progress <= self.PROGRESS_THROTTLE_SECONDS:
             return False
 
         self.last_progress = now
@@ -58,15 +84,42 @@ class ProgressHandler:
 
     @staticmethod
     async def report_progress(
-        args: dict[str, Any], sly_data: Dict[str, Any], network_definition: dict[str, Any], name: str = None
+        args: dict[str, Any],
+        sly_data: Dict[str, Any],
+        network_definition: dict[str, Any],
+        name: str = None,
+        force: bool = False,
     ):
         """
-        Common handler for progress during the building of agent networks
+        Common handler for progress during the building of agent networks.
 
-        :param args: The arguments dictionary for the calling CodedTool
+        Reports are throttled to at most one per PROGRESS_THROTTLE_SECONDS per
+        sly_data instance. A report suppressed by the throttle is not lost for
+        good: its reporter is stashed on the ProgressHandler and the latest
+        network state is sent by flush_pending() at the end of the agent run
+        (from AgentNetworkDefinitionMiddleware.aafter_agent()). Without that,
+        a build whose last edit lands inside the throttle window would leave
+        the client's progress view permanently one or two edits stale.
+
+        :param args: The arguments dictionary for the calling CodedTool.
+                Expected to contain a "progress_reporter" entry.
+        :param sly_data: The sly_data dictionary on which the throttling state
+                (ProgressHandler) and the ToolboxFactory cache are kept.
+                May be None, in which case the report is sent unthrottled and
+                without any caching. This is a defensive fallback only — all
+                current callers pass a real sly_data.
         :param network_definition: The network definition dictionary
         :param name: The name of the agent network. If None, will not be reported in progress.
+        :param force: When True, bypass the throttle and always send.
+                Used by AgentNetworkDefinitionMiddleware of the top-level designer,
+                whose reports fire at most once per designer model call — far less
+                frequently than the editor tools in the subnetworks — and which is
+                what guarantees the client sees the fully merged network state
+                (including subnetwork edits whose own reports were throttled)
+                before each designer model call.
         """
+        progress_reporter: AgentProgressReporter = args.get("progress_reporter")
+
         if sly_data is not None:
             async with await SlyDataLock.get_lock(sly_data, "progress_handler_lock"):
                 progress_handler: ProgressHandler = sly_data.get(PROGRESS_HANDLER)
@@ -74,10 +127,92 @@ class ProgressHandler:
                     progress_handler = ProgressHandler()
                     sly_data[PROGRESS_HANDLER] = progress_handler
 
-                if not progress_handler.should_report():
+                if not progress_handler.should_report(force=force):
+                    # Throttled. Remember the reporter so flush_pending() can send
+                    # the final state at the end of the run. The payload is *not*
+                    # remembered — flush_pending() re-reads the latest definition
+                    # from sly_data (see comment in __init__).
+                    progress_handler.pending_reporter = progress_reporter
                     return
 
-        progress_reporter: AgentProgressReporter = args.get("progress_reporter")
+                # We are sending now, so any previously suppressed report is
+                # superseded by this one (which carries same-or-newer state).
+                progress_handler.pending_reporter = None
+
+        await ProgressHandler._send_report(progress_reporter, sly_data, network_definition, name)
+
+    @staticmethod
+    async def flush_pending(sly_data: Dict[str, Any]):
+        """
+        Send the last throttled progress report, if any.
+
+        Called at the end of an agent run (AgentNetworkDefinitionMiddleware.aafter_agent())
+        while the request — and therefore the stashed reporter's journal — is still alive.
+        This guarantees the client always ends up seeing the final network state, even
+        when the report for the last edit fell inside the throttle window and was dropped.
+
+        The report goes out through the reporter stashed from the suppressed tool call,
+        so from the client's perspective it originates from the same tool as every other
+        progress report. This is what lets the (by design) reporter-less subnetwork
+        middleware flush without creating a duplicate progress stream of its own.
+
+        :param sly_data: The sly_data dictionary holding the throttling state.
+                May be None, in which case there is nothing to flush.
+        """
+        if sly_data is None:
+            return
+
+        pending_reporter: AgentProgressReporter = None
+        async with await SlyDataLock.get_lock(sly_data, "progress_handler_lock"):
+            progress_handler: ProgressHandler = sly_data.get(PROGRESS_HANDLER)
+            if progress_handler is None or progress_handler.pending_reporter is None:
+                # Either nothing was ever reported on this sly_data, or the most
+                # recent report went out unthrottled — the client is up to date.
+                return
+
+            pending_reporter = progress_handler.pending_reporter
+            progress_handler.pending_reporter = None
+            # Count the flush as a send so later reports on the same sly_data
+            # (e.g. a follow-up request within the same session) throttle
+            # relative to it.
+            progress_handler.last_progress = perf_counter()
+
+        # Re-read the freshest state from sly_data rather than replaying the payload
+        # of the suppressed call: several edits may have been throttled since the
+        # reporter was stashed, and we only want to pay for one conversion/report
+        # carrying the final state.
+        network_definition: dict[str, Any] = sly_data.get(AGENT_NETWORK_DEFINITION)
+        if not network_definition:
+            return
+
+        await ProgressHandler._send_report(
+            pending_reporter, sly_data, network_definition, sly_data.get(AGENT_NETWORK_NAME)
+        )
+
+    @staticmethod
+    async def _send_report(
+        progress_reporter: AgentProgressReporter,
+        sly_data: Dict[str, Any],
+        network_definition: dict[str, Any],
+        name: str = None,
+    ):
+        """
+        Format the network definition per AGENT_NETWORK_DESIGNER_PROGRESS_STYLE and send it.
+
+        This is the unthrottled sending path shared by report_progress() and
+        flush_pending(). Throttling decisions are made by the callers.
+
+        :param progress_reporter: The AgentProgressReporter to send the progress through
+        :param sly_data: The sly_data dictionary used for the ToolboxFactory cache.
+                May be None, in which case no caching happens and ConnectivityReporter
+                falls back to creating (and loading) its own factory for this report.
+        :param network_definition: The network definition dictionary
+        :param name: The name of the agent network. If None, will not be reported in progress.
+        """
+        if progress_reporter is None:
+            # Defensive: neuro-san always injects a progress_reporter into coded
+            # tool args, but without one there is nothing to send through.
+            return
 
         use_key: str = AGENT_NETWORK_DEFINITION
         use_network_definition: dict[str, Any] | list[dict[str, Any]] = network_definition

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -18,7 +18,6 @@ import logging
 from os import environ
 from time import perf_counter
 from typing import Any
-from typing import Dict
 
 from neuro_san.interfaces.agent_progress_reporter import AgentProgressReporter
 from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
@@ -63,7 +62,7 @@ class ProgressHandler:
         # always sends the freshest state and the (potentially expensive)
         # connectivity conversion is paid only once no matter how many reports
         # were suppressed in between.
-        self.pending_reporter: AgentProgressReporter = None
+        self.pending_reporter: AgentProgressReporter | None = None
 
     def should_report(self, force: bool = False) -> bool:
         """
@@ -89,7 +88,7 @@ class ProgressHandler:
     @staticmethod
     async def report_progress(
         args: dict[str, Any],
-        sly_data: Dict[str, Any],
+        sly_data: dict[str, Any],
         network_definition: dict[str, Any],
         name: str = None,
         force: bool = False,
@@ -126,7 +125,7 @@ class ProgressHandler:
                 (including subnetwork edits whose own reports were throttled)
                 before each designer model call.
         """
-        progress_reporter: AgentProgressReporter = args.get("progress_reporter")
+        progress_reporter: AgentProgressReporter | None = args.get("progress_reporter")
         if progress_reporter is None:
             # Nothing to send through. Checked before any throttle bookkeeping so
             # a reporter-less call can never consume the throttle slot or clobber
@@ -169,7 +168,7 @@ class ProgressHandler:
                     progress_handler.pending_reporter = progress_reporter
 
     @staticmethod
-    async def flush_pending(sly_data: Dict[str, Any]):
+    async def flush_pending(sly_data: dict[str, Any] | None):
         """
         Send the last throttled progress report, if any.
 
@@ -194,7 +193,7 @@ class ProgressHandler:
         if sly_data is None:
             return
 
-        pending_reporter: AgentProgressReporter = None
+        pending_reporter: AgentProgressReporter | None = None
         async with await SlyDataLock.get_lock(sly_data, PROGRESS_HANDLER_LOCK):
             progress_handler: ProgressHandler = sly_data.get(PROGRESS_HANDLER)
             if progress_handler is None or progress_handler.pending_reporter is None:
@@ -238,7 +237,7 @@ class ProgressHandler:
     @staticmethod
     async def _send_report(
         progress_reporter: AgentProgressReporter,
-        sly_data: Dict[str, Any],
+        sly_data: dict[str, Any],
         network_definition: dict[str, Any],
         name: str = None,
     ):
@@ -272,7 +271,7 @@ class ProgressHandler:
                     toolbox_factory: ContextTypeToolboxFactory = sly_data.get(TOOLBOX_FACTORY)
                     if toolbox_factory is None:
                         # DEF - not sure if this empty dict is good enough
-                        empty: Dict[str, Any] = {}
+                        empty: dict[str, Any] = {}
                         toolbox_factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory(empty)
                         toolbox_factory.load()
                         sly_data[TOOLBOX_FACTORY] = toolbox_factory

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -90,7 +90,7 @@ class ProgressHandler:
         args: dict[str, Any],
         sly_data: dict[str, Any],
         network_definition: dict[str, Any],
-        name: str = None,
+        name: str | None = None,
         force: bool = False,
     ):
         """
@@ -250,7 +250,7 @@ class ProgressHandler:
         progress_reporter: AgentProgressReporter,
         sly_data: dict[str, Any],
         network_definition: dict[str, Any],
-        name: str = None,
+        name: str | None = None,
     ):
         """
         Format the network definition per AGENT_NETWORK_DESIGNER_PROGRESS_STYLE and send it.

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -168,7 +168,7 @@ class ProgressHandler:
             # end-of-run flush retries with the freshest state; last_progress
             # stays advanced so the throttle window is respected either way.
             logger = AndLogger(logging.getLogger(ProgressHandler.__name__))
-            logger.error("Progress report failed; deferring to end-of-run flush: %s", exception)
+            logger.error("Progress report failed; deferring to end-of-run flush: %s", exception, exc_info=True)
             async with await SlyDataLock.get_lock(sly_data, PROGRESS_HANDLER_LOCK):
                 progress_handler = sly_data.get(PROGRESS_HANDLER)
                 # Only re-stash if nothing newer happened meanwhile: a non-None
@@ -248,7 +248,7 @@ class ProgressHandler:
             # message after the network was already successfully built (e.g. when
             # the client disconnected and the outgoing queue is already shut down).
             logger = AndLogger(logging.getLogger(ProgressHandler.__name__))
-            logger.error("Final progress flush failed: %s", exception)
+            logger.error("Final progress flush failed: %s", exception, exc_info=True)
 
     @staticmethod
     async def _send_report(

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -45,7 +45,12 @@ class ProgressHandler:
         """
         Constructor
         """
-        # Timestamp (per perf_counter()) of the last progress report actually sent.
+        # Timestamp (per perf_counter()) of the last time the throttle granted a
+        # send — stamped when a report passes should_report() or when a pending
+        # flush is consumed, i.e. just before the send itself runs, not after it
+        # completes. A failed send deliberately keeps the stamp so the throttle
+        # window is respected either way (see the failure path in
+        # report_progress(), which re-stashes the reporter instead).
         # Initialized to -inf so the very first report is always allowed through:
         # perf_counter()'s epoch is unspecified (on most platforms it is "seconds
         # since boot"), so initializing to 0.0 could wrongly throttle the first
@@ -134,7 +139,7 @@ class ProgressHandler:
             return
 
         async with await SlyDataLock.get_lock(sly_data, PROGRESS_HANDLER_LOCK):
-            progress_handler: ProgressHandler = sly_data.get(PROGRESS_HANDLER)
+            progress_handler: ProgressHandler | None = sly_data.get(PROGRESS_HANDLER)
             if progress_handler is None:
                 progress_handler = ProgressHandler()
                 sly_data[PROGRESS_HANDLER] = progress_handler
@@ -206,7 +211,7 @@ class ProgressHandler:
 
         pending_reporter: AgentProgressReporter | None = None
         async with await SlyDataLock.get_lock(sly_data, PROGRESS_HANDLER_LOCK):
-            progress_handler: ProgressHandler = sly_data.get(PROGRESS_HANDLER)
+            progress_handler: ProgressHandler | None = sly_data.get(PROGRESS_HANDLER)
             if progress_handler is None or progress_handler.pending_reporter is None:
                 # Either nothing was ever reported on this sly_data, or the most
                 # recent report went out unthrottled — the client is up to date.

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -234,7 +234,7 @@ class ProgressHandler:
         # definition or a non-dict shape (the persistence middleware can rewrite
         # this sly_data key to a connectivity-style list at end of run) cannot be
         # converted and is skipped.
-        network_definition: dict[str, Any] = sly_data.get(AGENT_NETWORK_DEFINITION)
+        network_definition: dict[str, Any] | list[dict[str, Any]] | None = sly_data.get(AGENT_NETWORK_DEFINITION)
         if not isinstance(network_definition, dict):
             return
 

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -150,6 +150,9 @@ class ProgressHandler:
             # We are sending now, so any previously suppressed report is
             # superseded by this one (which carries same-or-newer state).
             progress_handler.pending_reporter = None
+            # Remember this attempt's send stamp so the failure path below can
+            # tell whether a newer send completed while this one was in flight.
+            attempt_stamp: float = progress_handler.last_progress
 
         try:
             await ProgressHandler._send_report(progress_reporter, sly_data, network_definition, name)
@@ -163,8 +166,16 @@ class ProgressHandler:
             logger.error("Progress report failed; deferring to end-of-run flush: %s", exception)
             async with await SlyDataLock.get_lock(sly_data, PROGRESS_HANDLER_LOCK):
                 progress_handler = sly_data.get(PROGRESS_HANDLER)
-                # Only re-stash if nothing newer was stashed (or sent) meanwhile.
-                if progress_handler is not None and progress_handler.pending_reporter is None:
+                # Only re-stash if nothing newer happened meanwhile: a non-None
+                # pending_reporter means a newer throttled report is already
+                # stashed, and a last_progress advanced past this attempt's stamp
+                # means a newer send already delivered same-or-newer state — in
+                # either case re-stashing would only cause a redundant flush.
+                if (
+                    progress_handler is not None
+                    and progress_handler.pending_reporter is None
+                    and progress_handler.last_progress == attempt_stamp
+                ):
                     progress_handler.pending_reporter = progress_reporter
 
     @staticmethod

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -281,10 +281,10 @@ class ProgressHandler:
             # dictionary to look just like a ConnectivityResponse from the service.
 
             # Get a cached toolbox factory so we don't have to read info from a file every time
-            toolbox_factory: ContextTypeToolboxFactory = sly_data.get(TOOLBOX_FACTORY)
+            toolbox_factory: ContextTypeToolboxFactory | None = sly_data.get(TOOLBOX_FACTORY)
             if toolbox_factory is None:
                 async with await SlyDataLock.get_lock(sly_data, TOOLBOX_FACTORY_LOCK):
-                    toolbox_factory: ContextTypeToolboxFactory = sly_data.get(TOOLBOX_FACTORY)
+                    toolbox_factory: ContextTypeToolboxFactory | None = sly_data.get(TOOLBOX_FACTORY)
                     if toolbox_factory is None:
                         # DEF - not sure if this empty dict is good enough
                         empty: dict[str, Any] = {}

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -187,6 +187,33 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
         return await self._inject_into_request(self.network_def, request, handler)
 
+    @override
+    async def aafter_agent(self, state: AgentState[Any], runtime: Any) -> dict[str, Any] | None:
+        """
+        Flush any progress report that the throttle suppressed during this agent run.
+
+        ProgressHandler's throttle drops (rather than delays) reports arriving within the
+        throttle window, so without this hook a build whose final edit lands shortly after
+        the previous sent report would leave the client's progress view permanently stale
+        (issue #1257). Flushing here — at the end of the agent loop, while the request and
+        its journal are still alive — guarantees the final network state always goes out.
+
+        This matters most in the subnetworks (agent_network_editor and pals) and when those
+        networks are used directly: their middleware has no progress_reporter by design
+        (the client already receives the tools' own progress reports, so a middleware
+        reporter would duplicate that stream). The flush therefore reuses the reporter
+        stashed from the throttled tool call instead of needing one of its own.
+
+        In the top-level designer this is effectively a no-op: its forced middleware
+        reports (see _inject_into_request) clear the pending state on every model call.
+
+        :param state: Current agent state
+        :param runtime: Runtime context
+        :return: None to proceed normally
+        """
+        await ProgressHandler.flush_pending(self.sly_data)
+        return None
+
     async def _resolve_network_def(self) -> dict[str, Any] | list[dict[str, Any]] | None:
         """
         Resolve the agent network definition from sly_data, HOCON file, or S3 reservation.
@@ -400,8 +427,24 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             system_message = SystemMessage(content=definition_prompt)
 
         if self.progress_reporter is not None:
+            # Pass the real sly_data (the same dict instance the coded tools receive) so this
+            # report shares the ToolboxFactory cache and the throttle bookkeeping with the tools.
+            # Previously None was passed here, which skipped the cache and made ConnectivityReporter
+            # re-read the toolbox info files on every single report — the expensive part the
+            # throttle was introduced to avoid in the first place.
+            #
+            # force=True keeps this report unthrottled: it fires at most once per model call of
+            # the top-level designer (only the designer's middleware is configured with a
+            # progress_reporter) — far less frequently than the editor tools in the subnetworks —
+            # and it is what guarantees the client sees the fully merged network state, including
+            # subnetwork edits whose own throttled reports may have been dropped, before each
+            # designer model call.
             await ProgressHandler.report_progress(
-                {"progress_reporter": self.progress_reporter}, None, network_def, self.sly_data.get(AGENT_NETWORK_NAME)
+                {"progress_reporter": self.progress_reporter},
+                self.sly_data,
+                network_def,
+                self.sly_data.get(AGENT_NETWORK_NAME),
+                force=True,
             )
 
         return await handler(request.override(system_message=system_message))

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -65,6 +65,12 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
     This allows the LLM to reason about the current agent network structure without
     requiring it to be passed explicitly through the chat stream.
+
+    This middleware also anchors the progress-throttling contract of the editor
+    coded tools: its aafter_agent hook flushes any progress report that
+    ProgressHandler's throttle suppressed during the run (see flush_pending()).
+    A network that wires the editor tools without registering this middleware
+    silently loses that end-of-run flush.
     """
 
     def __init__(self, sly_data: dict[str, Any], progress_reporter: AgentProgressReporter | None = None) -> None:
@@ -195,8 +201,10 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         ProgressHandler's throttle drops (rather than delays) reports arriving within the
         throttle window, so without this hook a build whose final edit lands shortly after
         the previous sent report would leave the client's progress view permanently stale
-        (issue #1257). Flushing here — at the end of the agent loop, while the request and
-        its journal are still alive — guarantees the final network state always goes out.
+        (issue #1257). Flushing here — when the agent loop exits normally, while the
+        request and its journal are still alive — ensures the final network state goes
+        out. (If the run aborts on an unhandled error, after-agent hooks are skipped and
+        the throttled report stays dropped, matching pre-throttle behavior.)
 
         This matters most in the subnetworks (agent_network_editor and pals) and when those
         networks are used directly: their middleware has no progress_reporter by design
@@ -206,6 +214,9 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
         In the top-level designer this is effectively a no-op: its forced middleware
         reports (see _inject_into_request) clear the pending state on every model call.
+
+        flush_pending contains its own error handling — this hook runs as a langgraph
+        node, and an exception escaping it would replace the run's real final answer.
 
         :param state: Current agent state
         :param runtime: Runtime context


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Fixes #1257

PR #1254 throttled the Agent Network Designer's `ProgressHandler` to one report per 5 seconds, which left two corner cases:

1. **The last progress update could be dropped.** The throttle drops (rather than delays) reports inside the window, so a build whose final edit landed less than 5s after the previous sent report never reached the client — the UI kept showing a stale, one-or-two-edits-short graph.
2. **`AgentNetworkDefinitionMiddleware` passed `None` as `sly_data`.** That bypassed both the throttle bookkeeping and the `TOOLBOX_FACTORY` cache, so every middleware report in connectivity style re-read the toolbox info files — the very cost the throttle was introduced to avoid.

The fix:

- When a report is throttled, `ProgressHandler` stashes the tool's reporter, and a new `aafter_agent` hook on `AgentNetworkDefinitionMiddleware` flushes the **latest** network state (re-read from `sly_data`) through it when the agent loop exits. Because the flush reuses the throttled tool's own reporter, the (by design) reporter-less subnetwork middleware creates no duplicate progress stream — and direct use of `agent_network_editor` / `agent_network_instructions_editor` is covered too.
- The designer middleware now passes its real `sly_data` with a new `force=True` flag: its report stays unthrottled (it fires at most once per designer model call) but shares the ToolboxFactory cache and throttle bookkeeping with the tools.

Hardening from an adversarial review of the change:

- An empty dict is a legitimate final state (the last agent was removed) and is flushed; a non-dict shape (the persistence middleware can rewrite the key to a connectivity list at end of run) is skipped instead of crashing the converter.
- Sends are best-effort: a failure is logged, and in `report_progress` the reporter is re-stashed so the end-of-run flush retries with the freshest state. A failed send is no longer treated as delivered, and a flush failure cannot escape the langgraph `after_agent` node and replace the run's real final answer.
- The `progress_reporter` None check happens before any throttle bookkeeping; `sly_data` is now required (the unthrottled/uncached `None` fallback was dead code); the sly_data lock names are constants; `last_progress` initializes to `-inf` so the first report can never be throttled by `perf_counter()`'s arbitrary epoch.

No hocon changes and no new dependencies.

## Impact

- Clients always end a run with the completed agent-network graph, even when the last edit lands inside the throttle window.
- Connectivity-style middleware reports use the cached ToolboxFactory instead of re-reading toolbox info files on every designer model call.
- Progress-report failures can no longer fail a tool call or replace a successful run's final answer.
- Known limit: if a run aborts on an unhandled error, after-agent hooks are skipped and a throttled final report stays dropped — same as pre-fix behavior.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [X] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
