### PR TITLE
Fix toolbox factory process cache

### DIFF
--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -14,6 +14,7 @@
 #
 # END COPYRIGHT
 from copy import deepcopy
+from threading import Lock
 from typing import Any
 
 from leaf_common.serialization.interface.dictionary_converter import DictionaryConverter
@@ -22,6 +23,7 @@ from leaf_common.serialization.interface.dictionary_converter import DictionaryC
 # we are building agent networks.  This is not normally a recommended practice.
 from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
+from neuro_san.internals.run_context.factory.master_toolbox_factory import MasterToolboxFactory
 from neuro_san.internals.run_context.interfaces.agent_network_inspector import AgentNetworkInspector
 from neuro_san.internals.validation.network.url_network_validator import UrlNetworkValidator
 
@@ -42,19 +44,89 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
     yet-another format.
     """
 
+    # Process-wide cache of the loaded ToolboxFactory used by from_dict() when
+    # no factory is passed to the constructor. The toolbox info is loaded
+    # lazily on the first use in the process — the default file ships inside
+    # the neuro-san package and the optional override comes from the
+    # AGENT_TOOLBOX_INFO_FILE env var, both read at that first use — and is
+    # deliberately never refreshed: picking up an edited toolbox info file
+    # requires a process restart. (The pre-cache behavior of re-loading per
+    # conversation was an accident of sly_data scoping, not a supported
+    # hot-reload feature.)
+    _shared_toolbox_factory: ContextTypeToolboxFactory | None = None
+
+    # A threading.Lock rather than an asyncio.Lock: callers may run on
+    # different event loops in different threads, and an asyncio.Lock cannot
+    # be shared across event loops.
+    _shared_toolbox_factory_lock: Lock = Lock()
+
     def __init__(self, include_keys: list[str] = None, toolbox_factory: ContextTypeToolboxFactory = None):
         """
         Constructor
         :param include_keys: A list of keys to include in the conversion
-        :param toolbox_factory: An optional pre-load()-ed ContextTypeToolboxFactory,
-                passed through to the ConnectivityReporter so it does not construct
-                and load one from disk per from_dict() call. When None, the reporter
-                falls back to creating its own.
+        :param toolbox_factory: An optional pre-load()-ed ContextTypeToolboxFactory
+                to use for connectivity reporting. When None, from_dict() falls
+                back to the process-wide shared factory (see
+                get_shared_toolbox_factory()), so no caller pays the toolbox
+                file read + HOCON parse more than once per process.
         """
         self.include_keys = include_keys
         if include_keys is None:
             self.include_keys = ["tools", "instructions", "description"]
         self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
+
+    @classmethod
+    def peek_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory | None:
+        """
+        :return: The shared ToolboxFactory if it has already been loaded, else None.
+                Lock-free and safe to call from any thread or event loop. Async
+                callers can use a None result to decide to run
+                get_shared_toolbox_factory() in a worker thread instead of on
+                the event loop.
+        """
+        return ConnectivityDictionaryConverter._shared_toolbox_factory
+
+    @classmethod
+    def get_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory:
+        """
+        Get the process-wide ToolboxFactory, creating and load()-ing it on first call.
+
+        The first call in the process does file I/O plus a HOCON parse, so
+        async callers should check peek_shared_toolbox_factory() first and
+        reach this through asyncio.to_thread() on a miss. Once loaded, calls
+        return via a lock-free attribute read.
+
+        Note: attribute access goes through the class by name (not cls) so a
+        hypothetical subclass shares the one cache instead of splitting it.
+
+        :return: The shared, already-load()-ed ToolboxFactory instance.
+        """
+        factory: ContextTypeToolboxFactory | None = ConnectivityDictionaryConverter._shared_toolbox_factory
+        if factory is not None:
+            # Lock-free fast path: the attribute is published only after a
+            # successful load() and reference reads are atomic under the GIL,
+            # so a non-None read always yields a fully loaded factory.
+            return factory
+
+        with ConnectivityDictionaryConverter._shared_toolbox_factory_lock:
+            if ConnectivityDictionaryConverter._shared_toolbox_factory is None:
+                # The empty config dict is equivalent to the None that
+                # DesignerNetworkInspector.get_config() returns: the context
+                # type defaults to "langchain" and any AGENT_TOOLBOX_INFO_FILE
+                # env var override is still honored inside ToolboxFactory.
+                factory = MasterToolboxFactory.create_toolbox_factory({})
+                factory.load()
+                # Publish only after load() succeeds, for two reasons:
+                # * On failure (e.g. a bad AGENT_TOOLBOX_INFO_FILE) the cache
+                #   stays empty and the next call retries instead of serving a
+                #   half-initialized factory.
+                # * neuro-san 0.6.83's ToolboxFactory.load() guards itself with
+                #   a plain `loaded` flag and no lock, so publishing a fully
+                #   load()-ed instance is what makes ConnectivityReporter's
+                #   unconditional per-report load() call a safe no-op on every
+                #   thread that can see this factory. Do not reorder.
+                ConnectivityDictionaryConverter._shared_toolbox_factory = factory
+        return ConnectivityDictionaryConverter._shared_toolbox_factory
 
     def to_dict(self, obj: Connectivity) -> dict[str, Any]:
         """
@@ -107,7 +179,13 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
 
         inspector: AgentNetworkInspector = DesignerNetworkInspector(obj_dict_copy)
 
-        reporter: ConnectivityReporter = ConnectivityReporter(inspector, self.toolbox_factory)
+        # Fall back to the process-wide shared factory so every from_dict()
+        # caller benefits from the cache without having to pass one in.
+        toolbox_factory: ContextTypeToolboxFactory = self.toolbox_factory
+        if toolbox_factory is None:
+            toolbox_factory = self.get_shared_toolbox_factory()
+
+        reporter: ConnectivityReporter = ConnectivityReporter(inspector, toolbox_factory)
         connectivity = reporter.report_network_connectivity()
 
         # Add any keys that are not already in the connectivity report

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -46,6 +46,10 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         """
         Constructor
         :param include_keys: A list of keys to include in the conversion
+        :param toolbox_factory: An optional pre-load()-ed ContextTypeToolboxFactory,
+                passed through to the ConnectivityReporter so it does not construct
+                and load one from disk per from_dict() call. When None, the reporter
+                falls back to creating its own.
         """
         self.include_keys = include_keys
         if include_keys is None:

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -111,7 +111,8 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
             return factory
 
         with ConnectivityDictionaryConverter._shared_toolbox_factory_lock:
-            if ConnectivityDictionaryConverter._shared_toolbox_factory is None:
+            factory = ConnectivityDictionaryConverter._shared_toolbox_factory
+            if factory is None:
                 # The empty config dict is equivalent to the None that
                 # DesignerNetworkInspector.get_config() returns: the context
                 # type defaults to "langchain" and any AGENT_TOOLBOX_INFO_FILE
@@ -128,7 +129,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
                 #   unconditional per-report load() call a safe no-op on every
                 #   thread that can see this factory. Do not reorder.
                 ConnectivityDictionaryConverter._shared_toolbox_factory = factory
-        return ConnectivityDictionaryConverter._shared_toolbox_factory
+        return factory
 
     def to_dict(self, obj: Connectivity) -> dict[str, Any]:
         """

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -58,7 +58,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
     # A threading.Lock rather than an asyncio.Lock: callers may run on
     # different event loops in different threads, and an asyncio.Lock cannot
     # be shared across event loops.
-    _shared_toolbox_factory_lock: Lock = Lock()
+    _shared_toolbox_factory_lock = Lock()
 
     def __init__(
         self, include_keys: list[str] | None = None, toolbox_factory: ContextTypeToolboxFactory | None = None

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -60,7 +60,9 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
     # be shared across event loops.
     _shared_toolbox_factory_lock: Lock = Lock()
 
-    def __init__(self, include_keys: list[str] = None, toolbox_factory: ContextTypeToolboxFactory = None):
+    def __init__(
+        self, include_keys: list[str] | None = None, toolbox_factory: ContextTypeToolboxFactory | None = None
+    ):
         """
         Constructor
         :param include_keys: A list of keys to include in the conversion
@@ -73,7 +75,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         self.include_keys = include_keys
         if include_keys is None:
             self.include_keys = ["tools", "instructions", "description"]
-        self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
+        self.toolbox_factory: ContextTypeToolboxFactory | None = toolbox_factory
 
     @classmethod
     def peek_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory | None:
@@ -181,7 +183,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
 
         # Fall back to the process-wide shared factory so every from_dict()
         # caller benefits from the cache without having to pass one in.
-        toolbox_factory: ContextTypeToolboxFactory = self.toolbox_factory
+        toolbox_factory: ContextTypeToolboxFactory | None = self.toolbox_factory
         if toolbox_factory is None:
             toolbox_factory = self.get_shared_toolbox_factory()
 

--- a/coded_tools/agent_network_editor/constants.py
+++ b/coded_tools/agent_network_editor/constants.py
@@ -40,14 +40,10 @@ SUBNETWORKS: str = "subnetworks"
 # Cached dict mapping toolbox tool name to its description.
 TOOLBOX_INFO: str = "toolbox_info"
 
-# Cached ToolboxFactory instance used during ProgressHandler reporting.
-TOOLBOX_FACTORY: str = "toolbox_factory"
-
 # Cached ProgressHandler instance controls AGENT_PROGRESS reporting throttling
 PROGRESS_HANDLER: str = "progress_handler"
 
-# Names of the sly_data locks (see SlyDataLock.get_lock) guarding the entries above.
+# Name of the sly_data lock (see SlyDataLock.get_lock) guarding the entry above.
 # Defined here because SlyDataLock creates a fresh lock for any unknown name —
 # a typo'd literal would silently hand out a second, independent lock.
 PROGRESS_HANDLER_LOCK: str = "progress_handler_lock"
-TOOLBOX_FACTORY_LOCK: str = "toolbox_factory_lock"

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -15,7 +15,9 @@
 # END COPYRIGHT
 
 import logging
+from asyncio import to_thread
 from os import environ
+from threading import Lock
 from time import perf_counter
 from typing import Any
 
@@ -29,8 +31,6 @@ from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
 from coded_tools.agent_network_editor.constants import PROGRESS_HANDLER
 from coded_tools.agent_network_editor.constants import PROGRESS_HANDLER_LOCK
-from coded_tools.agent_network_editor.constants import TOOLBOX_FACTORY
-from coded_tools.agent_network_editor.constants import TOOLBOX_FACTORY_LOCK
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 
@@ -40,6 +40,26 @@ class ProgressHandler:
     """
 
     PROGRESS_THROTTLE_SECONDS: float = 5.0
+
+    # Process-wide cache of the loaded ToolboxFactory used for connectivity-style
+    # progress conversion. The toolbox info it loads is static for the life of
+    # the process (the default file ships inside the neuro-san package and the
+    # optional override comes from the AGENT_TOOLBOX_INFO_FILE env var, read at
+    # startup), so one shared, effectively read-only instance is enough.
+    #
+    # Class scope rather than sly_data scope matters here: sly_data is scoped
+    # per conversation *and* per network, and AND spans two progress-reporting
+    # networks (agent_network_editor and agent_network_instructions_editor), so
+    # a sly_data-cached factory re-paid the file read + HOCON parse twice per
+    # request, and again for every new conversation.
+    _toolbox_factory: ContextTypeToolboxFactory | None = None
+
+    # A threading.Lock rather than an asyncio.Lock (or SlyDataLock): the cache
+    # is shared across requests, whose coded tools may each run on their own
+    # event loop in their own thread, and an asyncio.Lock cannot be shared
+    # across event loops. Waiting on it never stalls an event loop because
+    # callers reach _get_toolbox_factory() through asyncio.to_thread().
+    _toolbox_factory_lock: Lock = Lock()
 
     def __init__(self):
         """
@@ -117,9 +137,9 @@ class ProgressHandler:
                 Expected to contain a "progress_reporter" entry; without one
                 there is nothing to send through and the call is a no-op.
         :param sly_data: The sly_data dictionary on which the throttling state
-                (ProgressHandler) and the ToolboxFactory cache are kept.
+                (ProgressHandler) is kept.
                 Required — every caller has one, and reporting without it would
-                silently skip both the throttle and the cache.
+                silently skip the throttle.
         :param network_definition: The network definition dictionary
         :param name: The name of the agent network. If None, will not be reported in progress.
         :param force: When True, bypass the throttle and always send.
@@ -160,7 +180,7 @@ class ProgressHandler:
             attempt_stamp: float = progress_handler.last_progress
 
         try:
-            await ProgressHandler._send_report(progress_reporter, sly_data, network_definition, name)
+            await ProgressHandler._send_report(progress_reporter, network_definition, name)
         except Exception as exception:  # pylint: disable=broad-exception-caught
             # Best-effort telemetry: a failed send (toolbox file I/O, connectivity
             # conversion, journal write on a closed stream) must not fail the tool
@@ -239,9 +259,7 @@ class ProgressHandler:
             return
 
         try:
-            await ProgressHandler._send_report(
-                pending_reporter, sly_data, network_definition, sly_data.get(AGENT_NETWORK_NAME)
-            )
+            await ProgressHandler._send_report(pending_reporter, network_definition, sly_data.get(AGENT_NETWORK_NAME))
         except Exception as exception:  # pylint: disable=broad-exception-caught
             # Best-effort: this hook runs as a langgraph node, and an exception
             # escaping it would replace the run's real final answer with an error
@@ -250,10 +268,34 @@ class ProgressHandler:
             logger = AndLogger(logging.getLogger(ProgressHandler.__name__))
             logger.error("Final progress flush failed: %s", exception, exc_info=True)
 
+    @classmethod
+    def _get_toolbox_factory(cls) -> ContextTypeToolboxFactory:
+        """
+        Get the process-wide ToolboxFactory, creating and load()-ing it on first call.
+
+        Synchronous by design — the first call does file I/O plus a HOCON parse,
+        and later calls may briefly wait on the lock — so async callers must go
+        through asyncio.to_thread() to keep that work off the event loop.
+
+        :return: The shared, already-load()-ed ToolboxFactory instance.
+        """
+        with cls._toolbox_factory_lock:
+            if cls._toolbox_factory is None:
+                # The empty config dict is equivalent to the None that
+                # DesignerNetworkInspector.get_config() returns: the context
+                # type defaults to "langchain" and any AGENT_TOOLBOX_INFO_FILE
+                # env var override is still honored inside ToolboxFactory.
+                factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory({})
+                factory.load()
+                # Publish only after load() succeeds: on failure (e.g. a bad
+                # AGENT_TOOLBOX_INFO_FILE) the cache stays empty and the next
+                # report retries instead of serving a half-initialized factory.
+                cls._toolbox_factory = factory
+        return cls._toolbox_factory
+
     @staticmethod
     async def _send_report(
         progress_reporter: AgentProgressReporter,
-        sly_data: dict[str, Any],
         network_definition: dict[str, Any],
         name: str | None = None,
     ):
@@ -262,11 +304,9 @@ class ProgressHandler:
 
         This is the unthrottled sending path shared by report_progress() and
         flush_pending(). Throttling decisions and error containment are the
-        callers' responsibility; both callers guarantee a non-None reporter
-        and sly_data.
+        callers' responsibility; both callers guarantee a non-None reporter.
 
         :param progress_reporter: The AgentProgressReporter to send the progress through
-        :param sly_data: The sly_data dictionary used for the ToolboxFactory cache
         :param network_definition: The network definition dictionary
         :param name: The name of the agent network. If None, will not be reported in progress.
         """
@@ -280,17 +320,10 @@ class ProgressHandler:
             # that it already knows how to render.  Using the different key name allows the AGENT_PROGRESS
             # dictionary to look just like a ConnectivityResponse from the service.
 
-            # Get a cached toolbox factory so we don't have to read info from a file every time
-            toolbox_factory: ContextTypeToolboxFactory | None = sly_data.get(TOOLBOX_FACTORY)
-            if toolbox_factory is None:
-                async with await SlyDataLock.get_lock(sly_data, TOOLBOX_FACTORY_LOCK):
-                    toolbox_factory: ContextTypeToolboxFactory | None = sly_data.get(TOOLBOX_FACTORY)
-                    if toolbox_factory is None:
-                        # DEF - not sure if this empty dict is good enough
-                        empty: dict[str, Any] = {}
-                        toolbox_factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory(empty)
-                        toolbox_factory.load()
-                        sly_data[TOOLBOX_FACTORY] = toolbox_factory
+            # Get the process-wide cached ToolboxFactory: only the first call in
+            # the process pays for the file read + HOCON parse, and to_thread()
+            # keeps that parse (and any wait on its lock) off the event loop.
+            toolbox_factory: ContextTypeToolboxFactory = await to_thread(ProgressHandler._get_toolbox_factory)
 
             # Do the conversion
             use_key: str = "connectivity_info"

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -17,13 +17,10 @@
 import logging
 from asyncio import to_thread
 from os import environ
-from threading import Lock
 from time import perf_counter
 from typing import Any
 
 from neuro_san.interfaces.agent_progress_reporter import AgentProgressReporter
-from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
-from neuro_san.internals.run_context.factory.master_toolbox_factory import MasterToolboxFactory
 
 from coded_tools.agent_network_editor.and_logger import AndLogger
 from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
@@ -40,26 +37,6 @@ class ProgressHandler:
     """
 
     PROGRESS_THROTTLE_SECONDS: float = 5.0
-
-    # Process-wide cache of the loaded ToolboxFactory used for connectivity-style
-    # progress conversion. The toolbox info it loads is static for the life of
-    # the process (the default file ships inside the neuro-san package and the
-    # optional override comes from the AGENT_TOOLBOX_INFO_FILE env var, read at
-    # startup), so one shared, effectively read-only instance is enough.
-    #
-    # Class scope rather than sly_data scope matters here: sly_data is scoped
-    # per conversation *and* per network, and AND spans two progress-reporting
-    # networks (agent_network_editor and agent_network_instructions_editor), so
-    # a sly_data-cached factory re-paid the file read + HOCON parse twice per
-    # request, and again for every new conversation.
-    _toolbox_factory: ContextTypeToolboxFactory | None = None
-
-    # A threading.Lock rather than an asyncio.Lock (or SlyDataLock): the cache
-    # is shared across requests, whose coded tools may each run on their own
-    # event loop in their own thread, and an asyncio.Lock cannot be shared
-    # across event loops. Waiting on it never stalls an event loop because
-    # callers reach _get_toolbox_factory() through asyncio.to_thread().
-    _toolbox_factory_lock: Lock = Lock()
 
     def __init__(self):
         """
@@ -268,31 +245,6 @@ class ProgressHandler:
             logger = AndLogger(logging.getLogger(ProgressHandler.__name__))
             logger.error("Final progress flush failed: %s", exception, exc_info=True)
 
-    @classmethod
-    def _get_toolbox_factory(cls) -> ContextTypeToolboxFactory:
-        """
-        Get the process-wide ToolboxFactory, creating and load()-ing it on first call.
-
-        Synchronous by design — the first call does file I/O plus a HOCON parse,
-        and later calls may briefly wait on the lock — so async callers must go
-        through asyncio.to_thread() to keep that work off the event loop.
-
-        :return: The shared, already-load()-ed ToolboxFactory instance.
-        """
-        with cls._toolbox_factory_lock:
-            if cls._toolbox_factory is None:
-                # The empty config dict is equivalent to the None that
-                # DesignerNetworkInspector.get_config() returns: the context
-                # type defaults to "langchain" and any AGENT_TOOLBOX_INFO_FILE
-                # env var override is still honored inside ToolboxFactory.
-                factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory({})
-                factory.load()
-                # Publish only after load() succeeds: on failure (e.g. a bad
-                # AGENT_TOOLBOX_INFO_FILE) the cache stays empty and the next
-                # report retries instead of serving a half-initialized factory.
-                cls._toolbox_factory = factory
-        return cls._toolbox_factory
-
     @staticmethod
     async def _send_report(
         progress_reporter: AgentProgressReporter,
@@ -320,14 +272,19 @@ class ProgressHandler:
             # that it already knows how to render.  Using the different key name allows the AGENT_PROGRESS
             # dictionary to look just like a ConnectivityResponse from the service.
 
-            # Get the process-wide cached ToolboxFactory: only the first call in
-            # the process pays for the file read + HOCON parse, and to_thread()
-            # keeps that parse (and any wait on its lock) off the event loop.
-            toolbox_factory: ContextTypeToolboxFactory = await to_thread(ProgressHandler._get_toolbox_factory)
+            # Warm the process-wide ToolboxFactory cache that from_dict() falls
+            # back to. Only the first call in the process pays for the file
+            # read + HOCON parse, and to_thread() keeps that parse off the
+            # event loop; once warm, the peek and the fallback inside
+            # from_dict() are lock-free attribute reads, so the steady-state
+            # path has no thread hop, no lock traffic, and no await between
+            # the throttle stamp and the conversion snapshot.
+            if ConnectivityDictionaryConverter.peek_shared_toolbox_factory() is None:
+                await to_thread(ConnectivityDictionaryConverter.get_shared_toolbox_factory)
 
             # Do the conversion
             use_key: str = "connectivity_info"
-            converter = ConnectivityDictionaryConverter(toolbox_factory=toolbox_factory)
+            converter = ConnectivityDictionaryConverter()
             use_network_definition = converter.from_dict(network_definition)
 
         elif agent_progress_style == "internal":

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -439,10 +439,9 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
 
         if self.progress_reporter is not None:
             # Pass the real sly_data (the same dict instance the coded tools receive) so this
-            # report shares the ToolboxFactory cache and the throttle bookkeeping with the tools.
-            # Previously None was passed here, which skipped the cache and made ConnectivityReporter
-            # re-read the toolbox info files on every single report — the expensive part the
-            # throttle was introduced to avoid in the first place.
+            # report shares the throttle bookkeeping with the tools and can look up the network
+            # name. (The ToolboxFactory used for connectivity conversion is no longer kept on
+            # sly_data — it is a process-wide cache on ConnectivityDictionaryConverter.)
             #
             # force=True keeps this report unthrottled: it fires at most once per model call of
             # the top-level designer (only the designer's middleware is configured with a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_shared_toolbox_factory():
+    """
+    Clear ConnectivityDictionaryConverter's process-wide ToolboxFactory cache
+    after each test.
+
+    The cache captures AGENT_TOOLBOX_INFO_FILE at its first load and is never
+    refreshed, so without this reset a test that triggers a connectivity-style
+    progress report would leak its loaded factory (and the env-var state it was
+    built from) into every later test in the same process, producing
+    order-dependent results.
+
+    The module is looked up via sys.modules instead of imported directly so
+    tests that never touch the converter don't pay for importing neuro-san
+    internals at collection time.
+    """
+    yield
+    module = sys.modules.get("coded_tools.agent_network_editor.connectivity_dictionary_converter")
+    if module is not None:
+        # pylint: disable=protected-access
+        module.ConnectivityDictionaryConverter._shared_toolbox_factory = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,24 +18,32 @@ import sys
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def reset_shared_toolbox_factory():
+def _clear_shared_toolbox_factory():
     """
-    Clear ConnectivityDictionaryConverter's process-wide ToolboxFactory cache
-    after each test.
-
-    The cache captures AGENT_TOOLBOX_INFO_FILE at its first load and is never
-    refreshed, so without this reset a test that triggers a connectivity-style
-    progress report would leak its loaded factory (and the env-var state it was
-    built from) into every later test in the same process, producing
-    order-dependent results.
+    Clear ConnectivityDictionaryConverter's process-wide ToolboxFactory cache.
 
     The module is looked up via sys.modules instead of imported directly so
     tests that never touch the converter don't pay for importing neuro-san
     internals at collection time.
     """
-    yield
     module = sys.modules.get("coded_tools.agent_network_editor.connectivity_dictionary_converter")
     if module is not None:
         # pylint: disable=protected-access
         module.ConnectivityDictionaryConverter._shared_toolbox_factory = None
+
+
+@pytest.fixture(autouse=True)
+def reset_shared_toolbox_factory():
+    """
+    Clear the process-wide ToolboxFactory cache before and after each test.
+
+    The cache captures AGENT_TOOLBOX_INFO_FILE at its first load and is never
+    refreshed, so without this reset a test that triggers a connectivity-style
+    progress report would leak its loaded factory (and the env-var state it was
+    built from) into every later test in the same process, producing
+    order-dependent results. Clearing before the test as well guards against
+    state populated outside any test, e.g. during collection or session setup.
+    """
+    _clear_shared_toolbox_factory()
+    yield
+    _clear_shared_toolbox_factory()


### PR DESCRIPTION
## Description

Fixes #1261

Follow-up to #1258: the ToolboxFactory used for connectivity-style progress conversion was cached in sly_data, which is scoped per conversation *and* per network — so the toolbox HOCON was still parsed twice per request (AND spans two progress-reporting networks) and again for every new conversation, with the synchronous parse running on the event loop under an async lock.

This PR:

- Caches **one loaded ToolboxFactory per process**, owned by `ConnectivityDictionaryConverter` (the class that actually consumes it). `from_dict()` falls back to the shared cache when no factory is passed, so every caller benefits — including `agent_network_persistence_middleware`, which previously self-built and re-parsed a factory once per run end.
- Keeps the one cold load **off the event loop** via `asyncio.to_thread()`; once warm, the path is a lock-free attribute read — no thread hop, no lock traffic, and no `await` between the throttle stamp and the conversion snapshot.
- Documents the load-bearing details: the empty-config factory is equivalent to the `None` that `DesignerNetworkInspector.get_config()` returns (resolves the `DEF - not sure if this empty dict is good enough` marker from #1258), the env var is read lazily at first use, and publishing the factory only after `load()` succeeds is what makes neuro-san 0.6.83's lock-free `ToolboxFactory.load()` flag safe for the shared instance.
- Fixes the now-stale comment in `agent_network_definition_middleware` that claimed sly_data carries the factory cache, and removes the orphaned `TOOLBOX_FACTORY`/`TOOLBOX_FACTORY_LOCK` sly_data key constants.
- Adds `tests/conftest.py` with an autouse fixture that resets the shared cache between tests, preventing order-dependent `AGENT_TOOLBOX_INFO_FILE` leakage.

## Impact

- Toolbox HOCON file read + pyhocon parse drops from ~2× per request plus once per new conversation to **exactly once per process**; steady-state progress reports do zero file I/O and zero lock traffic.
- No event-loop stalls from the parse on multi-user servers running `AGENT_NETWORK_DESIGNER_PROGRESS_STYLE=connectivity`.
- No public API changes: `report_progress()` / `flush_pending()` signatures and the converter's `toolbox_factory` constructor param are unchanged.
- One deliberate behavior change: edits to the toolbox info file are picked up on **process restart** only. The old per-conversation reload was an accident of sly_data scoping, not a supported hot-reload feature; this is now documented at the cache.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests (test infrastructure: autouse cache-reset fixture in new `tests/conftest.py`)
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (none added)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

