### PR TITLE
Report unreachable agents as isolated nodes in connectivity progress

### DIFF
--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -201,7 +201,13 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
                     break
 
             if found_entry is None:
-                continue
+                # Not reachable from the front man — or there is no front man at
+                # all, e.g. right after create_network when no agent has tools
+                # yet, in which case the reporter walk above yields an empty
+                # list. Emit the agent as an isolated node so clients can still
+                # render every defined agent.
+                found_entry = {"origin": name, "tools": internal_entry.get("tools", [])}
+                connectivity.append(found_entry)
 
             # Copy any keys that are not already in the connectivity report
             self.copy_keys_not_found(internal_entry, found_entry)


### PR DESCRIPTION
`ConnectivityDictionaryConverter.from_dict()` built its list solely from ConnectivityReporter's walk from the front man, and the key-merge pass skipped any agent the walk didn't visit. Right after `create_new_network` no agent has tools yet, so no front man exists and the report came out as an empty `connectivity_info` list — clients rendered an empty graph until the first update_agent_in_network wired the network up. The same skip silently dropped orphaned subtrees from every mid-edit report.

<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Append an {origin, tools} entry for each definition agent missing from the reporter output instead of skipping it; `copy_keys_not_found()` then fills instructions/description as usual. Create-time frames now carry all agents as isolated nodes, matching the internal progress style.

Fixes #1272 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
