### PR TITLE
Cache toolbox info per process

### DIFF
--- a/coded_tools/agent_network_editor/constants.py
+++ b/coded_tools/agent_network_editor/constants.py
@@ -37,9 +37,6 @@ SUBNETWORK_NAMES: str = "subnetwork_names"
 # surface available subnetworks (with descriptions) to the LLM.
 SUBNETWORKS: str = "subnetworks"
 
-# Cached dict mapping toolbox tool name to its description.
-TOOLBOX_INFO: str = "toolbox_info"
-
 # Cached ProgressHandler instance controls AGENT_PROGRESS reporting throttling
 PROGRESS_HANDLER: str = "progress_handler"
 

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -57,7 +57,10 @@ class GetToolbox(CodedTool):
                 Lock-free and safe to call from any thread or event loop. Async
                 callers can use a None result to decide to run
                 get_shared_toolbox_info() in a worker thread instead of on the
-                event loop.
+                event loop. Treat the result as read-only: it is the live
+                shared cache, not a copy — mutating it corrupts every
+                conversation in the process. get_toolbox_info() returns a
+                mutation-safe copy.
         """
         return GetToolbox._shared_toolbox_info
 
@@ -78,10 +81,14 @@ class GetToolbox(CodedTool):
         only the publishes below touch the attribute directly.
 
         :return: dict mapping tool names to descriptions; empty if the toolbox
-                info file does not exist. A missing file is cached as empty —
-                preserving the previous per-session "go fish, but only once"
-                behavior at process scope — while any other load error leaves
-                the cache unpublished so the next call retries.
+                info file does not exist. Failures are never published: a
+                missing file returns empty for this call only and the next
+                call retries, so a transient gap (a deploy replacing the file,
+                a not-yet-mounted volume) cannot pin an empty toolbox for the
+                life of the process. A malformed file raises out of the parse,
+                also unpublished. Treat the result as read-only: it is the
+                live shared cache, not a copy — get_toolbox_info() returns a
+                mutation-safe copy.
         """
         tools: dict[str, str] | None = GetToolbox.peek_shared_toolbox_info()
         if tools is not None:
@@ -101,26 +108,33 @@ class GetToolbox(CodedTool):
                 # Use a default if no value specified
                 toolbox_info_file = DEFAULT_TOOLBOX_INFO_FILE
 
-            # Go fish, but only once per process.
+            # Go fish — once per process once it succeeds.
             logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from Toolbox>>>>>>>>>>>>>>>>>>>")
             logger.info("Toolbox info file: %s", toolbox_info_file)
 
-            tools = {}
             try:
                 raw_tools: dict[str, Any] = ToolboxInfoRestorer().restore(toolbox_info_file)
-                logger.info("Successfully loaded the following toolbox: %s", str(raw_tools))
-
-                # Keep only each tool's description.
-                for tool_name, tool_info in raw_tools.items():
-                    tools[tool_name] = tool_info.get("description", "")
-
             except FileNotFoundError:
+                # Return empty WITHOUT publishing: caching the failure would
+                # serve an empty toolbox to every conversation until process
+                # restart, even after an operator restores the file (deploy
+                # races and wrong-CWD launches make a missing file a transient
+                # condition). The retry costs one failed open per call, and
+                # the recurring warning is the operator's signal.
                 logger.warning("Error: Failed to load toolbox info from %s.", toolbox_info_file)
+                return {}
 
-            # Publish only after the load-and-clean fully succeeded (or the
-            # file was definitively absent). Parse errors propagate out of the
-            # restore above without publishing, so a transiently broken file
-            # is retried on the next call instead of poisoning the cache.
+            logger.info("Successfully loaded the following toolbox: %s", str(raw_tools))
+
+            # Keep only each tool's description.
+            tools = {}
+            for tool_name, tool_info in raw_tools.items():
+                tools[tool_name] = tool_info.get("description", "")
+
+            # Publish only after the load-and-clean fully succeeded. Parse
+            # errors propagate out of the restore above without publishing,
+            # so a transiently broken file is retried on the next call
+            # instead of poisoning the cache.
             GetToolbox._shared_toolbox_info = tools
 
         return tools
@@ -148,14 +162,16 @@ class GetToolbox(CodedTool):
         Read toolbox info from the process-wide cache, loading it from a file
         on the first call in the process.
 
-        :return: dict mapping tool names to descriptions; empty if loading fails.
-                The returned dict is a copy, so callers may mutate it without
-                corrupting the shared cache.
+        :return: dict mapping tool names to descriptions; empty if the toolbox
+                info file does not exist (retried on the next call, never
+                cached). A malformed file raises. The returned dict is a copy,
+                so callers may mutate it without corrupting the shared cache.
         """
         tools: dict[str, str] | None = GetToolbox.peek_shared_toolbox_info()
         if tools is None:
-            # Cold path, at most once per process: keep the file read and
-            # HOCON parse off the event loop.
+            # Cold path — once per process on success, once per call while
+            # the file is missing: keep the file read and HOCON parse off
+            # the event loop.
             tools = await to_thread(GetToolbox.get_shared_toolbox_info)
         return dict(tools)
 
@@ -185,6 +201,7 @@ class GetToolbox(CodedTool):
             In case of successful execution:
                 the tool definition from toolbox as a dictionary.
             otherwise:
-                an empty dictionary.
+                an empty dictionary if the toolbox info file does not exist;
+                a malformed file raises.
         """
         return await self.get_toolbox_info()

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -16,14 +16,14 @@
 
 import logging
 import os
+from asyncio import to_thread
+from threading import Lock
 from typing import Any
 
 from neuro_san.interfaces.coded_tool import CodedTool
 from neuro_san.internals.run_context.langchain.toolbox.toolbox_info_restorer import ToolboxInfoRestorer
 
 from coded_tools.agent_network_editor.and_logger import AndLogger
-from coded_tools.agent_network_editor.constants import TOOLBOX_INFO
-from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 DEFAULT_TOOLBOX_INFO_FILE = os.path.join("neuro_san_studio", "toolbox", "agent_network_designer_toolbox_info.hocon")
 logger = AndLogger(logging.getLogger(__name__))
@@ -34,22 +34,66 @@ class GetToolbox(CodedTool):
     CodedTool implementation which provides a way to get tool definition from toolbox info file
     """
 
-    @staticmethod
-    async def get_toolbox_info(sly_data: dict[str, Any]) -> dict[str, Any]:
-        """
-        Read toolbox info from a cache in sly_data
-        or load it from a file.
+    # Process-wide cache of the {tool_name: description} mapping parsed from the
+    # toolbox info file (issue #1268). The file path — the
+    # AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE env var or the default — is
+    # resolved at first use and the parse happens once per process; the cache is
+    # deliberately never refreshed, so picking up an edited toolbox info file
+    # requires a process restart. This is the same trade-off already made for
+    # ConnectivityDictionaryConverter's shared ToolboxFactory. Previously the
+    # cache lived in sly_data, so a server handling N concurrent conversations
+    # re-parsed the same HOCON N times, on the event loop.
+    _shared_toolbox_info: dict[str, str] | None = None
 
-        :param sly_data: sly_data possibly containing cached toolbox info
-        :return: dict mapping tool names to descriptions; empty if loading fails
-        """
-        tools: dict[str, Any] = {}
+    # A threading.Lock rather than an asyncio.Lock: callers may run on
+    # different event loops in different threads, and an asyncio.Lock cannot
+    # be shared across event loops.
+    _shared_toolbox_info_lock = Lock()
 
-        async with await SlyDataLock.get_lock(sly_data, "toolbox_info_lock"):
-            # Try getting from sly_data
-            if TOOLBOX_INFO in sly_data:
-                # Return whatever we had cached before, including an empty dict
-                return sly_data.get(TOOLBOX_INFO)
+    @classmethod
+    def peek_shared_toolbox_info(cls) -> dict[str, str] | None:
+        """
+        :return: The shared toolbox info if it has already been loaded, else None.
+                Lock-free and safe to call from any thread or event loop. Async
+                callers can use a None result to decide to run
+                get_shared_toolbox_info() in a worker thread instead of on the
+                event loop.
+        """
+        return GetToolbox._shared_toolbox_info
+
+    @classmethod
+    def get_shared_toolbox_info(cls) -> dict[str, str]:
+        """
+        Get the process-wide toolbox info, reading and parsing the file on first call.
+
+        The first call in the process does file I/O plus a HOCON parse, so
+        async callers should check peek_shared_toolbox_info() first and reach
+        this through asyncio.to_thread() on a miss. Once loaded, calls return
+        via a lock-free read.
+
+        Note: cache access goes through the class by name (not cls) so a
+        hypothetical subclass shares the one cache instead of splitting it.
+        All reads funnel through peek_shared_toolbox_info() so any future
+        cache policy (expiration, refresh) has a single interception point;
+        only the publishes below touch the attribute directly.
+
+        :return: dict mapping tool names to descriptions; empty if the toolbox
+                info file does not exist. A missing file is cached as empty —
+                preserving the previous per-session "go fish, but only once"
+                behavior at process scope — while any other load error leaves
+                the cache unpublished so the next call retries.
+        """
+        tools: dict[str, str] | None = GetToolbox.peek_shared_toolbox_info()
+        if tools is not None:
+            # Lock-free fast path: the attribute is published only after a
+            # fully successful load-and-clean, and reference reads are atomic
+            # under the GIL, so a non-None read always yields a complete dict.
+            return tools
+
+        with GetToolbox._shared_toolbox_info_lock:
+            tools = GetToolbox.peek_shared_toolbox_info()
+            if tools is not None:
+                return tools
 
             # Check for toolbox info file in env var
             toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE")
@@ -57,25 +101,63 @@ class GetToolbox(CodedTool):
                 # Use a default if no value specified
                 toolbox_info_file = DEFAULT_TOOLBOX_INFO_FILE
 
-            # Go fish, but only once.
+            # Go fish, but only once per process.
             logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from Toolbox>>>>>>>>>>>>>>>>>>>")
             logger.info("Toolbox info file: %s", toolbox_info_file)
-            try:
-                # Need to do the load
-                tools = await ToolboxInfoRestorer().async_restore(toolbox_info_file)
-                logger.info("Successfully loaded the following toolbox: %s", str(tools))
 
-                # Clean up the dict so that it only contains "description" key.
-                for tool_name, tool_info in tools.items():
+            tools = {}
+            try:
+                raw_tools: dict[str, Any] = ToolboxInfoRestorer().restore(toolbox_info_file)
+                logger.info("Successfully loaded the following toolbox: %s", str(raw_tools))
+
+                # Keep only each tool's description.
+                for tool_name, tool_info in raw_tools.items():
                     tools[tool_name] = tool_info.get("description", "")
 
             except FileNotFoundError:
                 logger.warning("Error: Failed to load toolbox info from %s.", toolbox_info_file)
 
-            # Cache the results in sly_data - success or failure.
-            sly_data[TOOLBOX_INFO] = tools
+            # Publish only after the load-and-clean fully succeeded (or the
+            # file was definitively absent). Parse errors propagate out of the
+            # restore above without publishing, so a transiently broken file
+            # is retried on the next call instead of poisoning the cache.
+            GetToolbox._shared_toolbox_info = tools
 
         return tools
+
+    @classmethod
+    def clear_shared_toolbox_info_for_testing(cls):
+        """
+        Reset the process-wide toolbox info cache. For test isolation only.
+
+        Production code must never call this: the cache is deliberately
+        load-once-per-process (see the class comment above). Tests call it
+        (via tests/conftest.py) so toolbox info loaded under one test's
+        AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE state cannot leak into later
+        tests. Living here rather than in conftest keeps all the singleton
+        policy in this one class.
+        """
+        # Taking the lock serializes the reset with a concurrent first load,
+        # so this can never unpublish a mapping mid-initialization.
+        with GetToolbox._shared_toolbox_info_lock:
+            GetToolbox._shared_toolbox_info = None
+
+    @staticmethod
+    async def get_toolbox_info() -> dict[str, str]:
+        """
+        Read toolbox info from the process-wide cache, loading it from a file
+        on the first call in the process.
+
+        :return: dict mapping tool names to descriptions; empty if loading fails.
+                The returned dict is a copy, so callers may mutate it without
+                corrupting the shared cache.
+        """
+        tools: dict[str, str] | None = GetToolbox.peek_shared_toolbox_info()
+        if tools is None:
+            # Cold path, at most once per process: keep the file read and
+            # HOCON parse off the event loop.
+            tools = await to_thread(GetToolbox.get_shared_toolbox_info)
+        return dict(tools)
 
     async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any]:
         """
@@ -105,4 +187,4 @@ class GetToolbox(CodedTool):
             otherwise:
                 an empty dictionary.
         """
-        return await self.get_toolbox_info(sly_data)
+        return await self.get_toolbox_info()

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -14,6 +14,7 @@
 #
 # END COPYRIGHT
 
+from asyncio import to_thread
 from logging import getLogger
 from os import environ
 from typing import Any
@@ -196,7 +197,22 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             sample_queries: list[str] = self.sly_data.get(AGENT_NETWORK_QUERIES, [])
 
             await self._assemble_and_persist(network_def, agent_network_name, sample_queries)
-            self._determine_exported_network_definition(self.sly_data)
+
+            agent_progress_style: str = environ.get("AGENT_NETWORK_DESIGNER_PROGRESS_STYLE", "internal")
+
+            # Pre-warm the shared ToolboxFactory off the event loop before the
+            # sync export below converts to connectivity style. In the normal
+            # designer flow ProgressHandler has already done this while
+            # reporting progress, but a skip_designer run never reports
+            # progress, so on a cold process the from_dict() fallback inside
+            # the export would otherwise pay the one-time toolbox file read
+            # and HOCON parse on the event loop.
+            if (
+                agent_progress_style == "connectivity"
+                and ConnectivityDictionaryConverter.peek_shared_toolbox_factory() is None
+            ):
+                await to_thread(ConnectivityDictionaryConverter.get_shared_toolbox_factory)
+            self._determine_exported_network_definition(self.sly_data, agent_progress_style)
 
             self.logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
 
@@ -289,15 +305,19 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         if isinstance(persisted_reference, list):
             self.sly_data["agent_reservations"] = persisted_reference
 
-    def _determine_exported_network_definition(self, sly_data: dict[str, Any]):
+    def _determine_exported_network_definition(self, sly_data: dict[str, Any], agent_progress_style: str):
         """
-        Check the AGENT_NETWORK_DESIGNER_PROGRESS_STYLE env var to determine how to export
-        the agent network definition.
+        Determine how to export the agent network definition.
+
+        :param sly_data: The sly_data dictionary whose AGENT_NETWORK_DEFINITION
+                entry gets rewritten in place.
+        :param agent_progress_style: The AGENT_NETWORK_DESIGNER_PROGRESS_STYLE
+                env var value, read once by the caller (which also uses it to
+                decide whether to pre-warm the shared ToolboxFactory).
         """
         network_definition: dict[str, Any] = sly_data.get(AGENT_NETWORK_DEFINITION)
         use_network_definition: dict[str, Any] | list[dict[str, Any]] = network_definition
 
-        agent_progress_style: str = environ.get("AGENT_NETWORK_DESIGNER_PROGRESS_STYLE", "internal")
         if agent_progress_style == "connectivity":
             # The idea here is that a multi-user MAUI server can turn on this env variable
             # so that agent network progress is converted to connectivity-style data format

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -55,11 +55,12 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
         :return: A list of error strings (empty if valid)
         """
 
-        # Get infos from sly_data. These should have been put there by the respective tools
-        # from the agent network editor.
+        # Get infos from the agent network editor's tools. Subnetwork names and
+        # MCP servers are cached in sly_data by their respective tools; toolbox
+        # info comes from GetToolbox's process-wide cache.
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
         mcp_servers: list[str] = await GetMcpTool.get_mcp_servers(self.sly_data)
-        toolbox_tools: dict[str, Any] = await GetToolbox.get_toolbox_info(self.sly_data)
+        toolbox_tools: dict[str, Any] = await GetToolbox.get_toolbox_info()
 
         return (
             # The structure validator checks for the following structural issues:

--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -249,7 +249,7 @@ Operational notes:
                     ]
                 },
                 "from_downstream": {
-                    "sly_data": ["agent_network_definition", "agent_network_name", "agent_network_queries", "mcp_servers", "subnetworks", "toolbox_info"],
+                    "sly_data": ["agent_network_definition", "agent_network_name", "agent_network_queries", "mcp_servers", "subnetworks"],
                     # Allow all messages sent from specific downstream agents to be reported
                     # as if they came back from this agent network
                     "messages": ["/agent_network_editor", "/agent_network_query_generator", "/agent_network_instructions_editor"]

--- a/registries/agent_network_editor.hocon
+++ b/registries/agent_network_editor.hocon
@@ -188,7 +188,7 @@ Always respond with "Successfully created/edited the structure of the agent netw
 """,
             "allow": {
                 "to_upstream": {
-                    "sly_data": ["agent_network_definition", "agent_network_name", "mcp_servers", "subnetworks", "toolbox_info"]
+                    "sly_data": ["agent_network_definition", "agent_network_name", "mcp_servers", "subnetworks"]
                 }
             },
             "tools": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,36 +13,62 @@
 # limitations under the License.
 #
 # END COPYRIGHT
+# Note on the filename: conftest.py is the exact name pytest requires for
+# fixtures that apply automatically to every test under this directory —
+# pytest discovers and loads it by name, so it cannot be renamed to something
+# more descriptive without the autouse fixture below silently ceasing to run.
 import sys
 
 import pytest
 
+# Central inventory of the process-wide caches used by the Agent Network
+# Designer family, as (module, class, test-only clear method) triples. Each
+# cache lives on its owning class as a peek / get / clear-for-testing triple
+# (see ConnectivityDictionaryConverter.get_shared_toolbox_factory() for the
+# canonical pattern). Each captures file/env-var state at its first load and
+# is never refreshed, so a test that populates one would otherwise leak that
+# state into every later test in the same process, producing order-dependent
+# results. Add an entry here whenever a new shared cache is introduced.
+_PROCESS_CACHE_CLEARERS: list[tuple[str, str, str]] = [
+    # The loaded ToolboxFactory used for connectivity-style conversion
+    # of agent network definitions (issue #1262).
+    (
+        "coded_tools.agent_network_editor.connectivity_dictionary_converter",
+        "ConnectivityDictionaryConverter",
+        "clear_shared_toolbox_factory_for_testing",
+    ),
+    # The {tool_name: description} mapping parsed from the designer's
+    # toolbox info file (issue #1268).
+    (
+        "coded_tools.agent_network_editor.get_toolbox",
+        "GetToolbox",
+        "clear_shared_toolbox_info_for_testing",
+    ),
+]
 
-def _clear_shared_toolbox_factory():
+
+def _clear_process_caches():
     """
-    Clear ConnectivityDictionaryConverter's process-wide ToolboxFactory cache.
+    Clear every registered process-wide cache.
 
-    The module is looked up via sys.modules instead of imported directly so
-    tests that never touch the converter don't pay for importing neuro-san
+    Modules are looked up via sys.modules instead of imported directly so
+    tests that never touch these classes don't pay for importing neuro-san
     internals at collection time.
     """
-    module = sys.modules.get("coded_tools.agent_network_editor.connectivity_dictionary_converter")
-    if module is not None:
-        module.ConnectivityDictionaryConverter.clear_shared_toolbox_factory_for_testing()
+    for module_name, class_name, clear_method_name in _PROCESS_CACHE_CLEARERS:
+        module = sys.modules.get(module_name)
+        if module is not None:
+            getattr(getattr(module, class_name), clear_method_name)()
 
 
 @pytest.fixture(autouse=True)
-def reset_shared_toolbox_factory():
+def reset_process_caches():
     """
-    Clear the process-wide ToolboxFactory cache before and after each test.
+    Clear the process-wide caches before and after each test.
 
-    The cache captures AGENT_TOOLBOX_INFO_FILE at its first load and is never
-    refreshed, so without this reset a test that triggers a connectivity-style
-    progress report would leak its loaded factory (and the env-var state it was
-    built from) into every later test in the same process, producing
-    order-dependent results. Clearing before the test as well guards against
-    state populated outside any test, e.g. during collection or session setup.
+    Clearing before the test as well guards against state populated outside
+    any test, e.g. during collection or session setup.
     """
-    _clear_shared_toolbox_factory()
+    _clear_process_caches()
     yield
-    _clear_shared_toolbox_factory()
+    _clear_process_caches()


### PR DESCRIPTION
## Description

Fixes #1268.

`GetToolbox` cached the parsed toolbox info per **sly_data scope**, so a server handling N concurrent conversations re-read and re-parsed the same HOCON N times — once per conversation *and* once per validation pass that ran before the tool did (including `skip_designer` runs, which never populate sly_data at all). Worse, the parse ran on the shared event loop: `async_restore()` only makes the file *read* async — `deserialize_file_contents()` (pyhocon) runs synchronously — so under the 50x load test each cold parse stalled every in-flight conversation.

This PR moves the `{tool_name: description}` mapping to a process-wide cache on `GetToolbox`, using the same `peek / get / clear_for_testing` pattern as `ConnectivityDictionaryConverter`'s shared ToolboxFactory (#1262/#1275), with the one cold parse pushed off the event loop via `asyncio.to_thread()`. Riding along:

* **Persistence middleware pre-warm**: a cold `skip_designer` run never reports progress, so `ProgressHandler` isn't around to warm the shared ToolboxFactory before the connectivity-style export — the export's `from_dict()` fallback would pay that one-time load *on* the event loop. `aafter_agent` now pre-warms it through `to_thread` (and reads the progress-style env var once, passing it down).
* **Failure policy (from code review)**: a load failure is never published. A missing file returns empty *for that call only* and is retried next call, so a transient gap (deploy replacing the file, wrong-CWD launch) can't pin an empty toolbox for the life of the process — the cache heals the moment the file appears. A malformed file raises, also unpublished.
* Dead plumbing removed: the `toolbox_info` sly_data key, its `constants.py` entry, and its `to_upstream`/`from_downstream` allowlist entries in the designer/editor registries.
* `tests/conftest.py` now keeps a small registry of process-wide cache clearers (one entry per cache, cleared before/after each test) so the upcoming #1267/#1269 caches just add a line — plus a note on why the file must keep the pytest-mandated `conftest.py` name.

## Impact

Measured in the studio env:
* 50 concurrent cold conversations → **1** toolbox parse (was 50), and the parse happens in a worker thread (max event-loop stall during cold load ~13ms vs a 40–75ms on-loop block before).
* 1,000 warm calls complete in ~0.1ms total — the steady-state path is a lock-free attribute read plus a small defensive copy (`get_toolbox_info()` returns a copy so no caller can mutate the shared mapping).
* Missing-file scenario verified end-to-end: file absent → empty result per call, nothing cached → file restored → full toolbox served **without restart**.

Deliberate behavior changes to be aware of:
1. `AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE` is captured at first load; picking up an edited toolbox info file now requires a process restart (same trade-off already accepted for the shared ToolboxFactory in #1262).
2. `GetToolbox.get_toolbox_info()` no longer takes `sly_data`; the one caller (structure validation middleware) was updated.
3. Pre-seeding `sly_data["toolbox_info"]` from a client no longer overrides the toolbox (that undocumented channel also let a client bypass toolbox validation, so its removal is arguably a hardening — flagging it in case anything downstream relied on it).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
