### PR TITLE
Cache subnetwork names per process

### DIFF
--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -33,31 +33,6 @@ from coded_tools.agent_network_editor.shared_process_cache import SharedProcessC
 Connectivity = list[dict[str, Any]]
 
 
-def _load_shared_toolbox_factory() -> ContextTypeToolboxFactory:
-    """
-    Loader for the shared ToolboxFactory (runs inside SharedProcessCache).
-
-    The empty config dict is equivalent to the None that
-    DesignerNetworkInspector.get_config() returns: the context type defaults
-    to "langchain" and any AGENT_TOOLBOX_INFO_FILE env var override is still
-    honored inside ToolboxFactory.
-
-    Returning only after load() succeeds matters twice over (the cache
-    publishes nothing when this raises): on failure (e.g. a bad
-    AGENT_TOOLBOX_INFO_FILE) the next call retries instead of serving a
-    half-initialized factory, and — because neuro-san 0.6.83's
-    ToolboxFactory.load() guards itself with a plain `loaded` flag and no
-    lock — publishing a fully load()-ed instance is what makes
-    ConnectivityReporter's unconditional per-report load() call a safe no-op
-    on every thread that can see this factory.
-
-    :return: A fully load()-ed ContextTypeToolboxFactory.
-    """
-    factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory({})
-    factory.load()
-    return factory
-
-
 class ConnectivityDictionaryConverter(DictionaryConverter):
     """
     DictionaryConverter implementation for conversion back and forth from the
@@ -69,8 +44,33 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
     yet-another format.
     """
 
+    @staticmethod
+    def _load_shared_toolbox_factory() -> ContextTypeToolboxFactory:
+        """
+        Loader for the shared ToolboxFactory (runs inside SharedProcessCache).
+
+        The empty config dict is equivalent to the None that
+        DesignerNetworkInspector.get_config() returns: the context type defaults
+        to "langchain" and any AGENT_TOOLBOX_INFO_FILE env var override is still
+        honored inside ToolboxFactory.
+
+        Returning only after load() succeeds matters twice over (the cache
+        publishes nothing when this raises): on failure (e.g. a bad
+        AGENT_TOOLBOX_INFO_FILE) the next call retries instead of serving a
+        half-initialized factory, and — because neuro-san 0.6.83's
+        ToolboxFactory.load() guards itself with a plain `loaded` flag and no
+        lock — publishing a fully load()-ed instance is what makes
+        ConnectivityReporter's unconditional per-report load() call a safe no-op
+        on every thread that can see this factory.
+
+        :return: A fully load()-ed ContextTypeToolboxFactory.
+        """
+        factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory({})
+        factory.load()
+        return factory
+
     # Process-wide cache of the loaded ToolboxFactory used by from_dict() when
-    # no factory is passed to the constructor (issue #1262). The toolbox info
+    # no factory is passed to the constructor. The toolbox info
     # is loaded lazily on the first use in the process — the default file
     # ships inside the neuro-san package and the optional override comes from
     # the AGENT_TOOLBOX_INFO_FILE env var, both read at that first use — and

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -103,14 +103,6 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         self.toolbox_factory: ContextTypeToolboxFactory | None = toolbox_factory
 
     @classmethod
-    def peek_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory | None:
-        """
-        :return: The shared ToolboxFactory if it has already been loaded, else None.
-                Lock-free and safe to call from any thread or event loop.
-        """
-        return ConnectivityDictionaryConverter._shared_toolbox_factory_cache.peek()
-
-    @classmethod
     def get_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory:
         """
         Get the process-wide ToolboxFactory, creating and load()-ing it on first call.

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -14,7 +14,6 @@
 #
 # END COPYRIGHT
 from copy import deepcopy
-from threading import Lock
 from typing import Any
 
 from leaf_common.serialization.interface.dictionary_converter import DictionaryConverter
@@ -28,9 +27,35 @@ from neuro_san.internals.run_context.interfaces.agent_network_inspector import A
 from neuro_san.internals.validation.network.url_network_validator import UrlNetworkValidator
 
 from coded_tools.agent_network_editor.designer_network_inspector import DesignerNetworkInspector
+from coded_tools.agent_network_editor.shared_process_cache import SharedProcessCache
 
 # Type definition for sanity
 Connectivity = list[dict[str, Any]]
+
+
+def _load_shared_toolbox_factory() -> ContextTypeToolboxFactory:
+    """
+    Loader for the shared ToolboxFactory (runs inside SharedProcessCache).
+
+    The empty config dict is equivalent to the None that
+    DesignerNetworkInspector.get_config() returns: the context type defaults
+    to "langchain" and any AGENT_TOOLBOX_INFO_FILE env var override is still
+    honored inside ToolboxFactory.
+
+    Returning only after load() succeeds matters twice over (the cache
+    publishes nothing when this raises): on failure (e.g. a bad
+    AGENT_TOOLBOX_INFO_FILE) the next call retries instead of serving a
+    half-initialized factory, and — because neuro-san 0.6.83's
+    ToolboxFactory.load() guards itself with a plain `loaded` flag and no
+    lock — publishing a fully load()-ed instance is what makes
+    ConnectivityReporter's unconditional per-report load() call a safe no-op
+    on every thread that can see this factory.
+
+    :return: A fully load()-ed ContextTypeToolboxFactory.
+    """
+    factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory({})
+    factory.load()
+    return factory
 
 
 class ConnectivityDictionaryConverter(DictionaryConverter):
@@ -45,20 +70,20 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
     """
 
     # Process-wide cache of the loaded ToolboxFactory used by from_dict() when
-    # no factory is passed to the constructor. The toolbox info is loaded
-    # lazily on the first use in the process — the default file ships inside
-    # the neuro-san package and the optional override comes from the
-    # AGENT_TOOLBOX_INFO_FILE env var, both read at that first use — and is
-    # deliberately never refreshed: picking up an edited toolbox info file
-    # requires a process restart. (The pre-cache behavior of re-loading per
-    # conversation was an accident of sly_data scoping, not a supported
-    # hot-reload feature.)
-    _shared_toolbox_factory: ContextTypeToolboxFactory | None = None
-
-    # A threading.Lock rather than an asyncio.Lock: callers may run on
-    # different event loops in different threads, and an asyncio.Lock cannot
-    # be shared across event loops.
-    _shared_toolbox_factory_lock = Lock()
+    # no factory is passed to the constructor (issue #1262). The toolbox info
+    # is loaded lazily on the first use in the process — the default file
+    # ships inside the neuro-san package and the optional override comes from
+    # the AGENT_TOOLBOX_INFO_FILE env var, both read at that first use — and
+    # with no fingerprint it is deliberately never refreshed: picking up an
+    # edited toolbox info file requires a process restart. (The pre-cache
+    # behavior of re-loading per conversation was an accident of sly_data
+    # scoping, not a supported hot-reload feature.) Locking, publish ordering,
+    # and the async once-gate live in SharedProcessCache; access goes through
+    # the class by name (not cls) so a hypothetical subclass shares the one
+    # cache instead of splitting it.
+    _shared_toolbox_factory_cache: SharedProcessCache[ContextTypeToolboxFactory] = SharedProcessCache(
+        loader=_load_shared_toolbox_factory
+    )
 
     def __init__(
         self, include_keys: list[str] | None = None, toolbox_factory: ContextTypeToolboxFactory | None = None
@@ -81,12 +106,9 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
     def peek_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory | None:
         """
         :return: The shared ToolboxFactory if it has already been loaded, else None.
-                Lock-free and safe to call from any thread or event loop. Async
-                callers can use a None result to decide to run
-                get_shared_toolbox_factory() in a worker thread instead of on
-                the event loop.
+                Lock-free and safe to call from any thread or event loop.
         """
-        return ConnectivityDictionaryConverter._shared_toolbox_factory
+        return ConnectivityDictionaryConverter._shared_toolbox_factory_cache.peek()
 
     @classmethod
     def get_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory:
@@ -94,45 +116,28 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         Get the process-wide ToolboxFactory, creating and load()-ing it on first call.
 
         The first call in the process does file I/O plus a HOCON parse, so
-        async callers should check peek_shared_toolbox_factory() first and
-        reach this through asyncio.to_thread() on a miss. Once loaded, calls
-        return via a lock-free attribute read.
-
-        Note: cache access goes through the class by name (not cls) so a
-        hypothetical subclass shares the one cache instead of splitting it.
-        All reads funnel through peek_shared_toolbox_factory() so any future
-        cache policy (expiration, refresh) has a single interception point;
-        only the publish below touches the attribute directly.
+        this must not be called on an event loop — async callers use
+        aget_shared_toolbox_factory(), which keeps the cold load in a worker
+        thread. Once loaded, calls return via a lock-free read.
 
         :return: The shared, already-load()-ed ToolboxFactory instance.
         """
-        factory: ContextTypeToolboxFactory | None = ConnectivityDictionaryConverter.peek_shared_toolbox_factory()
-        if factory is not None:
-            # Lock-free fast path: the attribute is published only after a
-            # successful load() and reference reads are atomic under the GIL,
-            # so a non-None read always yields a fully loaded factory.
-            return factory
+        return ConnectivityDictionaryConverter._shared_toolbox_factory_cache.get()
 
-        with ConnectivityDictionaryConverter._shared_toolbox_factory_lock:
-            factory = ConnectivityDictionaryConverter.peek_shared_toolbox_factory()
-            if factory is None:
-                # The empty config dict is equivalent to the None that
-                # DesignerNetworkInspector.get_config() returns: the context
-                # type defaults to "langchain" and any AGENT_TOOLBOX_INFO_FILE
-                # env var override is still honored inside ToolboxFactory.
-                factory = MasterToolboxFactory.create_toolbox_factory({})
-                factory.load()
-                # Publish only after load() succeeds, for two reasons:
-                # * On failure (e.g. a bad AGENT_TOOLBOX_INFO_FILE) the cache
-                #   stays empty and the next call retries instead of serving a
-                #   half-initialized factory.
-                # * neuro-san 0.6.83's ToolboxFactory.load() guards itself with
-                #   a plain `loaded` flag and no lock, so publishing a fully
-                #   load()-ed instance is what makes ConnectivityReporter's
-                #   unconditional per-report load() call a safe no-op on every
-                #   thread that can see this factory. Do not reorder.
-                ConnectivityDictionaryConverter._shared_toolbox_factory = factory
-        return factory
+    @classmethod
+    async def aget_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory:
+        """
+        Async accessor for the process-wide ToolboxFactory: the one cold load
+        runs off the event loop (shared by concurrent cold callers); warm
+        calls return via the lock-free peek without awaiting.
+
+        This is the accessor async call sites should use — hand-rolling the
+        peek-then-to_thread dance per caller is how a caller forgets the
+        pre-warm and silently blocks the event loop on a cold process.
+
+        :return: The shared, already-load()-ed ToolboxFactory instance.
+        """
+        return await ConnectivityDictionaryConverter._shared_toolbox_factory_cache.aget()
 
     @classmethod
     def clear_shared_toolbox_factory_for_testing(cls):
@@ -146,10 +151,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         here rather than in conftest keeps all the singleton policy in this
         one class.
         """
-        # Taking the lock serializes the reset with a concurrent first load,
-        # so this can never unpublish a factory mid-initialization.
-        with ConnectivityDictionaryConverter._shared_toolbox_factory_lock:
-            ConnectivityDictionaryConverter._shared_toolbox_factory = None
+        ConnectivityDictionaryConverter._shared_toolbox_factory_cache.clear_for_testing()
 
     def to_dict(self, obj: Connectivity) -> dict[str, Any]:
         """

--- a/coded_tools/agent_network_editor/constants.py
+++ b/coded_tools/agent_network_editor/constants.py
@@ -29,10 +29,6 @@ AGENT_NETWORK_NAME: str = "agent_network_name"
 # Cached list of MCP server URLs available to the designer.
 MCP_SERVERS: str = "mcp_servers"
 
-# Cached list of external agent / subnetwork names (each in "/<name>" form). Populated by a lightweight
-# manifest-only parse so validators can check tool references without loading each subnetwork's full HOCON.
-SUBNETWORK_NAMES: str = "subnetwork_names"
-
 # Cached dict mapping external agent / subnetwork name to its front-man's description. Used when the editor needs to
 # surface available subnetworks (with descriptions) to the LLM.
 SUBNETWORKS: str = "subnetworks"

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -23,10 +23,10 @@ from typing import Any
 from leaf_common.config.config_filter_chain import ConfigFilterChain
 from neuro_san.interfaces.coded_tool import CodedTool
 from neuro_san.internals.graph.activations.branch_activation import BranchActivation
-from neuro_san.internals.graph.persistence.agent_filetree_mapper import AgentFileTreeMapper
 from neuro_san.internals.graph.persistence.manifest_dict_config_filter import ManifestDictConfigFilter
 from neuro_san.internals.graph.persistence.manifest_key_config_filter import ManifestKeyConfigFilter
 from neuro_san.internals.graph.persistence.raw_manifest_restorer import RawManifestRestorer
+from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
 from neuro_san.internals.graph.persistence.served_manifest_config_filter import ServedManifestConfigFilter
 from pyparsing.exceptions import ParseException
 
@@ -40,7 +40,10 @@ DEFAULT_MANIFEST_FILE = os.path.join("registries", "manifest_and.hocon")
 # Upper bound on how stale the shared subnetwork-names list can get from
 # changes a cheap probe cannot see (see _manifest_fingerprint below). One
 # manifest parse per window (~15-20ms, off the event loop) is the whole
-# steady-state refresh cost.
+# steady-state refresh cost. Deployment assumption: server deployments never
+# write the manifest at runtime — generated networks are only saved into the
+# local manifest on local runs — so this TTL exists to keep local runs fresh
+# after a save and otherwise acts as a safety net.
 SUBNETWORK_NAMES_TTL_SECONDS: float = 10.0
 
 logger = AndLogger(logging.getLogger(__name__))
@@ -73,7 +76,8 @@ def _manifest_fingerprint() -> tuple[str, int | None, int]:
     * a time bucket that rolls every SUBNETWORK_NAMES_TTL_SECONDS — the
       manifest composes other manifests via `include` (notably
       registries/generated/manifest.hocon, which grows every time the
-      designer saves a network), and a cheap probe cannot see those included
+      designer saves a network on a local run; server deployments never
+      write the manifest), and a cheap probe cannot see those included
       files, so the TTL bounds that staleness instead.
 
     :return: (path, mtime_ns or None, time bucket) tuple.
@@ -136,13 +140,12 @@ def _load_subnetwork_names() -> list[str]:
         filter_chain.register(ServedManifestConfigFilter(manifest_file, warn_on_skip=False, entry_for_skipped=False))
         one_manifest: dict[str, Any] = filter_chain.filter_config(raw_manifest)
 
-        # Derive external network names ("/<network_name>") via the canonical mapper used by
-        # neuro-san (matches RegistryManifestRestorer.find_external_network_names).
-        agent_mapper = AgentFileTreeMapper()
-        for manifest_key in one_manifest.keys():
-            agent_filepath: str = agent_mapper.agent_name_to_filepath(manifest_key)
-            network_name: str = agent_mapper.filepath_to_agent_network_name(agent_filepath)
-            names.append(f"/{network_name}")
+        # Derive external network names ("/<network_name>") via neuro-san's
+        # canonical implementation instead of re-rolling its mapper walk.
+        # Passing manifest_files explicitly keeps the constructor away from
+        # the server-wide AGENT_MANIFEST_FILE fallback; construction is cheap
+        # (it just stores the path and a default AgentFileTreeMapper).
+        names = RegistryManifestRestorer(manifest_files=manifest_file).find_external_network_names(one_manifest)
     except (ParseException, ValueError) as parse_error:
         # neuro-san's restorer deliberately re-wraps HOCON parse errors
         # (pyparsing ParseException, pyhocon ConfigException) as ValueError,
@@ -178,9 +181,10 @@ class GetSubnetwork(BranchActivation, CodedTool):
     # designer manifest (issue #1267). Previously cached per sly_data scope,
     # so a server handling N concurrent conversations re-parsed the same
     # manifest N times, on the event loop. Unlike the immortal toolbox
-    # caches, this source legitimately changes at runtime — the designer
-    # saves every generated network into a manifest the top file `include`s —
-    # so the fingerprint (path + mtime + TTL bucket, see
+    # caches, this source legitimately changes at runtime on local runs —
+    # the designer saves every generated network into a manifest the top
+    # file `include`s; server deployments persist elsewhere and never write
+    # it — so the fingerprint (path + mtime + TTL bucket, see
     # _manifest_fingerprint) keeps the list at most SUBNETWORK_NAMES_TTL_SECONDS
     # stale. Locking, publish ordering, and the async once-gate live in
     # SharedProcessCache; access goes through the class by name (not cls) so
@@ -188,17 +192,6 @@ class GetSubnetwork(BranchActivation, CodedTool):
     _shared_subnetwork_names_cache: SharedProcessCache[list[str]] = SharedProcessCache(
         loader=_load_subnetwork_names, fingerprint=_manifest_fingerprint
     )
-
-    @classmethod
-    def peek_shared_subnetwork_names(cls) -> list[str] | None:
-        """
-        :return: The shared subnetwork-names list if it has been loaded and is
-                still fresh, else None. Lock-free and safe to call from any
-                thread or event loop. Treat the result as read-only: it is
-                the live shared cache, not a copy — get_subnetwork_names()
-                returns a mutation-safe copy.
-        """
-        return GetSubnetwork._shared_subnetwork_names_cache.peek()
 
     @classmethod
     def clear_shared_subnetwork_names_for_testing(cls):

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -17,6 +17,7 @@
 import asyncio
 import logging
 import os
+from time import monotonic
 from typing import Any
 
 from leaf_common.config.config_filter_chain import ConfigFilterChain
@@ -30,12 +31,126 @@ from neuro_san.internals.graph.persistence.served_manifest_config_filter import 
 from pyparsing.exceptions import ParseException
 
 from coded_tools.agent_network_editor.and_logger import AndLogger
-from coded_tools.agent_network_editor.constants import SUBNETWORK_NAMES
 from coded_tools.agent_network_editor.constants import SUBNETWORKS
+from coded_tools.agent_network_editor.shared_process_cache import SharedProcessCache
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 DEFAULT_MANIFEST_FILE = os.path.join("registries", "manifest_and.hocon")
+
+# Upper bound on how stale the shared subnetwork-names list can get from
+# changes a cheap probe cannot see (see _manifest_fingerprint below). One
+# manifest parse per window (~15-20ms, off the event loop) is the whole
+# steady-state refresh cost.
+SUBNETWORK_NAMES_TTL_SECONDS: float = 10.0
+
 logger = AndLogger(logging.getLogger(__name__))
+
+
+def _resolve_manifest_file() -> str:
+    """
+    :return: The designer manifest path: the AGENT_NETWORK_DESIGNER_MANIFEST_FILE
+            env var, or the default. We use a designer-specific env var
+            (rather than AGENT_MANIFEST_FILE) so the designer's subnetwork
+            pool can be a narrow, curated subset of what the server hosts —
+            e.g. only industry/ + generated/ networks, not basic/, tools/,
+            experimental/, or the designer-family agents themselves. The
+            default points at manifest_and.hocon, which composes just those
+            two via `include`.
+    """
+    return os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE") or DEFAULT_MANIFEST_FILE
+
+
+def _manifest_fingerprint() -> tuple[str, int | None, int]:
+    """
+    Freshness probe for the shared subnetwork-names cache (see
+    SharedProcessCache): the cached list is served only while this value is
+    unchanged. Three components, each covering a different way the list can
+    go stale:
+
+    * the resolved path — an env-var change takes effect on the next read;
+    * the manifest file's mtime — a direct edit invalidates immediately, and
+      a missing manifest (mtime None) self-heals the moment the file appears;
+    * a time bucket that rolls every SUBNETWORK_NAMES_TTL_SECONDS — the
+      manifest composes other manifests via `include` (notably
+      registries/generated/manifest.hocon, which grows every time the
+      designer saves a network), and a cheap probe cannot see those included
+      files, so the TTL bounds that staleness instead.
+
+    :return: (path, mtime_ns or None, time bucket) tuple.
+    """
+    manifest_file: str = _resolve_manifest_file()
+    try:
+        mtime_ns: int | None = os.stat(manifest_file).st_mtime_ns
+    except OSError:
+        mtime_ns = None
+    time_bucket: int = int(monotonic() / SUBNETWORK_NAMES_TTL_SECONDS)
+    return (manifest_file, mtime_ns, time_bucket)
+
+
+def _load_subnetwork_names() -> list[str]:
+    """
+    Loader for the shared subnetwork-names list (runs inside
+    SharedProcessCache, off the event loop when reached via aget()).
+
+    Parses the designer manifest HOCON. pyhocon resolves `include`
+    statements, so composed manifests (e.g. manifest_and.hocon) flatten into
+    a single mapping of "path/to/file.hocon" -> enabled-bool-or-dict entries.
+
+    :return: List of subnetwork name strings (in "/<network_name>" form).
+            A missing or unparseable manifest returns an empty list, which IS
+            published: unlike an immortal cache this entry expires on its own
+            (mtime change or TTL bucket roll, whichever comes first), so a
+            bad manifest cannot poison the process beyond one TTL window —
+            and publishing the empty result prevents a per-call parse storm
+            within that window.
+    """
+    manifest_file: str = _resolve_manifest_file()
+
+    logger.info(">>>>>>>>>>>>>>>>>>>Getting Subnetwork Names from Manifest>>>>>>>>>>>>>>>>>>>")
+    logger.info("Manifest file: %s", manifest_file)
+
+    names: list[str] = []
+    try:
+        # RawManifestRestorer returns None if the file is missing — treated as
+        # an empty manifest (no subnetworks available).
+        raw_manifest: dict[str, Any] = RawManifestRestorer().restore(file_reference=manifest_file)
+        if raw_manifest is None:
+            logger.warning(
+                "Manifest file '%s' not found, no external agents/subnetworks will be available "
+                "in the generated network",
+                manifest_file,
+            )
+            raw_manifest = {}
+
+        # Use neuro-san's canonical manifest filters so we don't reimplement manifest semantics:
+        #   - ManifestKeyConfigFilter:    strips quote chars from quoted HOCON keys
+        #   - ManifestDictConfigFilter:   normalizes bool values to {"serve": ..., ...}
+        #   - ServedManifestConfigFilter: drops non-served entries
+        # We assemble our own chain rather than using ManifestFilterChain because the latter
+        # registers ServedManifestConfigFilter with warn_on_skip=True/entry_for_skipped=True,
+        # which would log a warning per disabled entry and keep them in the result. Here we
+        # want unserved entries silently dropped.
+        filter_chain = ConfigFilterChain()
+        filter_chain.register(ManifestKeyConfigFilter(manifest_file))
+        filter_chain.register(ManifestDictConfigFilter(manifest_file))
+        filter_chain.register(ServedManifestConfigFilter(manifest_file, warn_on_skip=False, entry_for_skipped=False))
+        one_manifest: dict[str, Any] = filter_chain.filter_config(raw_manifest)
+
+        # Derive external network names ("/<network_name>") via the canonical mapper used by
+        # neuro-san (matches RegistryManifestRestorer.find_external_network_names).
+        agent_mapper = AgentFileTreeMapper()
+        for manifest_key in one_manifest.keys():
+            agent_filepath: str = agent_mapper.agent_name_to_filepath(manifest_key)
+            network_name: str = agent_mapper.filepath_to_agent_network_name(agent_filepath)
+            names.append(f"/{network_name}")
+    except ParseException as parse_error:
+        logger.warning(
+            "Failed to parse manifest '%s', no subnetwork names will be available: %s",
+            manifest_file,
+            parse_error,
+        )
+
+    return names
 
 
 # pylint: disable=too-many-ancestors
@@ -55,91 +170,63 @@ class GetSubnetwork(BranchActivation, CodedTool):
     have access to a run_context (e.g. middleware classes).
     """
 
+    # Process-wide cache of the "/<network_name>" list parsed from the
+    # designer manifest (issue #1267). Previously cached per sly_data scope,
+    # so a server handling N concurrent conversations re-parsed the same
+    # manifest N times, on the event loop. Unlike the immortal toolbox
+    # caches, this source legitimately changes at runtime — the designer
+    # saves every generated network into a manifest the top file `include`s —
+    # so the fingerprint (path + mtime + TTL bucket, see
+    # _manifest_fingerprint) keeps the list at most SUBNETWORK_NAMES_TTL_SECONDS
+    # stale. Locking, publish ordering, and the async once-gate live in
+    # SharedProcessCache; access goes through the class by name (not cls) so
+    # a hypothetical subclass shares the one cache instead of splitting it.
+    _shared_subnetwork_names_cache: SharedProcessCache[list[str]] = SharedProcessCache(
+        loader=_load_subnetwork_names, fingerprint=_manifest_fingerprint
+    )
+
+    @classmethod
+    def peek_shared_subnetwork_names(cls) -> list[str] | None:
+        """
+        :return: The shared subnetwork-names list if it has been loaded and is
+                still fresh, else None. Lock-free and safe to call from any
+                thread or event loop. Treat the result as read-only: it is
+                the live shared cache, not a copy — get_subnetwork_names()
+                returns a mutation-safe copy.
+        """
+        return GetSubnetwork._shared_subnetwork_names_cache.peek()
+
+    @classmethod
+    def clear_shared_subnetwork_names_for_testing(cls):
+        """
+        Reset the process-wide subnetwork-names cache. For test isolation only.
+
+        Production code must never call this — staleness is already bounded
+        by the fingerprint. Tests call it (via tests/conftest.py) so names
+        loaded under one test's manifest/env state cannot leak into later
+        tests within the same TTL window. Living here rather than in conftest
+        keeps all the singleton policy in this one class.
+        """
+        GetSubnetwork._shared_subnetwork_names_cache.clear_for_testing()
+
     @staticmethod
-    async def get_subnetwork_names(sly_data: dict[str, Any]) -> list[str]:
+    async def get_subnetwork_names() -> list[str]:
         """
         Get the list of subnetwork names from the **designer manifest** only.
 
         Used by callers (e.g. middleware) that need to validate subnetwork references
         but do not have access to a run_context. Reads only the manifest HOCON, not
-        each subnetwork's HOCON.
+        each subnetwork's HOCON — and at most once per process per
+        SUBNETWORK_NAMES_TTL_SECONDS (or manifest edit), off the event loop,
+        shared by concurrent cold callers.
 
-        :param sly_data: The sly_data dictionary from the agent hierarchy. Acts as a
-                per-session cache via the `SUBNETWORK_NAMES` and `SUBNETWORKS` keys.
-                A `SlyDataLock` named "subnetwork_names_lock" is acquired here so
-                concurrent intra-session callers don't both parse the manifest.
         :return: List of subnetwork name strings (in "/<network_name>" form), or an
-                empty list if the manifest is missing or fails to parse. Empty results
-                are cached too so we don't keep retrying.
+                empty list if the manifest is missing or fails to parse (see
+                the loader for the self-healing semantics). The returned list
+                is a copy, so callers may mutate it without corrupting the
+                shared cache.
         """
-        # Lock per-sly_data so two concurrent intra-session callers don't both parse
-        # the manifest. Lock name is distinct from get_subnetworks() so the two methods
-        # don't block each other.
-        async with await SlyDataLock.get_lock(sly_data, "subnetwork_names_lock"):
-            # Per-session cache hit: if the full subnetwork dict was already loaded by
-            # get_subnetworks(), reuse its keys instead of re-reading the manifest.
-            if SUBNETWORKS in sly_data:
-                return list(sly_data[SUBNETWORKS].keys())
-            if SUBNETWORK_NAMES in sly_data:
-                return sly_data[SUBNETWORK_NAMES]
-
-            # We use a designer-specific env var (rather than AGENT_MANIFEST_FILE) so the designer's
-            # subnetwork pool can be a narrow, curated subset of what the server hosts — e.g. only
-            # industry/ + generated/ networks, not basic/, tools/, experimental/, or the
-            # designer-family agents themselves. Default points at manifest_and.hocon which composes
-            # just those two via `include`.
-            manifest_file: str = os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE") or DEFAULT_MANIFEST_FILE
-
-            logger.info(">>>>>>>>>>>>>>>>>>>Getting Subnetwork Names from Manifest>>>>>>>>>>>>>>>>>>>")
-            logger.info("Manifest file: %s", manifest_file)
-
-            # Parse the manifest HOCON. pyhocon resolves `include` statements, so composed manifests
-            # (e.g. manifest_and.hocon) flatten into a single mapping of
-            # "path/to/file.hocon" -> enabled-bool-or-dict entries. RawManifestRestorer returns None
-            # if the file is missing — treated as an empty manifest (no subnetworks available).
-            names: list[str] = []
-            try:
-                raw_manifest: dict[str, Any] = await RawManifestRestorer().async_restore(file_reference=manifest_file)
-                if raw_manifest is None:
-                    logger.warning(
-                        "Manifest file '%s' not found, no external agents/subnetworks will be available "
-                        "in the generated network",
-                        manifest_file,
-                    )
-                    raw_manifest = {}
-
-                # Use neuro-san's canonical manifest filters so we don't reimplement manifest semantics:
-                #   - ManifestKeyConfigFilter:    strips quote chars from quoted HOCON keys
-                #   - ManifestDictConfigFilter:   normalizes bool values to {"serve": ..., ...}
-                #   - ServedManifestConfigFilter: drops non-served entries
-                # We assemble our own chain rather than using ManifestFilterChain because the latter
-                # registers ServedManifestConfigFilter with warn_on_skip=True/entry_for_skipped=True,
-                # which would log a warning per disabled entry and keep them in the result. Here we
-                # want unserved entries silently dropped.
-                filter_chain = ConfigFilterChain()
-                filter_chain.register(ManifestKeyConfigFilter(manifest_file))
-                filter_chain.register(ManifestDictConfigFilter(manifest_file))
-                filter_chain.register(
-                    ServedManifestConfigFilter(manifest_file, warn_on_skip=False, entry_for_skipped=False)
-                )
-                one_manifest: dict[str, Any] = filter_chain.filter_config(raw_manifest)
-
-                # Derive external network names ("/<network_name>") via the canonical mapper used by
-                # neuro-san (matches RegistryManifestRestorer.find_external_network_names).
-                agent_mapper = AgentFileTreeMapper()
-                for manifest_key in one_manifest.keys():
-                    agent_filepath: str = agent_mapper.agent_name_to_filepath(manifest_key)
-                    network_name: str = agent_mapper.filepath_to_agent_network_name(agent_filepath)
-                    names.append(f"/{network_name}")
-            except ParseException as parse_error:
-                logger.warning(
-                    "Failed to parse manifest '%s', no subnetwork names will be available: %s",
-                    manifest_file,
-                    parse_error,
-                )
-
-            sly_data[SUBNETWORK_NAMES] = names
-        return names
+        return list(await GetSubnetwork._shared_subnetwork_names_cache.aget())
 
     async def get_subnetworks(self, sly_data: dict[str, Any]) -> dict[str, Any]:
         """
@@ -169,8 +256,9 @@ class GetSubnetwork(BranchActivation, CodedTool):
             if SUBNETWORKS in sly_data:
                 return sly_data[SUBNETWORKS]
 
-            # Get the curated subset of names from the designer manifest. Cheap and cached.
-            names: list[str] = await self.get_subnetwork_names(sly_data)
+            # Get the curated subset of names from the designer manifest.
+            # Cheap: served from the process-wide cache.
+            names: list[str] = await GetSubnetwork.get_subnetwork_names()
             if not names:
                 sly_data[SUBNETWORKS] = {}
                 return {}

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -49,117 +49,6 @@ SUBNETWORK_NAMES_TTL_SECONDS: float = 10.0
 logger = AndLogger(logging.getLogger(__name__))
 
 
-def _resolve_manifest_file() -> str:
-    """
-    :return: The designer manifest path: the AGENT_NETWORK_DESIGNER_MANIFEST_FILE
-            env var, or the default. We use a designer-specific env var
-            (rather than AGENT_MANIFEST_FILE) so the designer's subnetwork
-            pool can be a narrow, curated subset of what the server hosts —
-            e.g. only industry/ + generated/ networks, not basic/, tools/,
-            experimental/, or the designer-family agents themselves. The
-            default points at manifest_and.hocon, which composes just those
-            two via `include`.
-    """
-    return os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE") or DEFAULT_MANIFEST_FILE
-
-
-def _manifest_fingerprint() -> tuple[str, int | None, int]:
-    """
-    Freshness probe for the shared subnetwork-names cache (see
-    SharedProcessCache): the cached list is served only while this value is
-    unchanged. Three components, each covering a different way the list can
-    go stale:
-
-    * the resolved path — an env-var change takes effect on the next read;
-    * the manifest file's mtime — a direct edit invalidates immediately, and
-      a missing manifest (mtime None) self-heals the moment the file appears;
-    * a time bucket that rolls every SUBNETWORK_NAMES_TTL_SECONDS — the
-      manifest composes other manifests via `include` (notably
-      registries/generated/manifest.hocon, which grows every time the
-      designer saves a network on a local run; server deployments never
-      write the manifest), and a cheap probe cannot see those included
-      files, so the TTL bounds that staleness instead.
-
-    :return: (path, mtime_ns or None, time bucket) tuple.
-    """
-    manifest_file: str = _resolve_manifest_file()
-    try:
-        mtime_ns: int | None = os.stat(manifest_file).st_mtime_ns
-    except OSError:
-        mtime_ns = None
-    time_bucket: int = int(monotonic() / SUBNETWORK_NAMES_TTL_SECONDS)
-    return (manifest_file, mtime_ns, time_bucket)
-
-
-def _load_subnetwork_names() -> list[str]:
-    """
-    Loader for the shared subnetwork-names list (runs inside
-    SharedProcessCache, off the event loop when reached via aget()).
-
-    Parses the designer manifest HOCON. pyhocon resolves `include`
-    statements, so composed manifests (e.g. manifest_and.hocon) flatten into
-    a single mapping of "path/to/file.hocon" -> enabled-bool-or-dict entries.
-
-    :return: List of subnetwork name strings (in "/<network_name>" form).
-            A missing or unparseable manifest returns an empty list, which IS
-            published: unlike an immortal cache this entry expires on its own
-            (mtime change or TTL bucket roll, whichever comes first), so a
-            bad manifest cannot poison the process beyond one TTL window —
-            and publishing the empty result prevents a per-call parse storm
-            within that window.
-    """
-    manifest_file: str = _resolve_manifest_file()
-
-    logger.info(">>>>>>>>>>>>>>>>>>>Getting Subnetwork Names from Manifest>>>>>>>>>>>>>>>>>>>")
-    logger.info("Manifest file: %s", manifest_file)
-
-    names: list[str] = []
-    try:
-        # RawManifestRestorer returns None if the file is missing — treated as
-        # an empty manifest (no subnetworks available).
-        raw_manifest: dict[str, Any] = RawManifestRestorer().restore(file_reference=manifest_file)
-        if raw_manifest is None:
-            logger.warning(
-                "Manifest file '%s' not found, no external agents/subnetworks will be available "
-                "in the generated network",
-                manifest_file,
-            )
-            raw_manifest = {}
-
-        # Use neuro-san's canonical manifest filters so we don't reimplement manifest semantics:
-        #   - ManifestKeyConfigFilter:    strips quote chars from quoted HOCON keys
-        #   - ManifestDictConfigFilter:   normalizes bool values to {"serve": ..., ...}
-        #   - ServedManifestConfigFilter: drops non-served entries
-        # We assemble our own chain rather than using ManifestFilterChain because the latter
-        # registers ServedManifestConfigFilter with warn_on_skip=True/entry_for_skipped=True,
-        # which would log a warning per disabled entry and keep them in the result. Here we
-        # want unserved entries silently dropped.
-        filter_chain = ConfigFilterChain()
-        filter_chain.register(ManifestKeyConfigFilter(manifest_file))
-        filter_chain.register(ManifestDictConfigFilter(manifest_file))
-        filter_chain.register(ServedManifestConfigFilter(manifest_file, warn_on_skip=False, entry_for_skipped=False))
-        one_manifest: dict[str, Any] = filter_chain.filter_config(raw_manifest)
-
-        # Derive external network names ("/<network_name>") via neuro-san's
-        # canonical implementation instead of re-rolling its mapper walk.
-        # Passing manifest_files explicitly keeps the constructor away from
-        # the server-wide AGENT_MANIFEST_FILE fallback; construction is cheap
-        # (it just stores the path and a default AgentFileTreeMapper).
-        names = RegistryManifestRestorer(manifest_files=manifest_file).find_external_network_names(one_manifest)
-    except (ParseException, ValueError) as parse_error:
-        # neuro-san's restorer deliberately re-wraps HOCON parse errors
-        # (pyparsing ParseException, pyhocon ConfigException) as ValueError,
-        # so ValueError is what actually arrives here; ParseException stays
-        # in the tuple in case that wrapping ever goes away.
-        logger.warning(
-            "Failed to parse manifest '%s', no subnetwork names will be available: %s",
-            manifest_file,
-            parse_error,
-        )
-
-    return names
-
-
 # pylint: disable=too-many-ancestors
 class GetSubnetwork(BranchActivation, CodedTool):
     """
@@ -177,8 +66,121 @@ class GetSubnetwork(BranchActivation, CodedTool):
     have access to a run_context (e.g. middleware classes).
     """
 
+    @staticmethod
+    def _resolve_manifest_file() -> str:
+        """
+        :return: The designer manifest path: the AGENT_NETWORK_DESIGNER_MANIFEST_FILE
+                env var, or the default. We use a designer-specific env var
+                (rather than AGENT_MANIFEST_FILE) so the designer's subnetwork
+                pool can be a narrow, curated subset of what the server hosts —
+                e.g. only industry/ + generated/ networks, not basic/, tools/,
+                experimental/, or the designer-family agents themselves. The
+                default points at manifest_and.hocon, which composes just those
+                two via `include`.
+        """
+        return os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE") or DEFAULT_MANIFEST_FILE
+
+    @staticmethod
+    def _manifest_fingerprint() -> tuple[str, int | None, int]:
+        """
+        Freshness probe for the shared subnetwork-names cache (see
+        SharedProcessCache): the cached list is served only while this value is
+        unchanged. Three components, each covering a different way the list can
+        go stale:
+
+        * the resolved path — an env-var change takes effect on the next read;
+        * the manifest file's mtime — a direct edit invalidates immediately, and
+          a missing manifest (mtime None) self-heals the moment the file appears;
+        * a time bucket that rolls every SUBNETWORK_NAMES_TTL_SECONDS — the
+          manifest composes other manifests via `include` (notably
+          registries/generated/manifest.hocon, which grows every time the
+          designer saves a network on a local run; server deployments never
+          write the manifest), and a cheap probe cannot see those included
+          files, so the TTL bounds that staleness instead.
+
+        :return: (path, mtime_ns or None, time bucket) tuple.
+        """
+        manifest_file: str = GetSubnetwork._resolve_manifest_file()
+        try:
+            mtime_ns: int | None = os.stat(manifest_file).st_mtime_ns
+        except OSError:
+            mtime_ns = None
+        time_bucket: int = int(monotonic() / SUBNETWORK_NAMES_TTL_SECONDS)
+        return (manifest_file, mtime_ns, time_bucket)
+
+    @staticmethod
+    def _load_subnetwork_names() -> list[str]:
+        """
+        Loader for the shared subnetwork-names list (runs inside
+        SharedProcessCache, off the event loop when reached via aget()).
+
+        Parses the designer manifest HOCON. pyhocon resolves `include`
+        statements, so composed manifests (e.g. manifest_and.hocon) flatten into
+        a single mapping of "path/to/file.hocon" -> enabled-bool-or-dict entries.
+
+        :return: List of subnetwork name strings (in "/<network_name>" form).
+                A missing or unparseable manifest returns an empty list, which IS
+                published: unlike an immortal cache this entry expires on its own
+                (mtime change or TTL bucket roll, whichever comes first), so a
+                bad manifest cannot poison the process beyond one TTL window —
+                and publishing the empty result prevents a per-call parse storm
+                within that window.
+        """
+        manifest_file: str = GetSubnetwork._resolve_manifest_file()
+
+        logger.info(">>>>>>>>>>>>>>>>>>>Getting Subnetwork Names from Manifest>>>>>>>>>>>>>>>>>>>")
+        logger.info("Manifest file: %s", manifest_file)
+
+        names: list[str] = []
+        try:
+            # RawManifestRestorer returns None if the file is missing — treated as
+            # an empty manifest (no subnetworks available).
+            raw_manifest: dict[str, Any] = RawManifestRestorer().restore(file_reference=manifest_file)
+            if raw_manifest is None:
+                logger.warning(
+                    "Manifest file '%s' not found, no external agents/subnetworks will be available "
+                    "in the generated network",
+                    manifest_file,
+                )
+                raw_manifest = {}
+
+            # Use neuro-san's canonical manifest filters so we don't reimplement manifest semantics:
+            #   - ManifestKeyConfigFilter:    strips quote chars from quoted HOCON keys
+            #   - ManifestDictConfigFilter:   normalizes bool values to {"serve": ..., ...}
+            #   - ServedManifestConfigFilter: drops non-served entries
+            # We assemble our own chain rather than using ManifestFilterChain because the latter
+            # registers ServedManifestConfigFilter with warn_on_skip=True/entry_for_skipped=True,
+            # which would log a warning per disabled entry and keep them in the result. Here we
+            # want unserved entries silently dropped.
+            filter_chain = ConfigFilterChain()
+            filter_chain.register(ManifestKeyConfigFilter(manifest_file))
+            filter_chain.register(ManifestDictConfigFilter(manifest_file))
+            filter_chain.register(
+                ServedManifestConfigFilter(manifest_file, warn_on_skip=False, entry_for_skipped=False)
+            )
+            one_manifest: dict[str, Any] = filter_chain.filter_config(raw_manifest)
+
+            # Derive external network names ("/<network_name>") via neuro-san's
+            # canonical implementation instead of re-rolling its mapper walk.
+            # Passing manifest_files explicitly keeps the constructor away from
+            # the server-wide AGENT_MANIFEST_FILE fallback; construction is cheap
+            # (it just stores the path and a default AgentFileTreeMapper).
+            names = RegistryManifestRestorer(manifest_files=manifest_file).find_external_network_names(one_manifest)
+        except (ParseException, ValueError) as parse_error:
+            # neuro-san's restorer deliberately re-wraps HOCON parse errors
+            # (pyparsing ParseException, pyhocon ConfigException) as ValueError,
+            # so ValueError is what actually arrives here; ParseException stays
+            # in the tuple in case that wrapping ever goes away.
+            logger.warning(
+                "Failed to parse manifest '%s', no subnetwork names will be available: %s",
+                manifest_file,
+                parse_error,
+            )
+
+        return names
+
     # Process-wide cache of the "/<network_name>" list parsed from the
-    # designer manifest (issue #1267). Previously cached per sly_data scope,
+    # designer manifest. Previously cached per sly_data scope,
     # so a server handling N concurrent conversations re-parsed the same
     # manifest N times, on the event loop. Unlike the immortal toolbox
     # caches, this source legitimately changes at runtime on local runs —

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -143,7 +143,11 @@ def _load_subnetwork_names() -> list[str]:
             agent_filepath: str = agent_mapper.agent_name_to_filepath(manifest_key)
             network_name: str = agent_mapper.filepath_to_agent_network_name(agent_filepath)
             names.append(f"/{network_name}")
-    except ParseException as parse_error:
+    except (ParseException, ValueError) as parse_error:
+        # neuro-san's restorer deliberately re-wraps HOCON parse errors
+        # (pyparsing ParseException, pyhocon ConfigException) as ValueError,
+        # so ValueError is what actually arrives here; ParseException stays
+        # in the tuple in case that wrapping ever goes away.
         logger.warning(
             "Failed to parse manifest '%s', no subnetwork names will be available: %s",
             manifest_file,

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -16,17 +16,61 @@
 
 import logging
 import os
-from asyncio import to_thread
-from threading import Lock
 from typing import Any
 
 from neuro_san.interfaces.coded_tool import CodedTool
 from neuro_san.internals.run_context.langchain.toolbox.toolbox_info_restorer import ToolboxInfoRestorer
 
 from coded_tools.agent_network_editor.and_logger import AndLogger
+from coded_tools.agent_network_editor.shared_process_cache import SharedProcessCache
 
 DEFAULT_TOOLBOX_INFO_FILE = os.path.join("neuro_san_studio", "toolbox", "agent_network_designer_toolbox_info.hocon")
 logger = AndLogger(logging.getLogger(__name__))
+
+
+def _load_shared_toolbox_info() -> dict[str, str]:
+    """
+    Loader for the shared toolbox info (runs inside SharedProcessCache).
+
+    Resolves the toolbox info file — the AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE
+    env var or the default — reads and parses it, and reduces each entry to its
+    description.
+
+    :return: dict mapping tool names to descriptions.
+    :raise FileNotFoundError: When the file does not exist (after logging a
+            warning with the resolved path). The cache publishes nothing on a
+            raise, so a transient gap — a deploy replacing the file, a
+            wrong-CWD launch — cannot pin an empty toolbox for the life of
+            the process: the next call retries and heals the moment the file
+            appears. A malformed file raises out of the parse, likewise
+            unpublished.
+    """
+    # Check for toolbox info file in env var
+    toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE")
+    if not toolbox_info_file:
+        # Use a default if no value specified
+        toolbox_info_file = DEFAULT_TOOLBOX_INFO_FILE
+
+    # Go fish — once per process once it succeeds.
+    logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from Toolbox>>>>>>>>>>>>>>>>>>>")
+    logger.info("Toolbox info file: %s", toolbox_info_file)
+
+    try:
+        raw_tools: dict[str, Any] = ToolboxInfoRestorer().restore(toolbox_info_file)
+    except FileNotFoundError:
+        # The warning lives here because only the loader knows the resolved
+        # path; the callers' policy (return empty for this call) lives with
+        # them. The recurring warning is the operator's signal.
+        logger.warning("Error: Failed to load toolbox info from %s.", toolbox_info_file)
+        raise
+
+    logger.info("Successfully loaded the following toolbox: %s", str(raw_tools))
+
+    # Keep only each tool's description.
+    tools: dict[str, str] = {}
+    for tool_name, tool_info in raw_tools.items():
+        tools[tool_name] = tool_info.get("description", "")
+    return tools
 
 
 class GetToolbox(CodedTool):
@@ -34,110 +78,53 @@ class GetToolbox(CodedTool):
     CodedTool implementation which provides a way to get tool definition from toolbox info file
     """
 
-    # Process-wide cache of the {tool_name: description} mapping parsed from the
-    # toolbox info file (issue #1268). The file path — the
-    # AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE env var or the default — is
-    # resolved at first use and the parse happens once per process; the cache is
-    # deliberately never refreshed, so picking up an edited toolbox info file
-    # requires a process restart. This is the same trade-off already made for
+    # Process-wide cache of the {tool_name: description} mapping parsed from
+    # the toolbox info file (issue #1268). With no fingerprint the mapping is
+    # deliberately never refreshed once loaded, so picking up an edited
+    # toolbox info file requires a process restart — the same trade-off as
     # ConnectivityDictionaryConverter's shared ToolboxFactory. Previously the
     # cache lived in sly_data, so a server handling N concurrent conversations
-    # re-parsed the same HOCON N times, on the event loop.
-    _shared_toolbox_info: dict[str, str] | None = None
-
-    # A threading.Lock rather than an asyncio.Lock: callers may run on
-    # different event loops in different threads, and an asyncio.Lock cannot
-    # be shared across event loops.
-    _shared_toolbox_info_lock = Lock()
+    # re-parsed the same HOCON N times, on the event loop. Locking, publish
+    # ordering, and the async once-gate live in SharedProcessCache; access
+    # goes through the class by name (not cls) so a hypothetical subclass
+    # shares the one cache instead of splitting it.
+    _shared_toolbox_info_cache: SharedProcessCache[dict[str, str]] = SharedProcessCache(
+        loader=_load_shared_toolbox_info
+    )
 
     @classmethod
     def peek_shared_toolbox_info(cls) -> dict[str, str] | None:
         """
-        :return: The shared toolbox info if it has already been loaded, else None.
-                Lock-free and safe to call from any thread or event loop. Async
-                callers can use a None result to decide to run
-                get_shared_toolbox_info() in a worker thread instead of on the
-                event loop. Treat the result as read-only: it is the live
-                shared cache, not a copy — mutating it corrupts every
-                conversation in the process. get_toolbox_info() returns a
-                mutation-safe copy.
+        :return: The shared toolbox info if it has already been loaded, else
+                None. Lock-free and safe to call from any thread or event
+                loop. Treat the result as read-only: it is the live shared
+                cache, not a copy — mutating it corrupts every conversation
+                in the process. get_toolbox_info() returns a mutation-safe
+                copy.
         """
-        return GetToolbox._shared_toolbox_info
+        return GetToolbox._shared_toolbox_info_cache.peek()
 
     @classmethod
     def get_shared_toolbox_info(cls) -> dict[str, str]:
         """
-        Get the process-wide toolbox info, reading and parsing the file on first call.
+        Get the process-wide toolbox info, reading and parsing the file on
+        first call.
 
         The first call in the process does file I/O plus a HOCON parse, so
-        async callers should check peek_shared_toolbox_info() first and reach
-        this through asyncio.to_thread() on a miss. Once loaded, calls return
-        via a lock-free read.
+        this must not be called on an event loop — async callers use
+        get_toolbox_info(), which keeps the cold load in a worker thread.
 
-        Note: cache access goes through the class by name (not cls) so a
-        hypothetical subclass shares the one cache instead of splitting it.
-        All reads funnel through peek_shared_toolbox_info() so any future
-        cache policy (expiration, refresh) has a single interception point;
-        only the publishes below touch the attribute directly.
-
-        :return: dict mapping tool names to descriptions; empty if the toolbox
-                info file does not exist. Failures are never published: a
-                missing file returns empty for this call only and the next
-                call retries, so a transient gap (a deploy replacing the file,
-                a not-yet-mounted volume) cannot pin an empty toolbox for the
-                life of the process. A malformed file raises out of the parse,
-                also unpublished. Treat the result as read-only: it is the
-                live shared cache, not a copy — get_toolbox_info() returns a
-                mutation-safe copy.
+        :return: dict mapping tool names to descriptions; empty if the
+                toolbox info file does not exist (retried on the next call,
+                never cached — see the loader). A malformed file raises.
+                Treat the result as read-only: it is the live shared cache,
+                not a copy — get_toolbox_info() returns a mutation-safe copy.
         """
-        tools: dict[str, str] | None = GetToolbox.peek_shared_toolbox_info()
-        if tools is not None:
-            # Lock-free fast path: the attribute is published only after a
-            # fully successful load-and-clean, and reference reads are atomic
-            # under the GIL, so a non-None read always yields a complete dict.
-            return tools
-
-        with GetToolbox._shared_toolbox_info_lock:
-            tools = GetToolbox.peek_shared_toolbox_info()
-            if tools is not None:
-                return tools
-
-            # Check for toolbox info file in env var
-            toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE")
-            if not toolbox_info_file:
-                # Use a default if no value specified
-                toolbox_info_file = DEFAULT_TOOLBOX_INFO_FILE
-
-            # Go fish — once per process once it succeeds.
-            logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from Toolbox>>>>>>>>>>>>>>>>>>>")
-            logger.info("Toolbox info file: %s", toolbox_info_file)
-
-            try:
-                raw_tools: dict[str, Any] = ToolboxInfoRestorer().restore(toolbox_info_file)
-            except FileNotFoundError:
-                # Return empty WITHOUT publishing: caching the failure would
-                # serve an empty toolbox to every conversation until process
-                # restart, even after an operator restores the file (deploy
-                # races and wrong-CWD launches make a missing file a transient
-                # condition). The retry costs one failed open per call, and
-                # the recurring warning is the operator's signal.
-                logger.warning("Error: Failed to load toolbox info from %s.", toolbox_info_file)
-                return {}
-
-            logger.info("Successfully loaded the following toolbox: %s", str(raw_tools))
-
-            # Keep only each tool's description.
-            tools = {}
-            for tool_name, tool_info in raw_tools.items():
-                tools[tool_name] = tool_info.get("description", "")
-
-            # Publish only after the load-and-clean fully succeeded. Parse
-            # errors propagate out of the restore above without publishing,
-            # so a transiently broken file is retried on the next call
-            # instead of poisoning the cache.
-            GetToolbox._shared_toolbox_info = tools
-
-        return tools
+        try:
+            return GetToolbox._shared_toolbox_info_cache.get()
+        except FileNotFoundError:
+            # Already logged by the loader with the resolved path.
+            return {}
 
     @classmethod
     def clear_shared_toolbox_info_for_testing(cls):
@@ -151,28 +138,25 @@ class GetToolbox(CodedTool):
         tests. Living here rather than in conftest keeps all the singleton
         policy in this one class.
         """
-        # Taking the lock serializes the reset with a concurrent first load,
-        # so this can never unpublish a mapping mid-initialization.
-        with GetToolbox._shared_toolbox_info_lock:
-            GetToolbox._shared_toolbox_info = None
+        GetToolbox._shared_toolbox_info_cache.clear_for_testing()
 
     @staticmethod
     async def get_toolbox_info() -> dict[str, str]:
         """
         Read toolbox info from the process-wide cache, loading it from a file
-        on the first call in the process.
+        on the first call in the process. The cold load runs off the event
+        loop and is shared by concurrent cold callers.
 
         :return: dict mapping tool names to descriptions; empty if the toolbox
                 info file does not exist (retried on the next call, never
                 cached). A malformed file raises. The returned dict is a copy,
                 so callers may mutate it without corrupting the shared cache.
         """
-        tools: dict[str, str] | None = GetToolbox.peek_shared_toolbox_info()
-        if tools is None:
-            # Cold path — once per process on success, once per call while
-            # the file is missing: keep the file read and HOCON parse off
-            # the event loop.
-            tools = await to_thread(GetToolbox.get_shared_toolbox_info)
+        try:
+            tools: dict[str, str] = await GetToolbox._shared_toolbox_info_cache.aget()
+        except FileNotFoundError:
+            # Already logged by the loader with the resolved path.
+            return {}
         return dict(tools)
 
     async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any]:

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -93,40 +93,6 @@ class GetToolbox(CodedTool):
     )
 
     @classmethod
-    def peek_shared_toolbox_info(cls) -> dict[str, str] | None:
-        """
-        :return: The shared toolbox info if it has already been loaded, else
-                None. Lock-free and safe to call from any thread or event
-                loop. Treat the result as read-only: it is the live shared
-                cache, not a copy — mutating it corrupts every conversation
-                in the process. get_toolbox_info() returns a mutation-safe
-                copy.
-        """
-        return GetToolbox._shared_toolbox_info_cache.peek()
-
-    @classmethod
-    def get_shared_toolbox_info(cls) -> dict[str, str]:
-        """
-        Get the process-wide toolbox info, reading and parsing the file on
-        first call.
-
-        The first call in the process does file I/O plus a HOCON parse, so
-        this must not be called on an event loop — async callers use
-        get_toolbox_info(), which keeps the cold load in a worker thread.
-
-        :return: dict mapping tool names to descriptions; empty if the
-                toolbox info file does not exist (retried on the next call,
-                never cached — see the loader). A malformed file raises.
-                Treat the result as read-only: it is the live shared cache,
-                not a copy — get_toolbox_info() returns a mutation-safe copy.
-        """
-        try:
-            return GetToolbox._shared_toolbox_info_cache.get()
-        except FileNotFoundError:
-            # Already logged by the loader with the resolved path.
-            return {}
-
-    @classmethod
     def clear_shared_toolbox_info_for_testing(cls):
         """
         Reset the process-wide toolbox info cache. For test isolation only.

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -28,58 +28,58 @@ DEFAULT_TOOLBOX_INFO_FILE = os.path.join("neuro_san_studio", "toolbox", "agent_n
 logger = AndLogger(logging.getLogger(__name__))
 
 
-def _load_shared_toolbox_info() -> dict[str, str]:
-    """
-    Loader for the shared toolbox info (runs inside SharedProcessCache).
-
-    Resolves the toolbox info file — the AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE
-    env var or the default — reads and parses it, and reduces each entry to its
-    description.
-
-    :return: dict mapping tool names to descriptions.
-    :raise FileNotFoundError: When the file does not exist (after logging a
-            warning with the resolved path). The cache publishes nothing on a
-            raise, so a transient gap — a deploy replacing the file, a
-            wrong-CWD launch — cannot pin an empty toolbox for the life of
-            the process: the next call retries and heals the moment the file
-            appears. A malformed file raises out of the parse, likewise
-            unpublished.
-    """
-    # Check for toolbox info file in env var
-    toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE")
-    if not toolbox_info_file:
-        # Use a default if no value specified
-        toolbox_info_file = DEFAULT_TOOLBOX_INFO_FILE
-
-    # Go fish — once per process once it succeeds.
-    logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from Toolbox>>>>>>>>>>>>>>>>>>>")
-    logger.info("Toolbox info file: %s", toolbox_info_file)
-
-    try:
-        raw_tools: dict[str, Any] = ToolboxInfoRestorer().restore(toolbox_info_file)
-    except FileNotFoundError:
-        # The warning lives here because only the loader knows the resolved
-        # path; the callers' policy (return empty for this call) lives with
-        # them. The recurring warning is the operator's signal.
-        logger.warning("Error: Failed to load toolbox info from %s.", toolbox_info_file)
-        raise
-
-    logger.info("Successfully loaded the following toolbox: %s", str(raw_tools))
-
-    # Keep only each tool's description.
-    tools: dict[str, str] = {}
-    for tool_name, tool_info in raw_tools.items():
-        tools[tool_name] = tool_info.get("description", "")
-    return tools
-
-
 class GetToolbox(CodedTool):
     """
     CodedTool implementation which provides a way to get tool definition from toolbox info file
     """
 
+    @staticmethod
+    def _load_shared_toolbox_info() -> dict[str, str]:
+        """
+        Loader for the shared toolbox info (runs inside SharedProcessCache).
+
+        Resolves the toolbox info file — the AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE
+        env var or the default — reads and parses it, and reduces each entry to its
+        description.
+
+        :return: dict mapping tool names to descriptions.
+        :raise FileNotFoundError: When the file does not exist (after logging a
+                warning with the resolved path). The cache publishes nothing on a
+                raise, so a transient gap — a deploy replacing the file, a
+                wrong-CWD launch — cannot pin an empty toolbox for the life of
+                the process: the next call retries and heals the moment the file
+                appears. A malformed file raises out of the parse, likewise
+                unpublished.
+        """
+        # Check for toolbox info file in env var
+        toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE")
+        if not toolbox_info_file:
+            # Use a default if no value specified
+            toolbox_info_file = DEFAULT_TOOLBOX_INFO_FILE
+
+        # Go fish — once per process once it succeeds.
+        logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from Toolbox>>>>>>>>>>>>>>>>>>>")
+        logger.info("Toolbox info file: %s", toolbox_info_file)
+
+        try:
+            raw_tools: dict[str, Any] = ToolboxInfoRestorer().restore(toolbox_info_file)
+        except FileNotFoundError:
+            # The warning lives here because only the loader knows the resolved
+            # path; the callers' policy (return empty for this call) lives with
+            # them. The recurring warning is the operator's signal.
+            logger.warning("Error: Failed to load toolbox info from %s.", toolbox_info_file)
+            raise
+
+        logger.info("Successfully loaded the following toolbox: %s", str(raw_tools))
+
+        # Keep only each tool's description.
+        tools: dict[str, str] = {}
+        for tool_name, tool_info in raw_tools.items():
+            tools[tool_name] = tool_info.get("description", "")
+        return tools
+
     # Process-wide cache of the {tool_name: description} mapping parsed from
-    # the toolbox info file (issue #1268). With no fingerprint the mapping is
+    # the toolbox info file. With no fingerprint the mapping is
     # deliberately never refreshed once loaded, so picking up an edited
     # toolbox info file requires a process restart — the same trade-off as
     # ConnectivityDictionaryConverter's shared ToolboxFactory. Previously the

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -42,14 +42,15 @@ class GetToolbox(CodedTool):
         env var or the default — reads and parses it, and reduces each entry to its
         description.
 
-        :return: dict mapping tool names to descriptions.
-        :raise FileNotFoundError: When the file does not exist (after logging a
-                warning with the resolved path). The cache publishes nothing on a
-                raise, so a transient gap — a deploy replacing the file, a
-                wrong-CWD launch — cannot pin an empty toolbox for the life of
-                the process: the next call retries and heals the moment the file
-                appears. A malformed file raises out of the parse, likewise
-                unpublished.
+        :return: dict mapping tool names to descriptions; never empty.
+        :raise FileNotFoundError: When the file does not exist, or when it
+                yields no tools at all (after logging a warning with the
+                resolved path). The cache publishes nothing on a raise, so a
+                transient gap — a deploy replacing the file, a wrong-CWD
+                launch, a read that comes back empty — cannot pin an empty
+                toolbox for the life of the process: the next call retries
+                and heals the moment the file reads correctly. A malformed
+                file raises out of the parse, likewise unpublished.
         """
         # Check for toolbox info file in env var
         toolbox_info_file: str = os.getenv("AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE")
@@ -76,6 +77,18 @@ class GetToolbox(CodedTool):
         tools: dict[str, str] = {}
         for tool_name, tool_info in raw_tools.items():
             tools[tool_name] = tool_info.get("description", "")
+
+        if not tools:
+            # The designer's toolbox file always defines tools, so an empty
+            # mapping only ever means the read went wrong — observed in the
+            # wild as a one-off restore() returning {} that this cache (no
+            # fingerprint) then pinned until a server restart. Raising
+            # instead of returning keeps the empty result unpublished: this
+            # call degrades to an empty toolbox, and the next call retries
+            # and heals. FileNotFoundError so callers' existing
+            # missing-file policy applies unchanged.
+            logger.warning("Toolbox info from %s came back empty; treating as a failed load.", toolbox_info_file)
+            raise FileNotFoundError(f"Toolbox info file {toolbox_info_file} yielded no tools")
         return tools
 
     # Process-wide cache of the {tool_name: description} mapping parsed from

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -17,9 +17,9 @@
 Inventory of every process-wide global cache in the Agent Network Designer
 family: what each one holds, where it lives, how it expires, and who reads it.
 
-Add an entry (comment block + registry triple) whenever a new process-wide
-global is introduced. The shared mechanism — locking, publish ordering,
-freshness fingerprints, the async once-gate — lives in
+Add an entry (comment block + registry triple in ProcessGlobals) whenever a
+new process-wide global is introduced. The shared mechanism — locking,
+publish ordering, freshness fingerprints, the async once-gate — lives in
 shared_process_cache.SharedProcessCache; each cache's policy lives on its
 owning class; this module is the map of all of them.
 
@@ -32,89 +32,96 @@ imports.
 
 import sys
 
-# ---------------------------------------------------------------------------
-# 1. Shared ToolboxFactory (issue #1262)
-#    Holds:   a load()-ed neuro-san ContextTypeToolboxFactory used to render
-#             connectivity-style views of agent network definitions.
-#    Lives:   connectivity_dictionary_converter.ConnectivityDictionaryConverter
-#             (get_/aget_shared_toolbox_factory)
-#    Expiry:  none — loaded once; restart to pick up an edited
-#             AGENT_TOOLBOX_INFO_FILE.
-#    Used by: ConnectivityDictionaryConverter.from_dict() (fallback when no
-#             factory was passed in);
-#             progress_handler.ProgressHandler._send_report() (pre-warm before
-#             connectivity conversion);
-#             agent_network_persistence_middleware.AgentNetworkPersistenceMiddleware
-#             .aafter_agent() (pre-warm before the skip_designer-safe export).
-#
-# 2. Shared toolbox info (issue #1268)
-#    Holds:   the {tool_name: description} mapping parsed from the designer's
-#             toolbox info file (AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE).
-#    Lives:   get_toolbox.GetToolbox (async get_toolbox_info)
-#    Expiry:  none — loaded once (a missing file is retried, never cached);
-#             restart to pick up edits.
-#    Used by: GetToolbox.async_invoke() (the coded tool the editor LLM calls);
-#             agent_network_structure_validation_middleware
-#             .AgentNetworkStructureValidationMiddleware.validate().
-#
-# 3. Shared subnetwork names (issue #1267)
-#    Holds:   the "/<network_name>" list parsed from the designer manifest
-#             (AGENT_NETWORK_DESIGNER_MANIFEST_FILE).
-#    Lives:   get_subnetwork.GetSubnetwork (async get_subnetwork_names)
-#    Expiry:  manifest path/mtime change, or at most
-#             get_subnetwork.SUBNETWORK_NAMES_TTL_SECONDS (the manifest
-#             `include`s other manifests a cheap probe cannot see, notably
-#             registries/generated/manifest.hocon which grows as the designer
-#             saves networks on local runs; server deployments never write
-#             the manifest at runtime).
-#    Used by: GetSubnetwork.get_subnetworks() (the coded tool path);
-#             agent_network_structure_validation_middleware
-#             .AgentNetworkStructureValidationMiddleware.validate();
-#             agent_network_persistence_middleware.AgentNetworkPersistenceMiddleware
-#             ._assemble_and_persist().
-# ---------------------------------------------------------------------------
 
-# Machine-readable registry of the entries above, as
-# (module, class, test-only clear method) triples consumed by
-# clear_all_process_globals_for_testing() below.
-PROCESS_GLOBALS: list[tuple[str, str, str]] = [
-    (
-        "coded_tools.agent_network_editor.connectivity_dictionary_converter",
-        "ConnectivityDictionaryConverter",
-        "clear_shared_toolbox_factory_for_testing",
-    ),
-    (
-        "coded_tools.agent_network_editor.get_toolbox",
-        "GetToolbox",
-        "clear_shared_toolbox_info_for_testing",
-    ),
-    (
-        "coded_tools.agent_network_editor.get_subnetwork",
-        "GetSubnetwork",
-        "clear_shared_subnetwork_names_for_testing",
-    ),
-]
-
-
-def clear_all_process_globals_for_testing():
+class ProcessGlobals:  # pylint: disable=too-few-public-methods
     """
-    Clear every cache registered in PROCESS_GLOBALS. For test isolation only
-    (tests/conftest.py runs this around every test).
-
-    Production code must never call this: each cache is deliberately
-    load-once (or self-expiring) per the policies above. Each captures file
-    and env-var state at its first load, so without clearing between tests a
-    test that populates one would leak that state into every later test in
-    the same process, producing order-dependent results.
-
-    Modules are looked up via sys.modules instead of imported directly so a
-    test run that never touches these classes doesn't pay for importing
-    neuro-san internals, and pytest collection stays light. A module absent
-    from sys.modules was never imported, so its cache cannot be populated —
-    skipping it is correct, not merely convenient. A typo'd class or method
-    name still fails loudly via getattr whenever the module IS loaded.
+    The registry of process-wide global caches, documented entry by entry
+    below, plus the test-only helper that clears them all.
     """
-    for module_name, class_name, clear_method_name in PROCESS_GLOBALS:
-        module = sys.modules.get(module_name)
-        if module is not None:
-            getattr(getattr(module, class_name), clear_method_name)()
+
+    # -----------------------------------------------------------------------
+    # 1. Shared ToolboxFactory
+    #    Holds:   a load()-ed neuro-san ContextTypeToolboxFactory used to render
+    #             connectivity-style views of agent network definitions.
+    #    Lives:   connectivity_dictionary_converter.ConnectivityDictionaryConverter
+    #             (get_/aget_shared_toolbox_factory)
+    #    Expiry:  none — loaded once; restart to pick up an edited
+    #             AGENT_TOOLBOX_INFO_FILE.
+    #    Used by: ConnectivityDictionaryConverter.from_dict() (fallback when no
+    #             factory was passed in);
+    #             progress_handler.ProgressHandler._send_report() (pre-warm before
+    #             connectivity conversion);
+    #             agent_network_persistence_middleware.AgentNetworkPersistenceMiddleware
+    #             .aafter_agent() (pre-warm before the skip_designer-safe export).
+    #
+    # 2. Shared toolbox info
+    #    Holds:   the {tool_name: description} mapping parsed from the designer's
+    #             toolbox info file (AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE).
+    #    Lives:   get_toolbox.GetToolbox (async get_toolbox_info)
+    #    Expiry:  none — loaded once (a missing file is retried, never cached);
+    #             restart to pick up edits.
+    #    Used by: GetToolbox.async_invoke() (the coded tool the editor LLM calls);
+    #             agent_network_structure_validation_middleware
+    #             .AgentNetworkStructureValidationMiddleware.validate().
+    #
+    # 3. Shared subnetwork names
+    #    Holds:   the "/<network_name>" list parsed from the designer manifest
+    #             (AGENT_NETWORK_DESIGNER_MANIFEST_FILE).
+    #    Lives:   get_subnetwork.GetSubnetwork (async get_subnetwork_names)
+    #    Expiry:  manifest path/mtime change, or at most
+    #             get_subnetwork.SUBNETWORK_NAMES_TTL_SECONDS (the manifest
+    #             `include`s other manifests a cheap probe cannot see, notably
+    #             registries/generated/manifest.hocon which grows as the designer
+    #             saves networks on local runs; server deployments never write
+    #             the manifest at runtime).
+    #    Used by: GetSubnetwork.get_subnetworks() (the coded tool path);
+    #             agent_network_structure_validation_middleware
+    #             .AgentNetworkStructureValidationMiddleware.validate();
+    #             agent_network_persistence_middleware.AgentNetworkPersistenceMiddleware
+    #             ._assemble_and_persist().
+    # -----------------------------------------------------------------------
+
+    # Machine-readable registry of the entries above, as
+    # (module, class, test-only clear method) triples consumed by
+    # clear_all_for_testing() below.
+    REGISTRY: list[tuple[str, str, str]] = [
+        (
+            "coded_tools.agent_network_editor.connectivity_dictionary_converter",
+            "ConnectivityDictionaryConverter",
+            "clear_shared_toolbox_factory_for_testing",
+        ),
+        (
+            "coded_tools.agent_network_editor.get_toolbox",
+            "GetToolbox",
+            "clear_shared_toolbox_info_for_testing",
+        ),
+        (
+            "coded_tools.agent_network_editor.get_subnetwork",
+            "GetSubnetwork",
+            "clear_shared_subnetwork_names_for_testing",
+        ),
+    ]
+
+    @staticmethod
+    def clear_all_for_testing():
+        """
+        Clear every cache registered in REGISTRY. For test isolation only
+        (tests/conftest.py runs this around every test).
+
+        Production code must never call this: each cache is deliberately
+        load-once (or self-expiring) per the policies above. Each captures file
+        and env-var state at its first load, so without clearing between tests a
+        test that populates one would leak that state into every later test in
+        the same process, producing order-dependent results.
+
+        Modules are looked up via sys.modules instead of imported directly so a
+        test run that never touches these classes doesn't pay for importing
+        neuro-san internals, and pytest collection stays light. A module absent
+        from sys.modules was never imported, so its cache cannot be populated —
+        skipping it is correct, not merely convenient. A typo'd class or method
+        name still fails loudly via getattr whenever the module IS loaded.
+        """
+        for module_name, class_name, clear_method_name in ProcessGlobals.REGISTRY:
+            module = sys.modules.get(module_name)
+            if module is not None:
+                getattr(getattr(module, class_name), clear_method_name)()

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -1,0 +1,121 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Inventory of every process-wide global cache in the Agent Network Designer
+family: what each one holds, where it lives, how it expires, and who reads it.
+
+Add an entry (comment block + registry triple) whenever a new process-wide
+global is introduced. The shared mechanism — locking, publish ordering,
+freshness fingerprints, the async once-gate — lives in
+shared_process_cache.SharedProcessCache; each cache's policy lives on its
+owning class; this module is the map of all of them.
+
+The instances themselves stay on their owners rather than here because each
+loader needs its owner's imports (and moving them would create import
+cycles); everything below is therefore strings-and-pointers by design, which
+also keeps this module (and test collection through it) free of neuro-san
+imports.
+"""
+
+import sys
+
+# ---------------------------------------------------------------------------
+# 1. Shared ToolboxFactory (issue #1262)
+#    Holds:   a load()-ed neuro-san ContextTypeToolboxFactory used to render
+#             connectivity-style views of agent network definitions.
+#    Lives:   connectivity_dictionary_converter.ConnectivityDictionaryConverter
+#             (peek_/get_/aget_shared_toolbox_factory)
+#    Expiry:  none — loaded once; restart to pick up an edited
+#             AGENT_TOOLBOX_INFO_FILE.
+#    Used by: ConnectivityDictionaryConverter.from_dict() (fallback when no
+#             factory was passed in);
+#             progress_handler.ProgressHandler._send_report() (pre-warm before
+#             connectivity conversion);
+#             agent_network_persistence_middleware.AgentNetworkPersistenceMiddleware
+#             .aafter_agent() (pre-warm before the skip_designer-safe export).
+#
+# 2. Shared toolbox info (issue #1268)
+#    Holds:   the {tool_name: description} mapping parsed from the designer's
+#             toolbox info file (AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE).
+#    Lives:   get_toolbox.GetToolbox (peek_/get_shared_toolbox_info,
+#             async get_toolbox_info)
+#    Expiry:  none — loaded once (a missing file is retried, never cached);
+#             restart to pick up edits.
+#    Used by: GetToolbox.async_invoke() (the coded tool the editor LLM calls);
+#             agent_network_structure_validation_middleware
+#             .AgentNetworkStructureValidationMiddleware.validate().
+#
+# 3. Shared subnetwork names (issue #1267)
+#    Holds:   the "/<network_name>" list parsed from the designer manifest
+#             (AGENT_NETWORK_DESIGNER_MANIFEST_FILE).
+#    Lives:   get_subnetwork.GetSubnetwork (peek_shared_subnetwork_names,
+#             async get_subnetwork_names)
+#    Expiry:  manifest path/mtime change, or at most
+#             get_subnetwork.SUBNETWORK_NAMES_TTL_SECONDS (the manifest
+#             `include`s other manifests a cheap probe cannot see, notably
+#             registries/generated/manifest.hocon which grows as the designer
+#             saves networks).
+#    Used by: GetSubnetwork.get_subnetworks() (the coded tool path);
+#             agent_network_structure_validation_middleware
+#             .AgentNetworkStructureValidationMiddleware.validate();
+#             agent_network_persistence_middleware.AgentNetworkPersistenceMiddleware
+#             ._assemble_and_persist().
+# ---------------------------------------------------------------------------
+
+# Machine-readable registry of the entries above, as
+# (module, class, test-only clear method) triples consumed by
+# clear_all_process_globals_for_testing() below.
+PROCESS_GLOBALS: list[tuple[str, str, str]] = [
+    (
+        "coded_tools.agent_network_editor.connectivity_dictionary_converter",
+        "ConnectivityDictionaryConverter",
+        "clear_shared_toolbox_factory_for_testing",
+    ),
+    (
+        "coded_tools.agent_network_editor.get_toolbox",
+        "GetToolbox",
+        "clear_shared_toolbox_info_for_testing",
+    ),
+    (
+        "coded_tools.agent_network_editor.get_subnetwork",
+        "GetSubnetwork",
+        "clear_shared_subnetwork_names_for_testing",
+    ),
+]
+
+
+def clear_all_process_globals_for_testing():
+    """
+    Clear every cache registered in PROCESS_GLOBALS. For test isolation only
+    (tests/conftest.py runs this around every test).
+
+    Production code must never call this: each cache is deliberately
+    load-once (or self-expiring) per the policies above. Each captures file
+    and env-var state at its first load, so without clearing between tests a
+    test that populates one would leak that state into every later test in
+    the same process, producing order-dependent results.
+
+    Modules are looked up via sys.modules instead of imported directly so a
+    test run that never touches these classes doesn't pay for importing
+    neuro-san internals, and pytest collection stays light. A module absent
+    from sys.modules was never imported, so its cache cannot be populated —
+    skipping it is correct, not merely convenient. A typo'd class or method
+    name still fails loudly via getattr whenever the module IS loaded.
+    """
+    for module_name, class_name, clear_method_name in PROCESS_GLOBALS:
+        module = sys.modules.get(module_name)
+        if module is not None:
+            getattr(getattr(module, class_name), clear_method_name)()

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -37,7 +37,7 @@ import sys
 #    Holds:   a load()-ed neuro-san ContextTypeToolboxFactory used to render
 #             connectivity-style views of agent network definitions.
 #    Lives:   connectivity_dictionary_converter.ConnectivityDictionaryConverter
-#             (peek_/get_/aget_shared_toolbox_factory)
+#             (get_/aget_shared_toolbox_factory)
 #    Expiry:  none — loaded once; restart to pick up an edited
 #             AGENT_TOOLBOX_INFO_FILE.
 #    Used by: ConnectivityDictionaryConverter.from_dict() (fallback when no
@@ -50,8 +50,7 @@ import sys
 # 2. Shared toolbox info (issue #1268)
 #    Holds:   the {tool_name: description} mapping parsed from the designer's
 #             toolbox info file (AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE).
-#    Lives:   get_toolbox.GetToolbox (peek_/get_shared_toolbox_info,
-#             async get_toolbox_info)
+#    Lives:   get_toolbox.GetToolbox (async get_toolbox_info)
 #    Expiry:  none — loaded once (a missing file is retried, never cached);
 #             restart to pick up edits.
 #    Used by: GetToolbox.async_invoke() (the coded tool the editor LLM calls);
@@ -61,13 +60,13 @@ import sys
 # 3. Shared subnetwork names (issue #1267)
 #    Holds:   the "/<network_name>" list parsed from the designer manifest
 #             (AGENT_NETWORK_DESIGNER_MANIFEST_FILE).
-#    Lives:   get_subnetwork.GetSubnetwork (peek_shared_subnetwork_names,
-#             async get_subnetwork_names)
+#    Lives:   get_subnetwork.GetSubnetwork (async get_subnetwork_names)
 #    Expiry:  manifest path/mtime change, or at most
 #             get_subnetwork.SUBNETWORK_NAMES_TTL_SECONDS (the manifest
 #             `include`s other manifests a cheap probe cannot see, notably
 #             registries/generated/manifest.hocon which grows as the designer
-#             saves networks).
+#             saves networks on local runs; server deployments never write
+#             the manifest at runtime).
 #    Used by: GetSubnetwork.get_subnetworks() (the coded tool path);
 #             agent_network_structure_validation_middleware
 #             .AgentNetworkStructureValidationMiddleware.validate();

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -15,7 +15,6 @@
 # END COPYRIGHT
 
 import logging
-from asyncio import to_thread
 from os import environ
 from time import perf_counter
 from typing import Any
@@ -272,15 +271,13 @@ class ProgressHandler:
             # that it already knows how to render.  Using the different key name allows the AGENT_PROGRESS
             # dictionary to look just like a ConnectivityResponse from the service.
 
-            # Warm the process-wide ToolboxFactory cache that from_dict() falls
-            # back to. Only the first call in the process pays for the file
-            # read + HOCON parse, and to_thread() keeps that parse off the
-            # event loop; once warm, the peek and the fallback inside
-            # from_dict() are lock-free attribute reads, so the steady-state
-            # path has no thread hop, no lock traffic, and no await between
-            # the throttle stamp and the conversion snapshot.
-            if ConnectivityDictionaryConverter.peek_shared_toolbox_factory() is None:
-                await to_thread(ConnectivityDictionaryConverter.get_shared_toolbox_factory)
+            # Warm the process-wide ToolboxFactory cache that from_dict()
+            # falls back to. Only the first call in the process pays for the
+            # file read + HOCON parse, off the event loop; once warm, aget's
+            # peek and the fallback inside from_dict() are lock-free reads
+            # with no thread hop, no lock traffic, and no actual suspension
+            # between the throttle stamp and the conversion snapshot.
+            await ConnectivityDictionaryConverter.aget_shared_toolbox_factory()
 
             # Do the conversion
             use_key: str = "connectivity_info"

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -1,0 +1,187 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Generic process-wide, load-once cache for expensive shared values.
+
+This is the one copy of the locking and publish discipline that the Agent
+Network Designer family's shared caches were previously each hand-rolling
+(ConnectivityDictionaryConverter's ToolboxFactory for issue #1262, GetToolbox's
+toolbox info for #1268, GetSubnetwork's subnetwork names for #1267). Each
+owning class keeps its public peek/get/clear_for_testing API and delegates to
+an instance of this class, so all cache *policy* stays visible on the owner
+while the subtle *mechanism* lives here once.
+"""
+
+from asyncio import Task
+from asyncio import get_running_loop
+from asyncio import to_thread
+from threading import Lock
+from typing import Any
+from typing import Callable
+from typing import Generic
+from typing import TypeVar
+from weakref import WeakKeyDictionary
+
+T = TypeVar("T")
+
+
+class SharedProcessCache(Generic[T]):
+    """
+    Process-wide cache of a single expensive value, safe across threads and
+    event loops.
+
+    * loader: synchronous callable producing the value. It runs under the
+      cache lock — and in a worker thread when reached through aget() — so it
+      may do blocking file I/O and CPU-heavy parsing. It must either return a
+      complete, ready-to-share value or raise; on a raise nothing is
+      published, so the next call retries instead of serving a half-built or
+      failure value. Loaders must not return None (return an empty container
+      instead) — None is the cache's "not loaded" sentinel.
+    * fingerprint: optional cheap callable identifying the version of the
+      source the value was built from (e.g. a (path, mtime) tuple, which can
+      also fold in a time bucket for TTL-style expiry). It is captured just
+      BEFORE the loader runs and re-checked on every read; when the current
+      fingerprint no longer matches the stored one, the entry is treated as a
+      miss and reloaded. It must be lock-free-safe and must not raise. When
+      None, the value is loaded once and lives for the life of the process.
+
+    Concurrency notes (the reasoning previously duplicated per cache):
+    * The guard is a threading.Lock rather than an asyncio.Lock because
+      callers may run on different event loops in different threads, and an
+      asyncio.Lock cannot be shared across event loops.
+    * The warm path takes no lock: the entry is a single attribute written
+      exactly once per load, only after the loader fully succeeded, and
+      CPython reference reads are atomic under the GIL — so a non-None read
+      always yields a complete (value, fingerprint) pair. Do not reorder the
+      publish in get().
+    * aget() keeps the cold load off the event loop via asyncio.to_thread()
+      and funnels concurrent cold callers on the same loop into ONE load: the
+      first caller creates the load task and the rest await it, so a cold
+      burst cannot fill the loop's default executor with lock-waiters.
+    """
+
+    def __init__(self, loader: Callable[[], T], fingerprint: Callable[[], Any] | None = None):
+        """
+        Constructor
+
+        :param loader: Synchronous callable that builds the value. See the
+                class docstring for its contract.
+        :param fingerprint: Optional source-version probe. See the class
+                docstring for its contract.
+        """
+        self._loader = loader
+        self._fingerprint = fingerprint
+        # The one shared slot: None, or a (value, fingerprint-at-load) pair
+        # stored as a single tuple so lock-free readers see it atomically.
+        self._entry: tuple[T, Any] | None = None
+        self._lock = Lock()
+        # Per-event-loop in-flight load task, so concurrent async callers on
+        # one loop share a single to_thread() dispatch. Weak keys let a
+        # closed loop's entry disappear on its own. Access races between
+        # loops are benign: at worst two loops each run a load, and the lock
+        # in get() still serializes the actual work.
+        self._loads_in_flight: WeakKeyDictionary = WeakKeyDictionary()
+
+    def peek(self) -> T | None:
+        """
+        :return: The cached value if it is present and still fresh per the
+                fingerprint, else None. Lock-free and safe to call from any
+                thread or event loop; async callers can use a None result to
+                decide to reach get() through a worker thread. Treat the
+                result as read-only unless the owner documents otherwise — it
+                is the live shared value, not a copy.
+        """
+        entry: tuple[T, Any] | None = self._entry
+        if entry is None:
+            return None
+        value, loaded_fingerprint = entry
+        if self._fingerprint is not None and self._fingerprint() != loaded_fingerprint:
+            # The source moved on since this value was built: report a miss
+            # and leave the stale entry in place for get() to replace.
+            return None
+        return value
+
+    def get(self) -> T:
+        """
+        Get the value, running the loader on a miss (first call in the
+        process, or the fingerprint went stale).
+
+        Blocking: the loader may do file I/O and parsing, so async callers
+        must not call this on the event loop — use aget(), or peek() first
+        and reach this via asyncio.to_thread().
+
+        :return: The cached or freshly loaded value. Loader exceptions
+                propagate without publishing anything, so the next call
+                retries.
+        """
+        value: T | None = self.peek()
+        if value is not None:
+            return value
+
+        with self._lock:
+            # Double-check under the lock: another thread may have loaded
+            # while this one waited.
+            value = self.peek()
+            if value is not None:
+                return value
+
+            # Capture the fingerprint BEFORE loading: if the source changes
+            # while the loader runs, the next read's probe mismatches and the
+            # value is rebuilt, rather than a torn read living forever.
+            loaded_fingerprint: Any = self._fingerprint() if self._fingerprint is not None else None
+            value = self._loader()
+            # Publish only after the loader fully succeeded. Do not reorder.
+            self._entry = (value, loaded_fingerprint)
+
+        return value
+
+    async def aget(self) -> T:
+        """
+        Async get(): warm reads return via the lock-free peek with no
+        awaiting at all; a cold load runs in a worker thread, shared by every
+        concurrent cold caller on this event loop.
+
+        :return: The cached or freshly loaded value. Loader exceptions
+                propagate to every caller awaiting that load, and the next
+                aget() starts a fresh attempt.
+        """
+        value: T | None = self.peek()
+        if value is not None:
+            return value
+
+        loop = get_running_loop()
+        task: Task | None = self._loads_in_flight.get(loop)
+        if task is None or task.done():
+            # A done task is a finished earlier attempt (possibly failed or
+            # stale); start a new one. Awaiters of the old task are unaffected.
+            task = loop.create_task(to_thread(self.get))
+            self._loads_in_flight[loop] = task
+        # Awaiting a shared task is safe under cancellation: cancelling one
+        # awaiter does not cancel the task, so the load still completes for
+        # the others.
+        return await task
+
+    def clear_for_testing(self):
+        """
+        Drop the cached value. For test isolation only — production code
+        relies on load-once semantics. Not safe against a concurrently
+        in-flight load publishing just after the clear; tests run loads
+        sequentially, where this cannot happen.
+        """
+        # Taking the lock serializes the reset with a concurrent load, so
+        # this can never unpublish an entry mid-initialization.
+        with self._lock:
+            self._entry = None

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -18,11 +18,11 @@ Generic process-wide, load-once cache for expensive shared values.
 
 This is the one copy of the locking and publish discipline that the Agent
 Network Designer family's shared caches were previously each hand-rolling
-(ConnectivityDictionaryConverter's ToolboxFactory for issue #1262, GetToolbox's
-toolbox info for #1268, GetSubnetwork's subnetwork names for #1267). Each
-owning class keeps its public peek/get/clear_for_testing API and delegates to
-an instance of this class, so all cache *policy* stays visible on the owner
-while the subtle *mechanism* lives here once.
+(ConnectivityDictionaryConverter's ToolboxFactory, GetToolbox's toolbox info,
+GetSubnetwork's subnetwork names). Each owning class keeps its public
+accessors and clear_*_for_testing API and delegates to an instance of this
+class, so all cache *policy* stays visible on the owner while the subtle
+*mechanism* lives here once.
 """
 
 from asyncio import Task

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -27,6 +27,7 @@ while the subtle *mechanism* lives here once.
 
 from asyncio import Task
 from asyncio import get_running_loop
+from asyncio import shield
 from asyncio import to_thread
 from threading import Lock
 from typing import Any
@@ -70,7 +71,9 @@ class SharedProcessCache(Generic[T]):
     * aget() keeps the cold load off the event loop via asyncio.to_thread()
       and funnels concurrent cold callers on the same loop into ONE load: the
       first caller creates the load task and the rest await it, so a cold
-      burst cannot fill the loop's default executor with lock-waiters.
+      burst cannot fill the loop's default executor with lock-waiters. The
+      await is shield()-ed, so one cancelled caller cannot cancel the shared
+      load out from under the others.
     """
 
     def __init__(self, loader: Callable[[], T], fingerprint: Callable[[], Any] | None = None):
@@ -89,10 +92,12 @@ class SharedProcessCache(Generic[T]):
         self._entry: tuple[T, Any] | None = None
         self._lock = Lock()
         # Per-event-loop in-flight load task, so concurrent async callers on
-        # one loop share a single to_thread() dispatch. Weak keys let a
-        # closed loop's entry disappear on its own. Access races between
-        # loops are benign: at worst two loops each run a load, and the lock
-        # in get() still serializes the actual work.
+        # one loop share a single to_thread() dispatch. Entries are removed
+        # by each task's done callback (_forget_in_flight_load) — the weak
+        # keying alone cannot reclaim them, because a Task strongly
+        # references the loop it runs on, i.e. its own key. Access races
+        # between loops are benign: at worst two loops each run a load, and
+        # the lock in get() still serializes the actual work.
         self._loads_in_flight: WeakKeyDictionary = WeakKeyDictionary()
 
     def peek(self) -> T | None:
@@ -169,19 +174,55 @@ class SharedProcessCache(Generic[T]):
             # stale); start a new one. Awaiters of the old task are unaffected.
             task = loop.create_task(to_thread(self.get))
             self._loads_in_flight[loop] = task
-        # Awaiting a shared task is safe under cancellation: cancelling one
-        # awaiter does not cancel the task, so the load still completes for
-        # the others.
-        return await task
+            task.add_done_callback(self._forget_in_flight_load)
+        # shield() detaches awaiter cancellation from the shared task: a
+        # cancelled awaiter still gets its CancelledError, but the load keeps
+        # running and completes for the other awaiters. An unshielded await
+        # here would let one cancelled caller cancel everyone else's load,
+        # because Task.cancel() propagates into whatever the task is awaiting.
+        return await shield(task)
+
+    def _forget_in_flight_load(self, task: Task):
+        """
+        Done-callback for once-gate load tasks (see aget()).
+
+        Dropping the finished task promptly matters beyond tidiness: a Task
+        strongly references the event loop it runs on — its own dictionary
+        key — so entries would otherwise never be garbage-collected despite
+        the weak keying, leaking one loop + task per event loop under
+        loop-per-test runners. Retrieving the exception keeps a failed load
+        whose awaiters were all cancelled from logging "Task exception was
+        never retrieved".
+        """
+        loop = task.get_loop()
+        # Only forget the task this callback belongs to: clear_for_testing()
+        # may have dropped it already. pop() instead of del so a concurrent
+        # clear between the check and the removal stays a no-op; a *newer*
+        # task cannot sneak into the slot in that window, because only this
+        # loop's thread installs tasks for this key.
+        if self._loads_in_flight.get(loop) is task:
+            self._loads_in_flight.pop(loop, None)
+        if not task.cancelled():
+            # Mark a failed load's exception as retrieved (returns None on
+            # success). Awaiters that were still around received it via the
+            # shield()-ed await.
+            task.exception()
 
     def clear_for_testing(self):
         """
-        Drop the cached value. For test isolation only — production code
-        relies on load-once semantics. Not safe against a concurrently
-        in-flight load publishing just after the clear; tests run loads
-        sequentially, where this cannot happen.
+        Drop the cached value and forget any in-flight once-gate loads. For
+        test isolation only — production code relies on load-once semantics.
+
+        Forgetting the in-flight tasks matters: without it, an aget() issued
+        after the clear could adopt a still-pending pre-clear load and
+        receive a value built under the previous test's env/file state. The
+        lock serializes this reset with a load that is mid-publish; a
+        pre-clear load that was dispatched but never awaited can still
+        publish after the reset, which tests avoid by running loads
+        sequentially.
         """
         # Taking the lock serializes the reset with a concurrent load, so
         # this can never unpublish an entry mid-initialization.
         with self._lock:
             self._entry = None
+            self._loads_in_flight.clear()

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -137,19 +137,21 @@ class SharedProcessCache(Generic[T]):
             return value
 
         with self._lock:
-            # Double-check under the lock: another thread may have loaded
-            # while this one waited.
-            value = self.peek()
-            if value is not None:
-                return value
+            # Probe the fingerprint once per miss: it serves both as the
+            # double-check against a load that finished while this thread
+            # waited for the lock, and as the freshness capture stored with
+            # the value below — so a stat-style probe runs once, not twice.
+            current_fingerprint: Any = self._fingerprint() if self._fingerprint is not None else None
+            entry: tuple[T, Any] | None = self._entry
+            if entry is not None and (self._fingerprint is None or entry[1] == current_fingerprint):
+                return entry[0]
 
-            # Capture the fingerprint BEFORE loading: if the source changes
-            # while the loader runs, the next read's probe mismatches and the
-            # value is rebuilt, rather than a torn read living forever.
-            loaded_fingerprint: Any = self._fingerprint() if self._fingerprint is not None else None
+            # The fingerprint was captured BEFORE loading: if the source
+            # changes while the loader runs, the next read's probe mismatches
+            # and the value is rebuilt, rather than a torn read living forever.
             value = self._loader()
             # Publish only after the loader fully succeeded. Do not reorder.
-            self._entry = (value, loaded_fingerprint)
+            self._entry = (value, current_fingerprint)
 
         return value
 

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -14,7 +14,6 @@
 #
 # END COPYRIGHT
 
-from asyncio import to_thread
 from logging import getLogger
 from os import environ
 from typing import Any
@@ -207,11 +206,8 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             # progress, so on a cold process the from_dict() fallback inside
             # the export would otherwise pay the one-time toolbox file read
             # and HOCON parse on the event loop.
-            if (
-                agent_progress_style == "connectivity"
-                and ConnectivityDictionaryConverter.peek_shared_toolbox_factory() is None
-            ):
-                await to_thread(ConnectivityDictionaryConverter.get_shared_toolbox_factory)
+            if agent_progress_style == "connectivity":
+                await ConnectivityDictionaryConverter.aget_shared_toolbox_factory()
             self._determine_exported_network_definition(self.sly_data, agent_progress_style)
 
             self.logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
@@ -266,7 +262,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.logger.info(">>>>>>>>>>>>>>>>>>>Assemble and Persist Agent Network>>>>>>>>>>>>>>>>>>")
         self.logger.info("Agent Network Name: %s", agent_network_name)
 
-        subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
+        subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names()
         mcp_servers: list[str] = await GetMcpTool.get_mcp_servers(self.sly_data)
         persistor: AgentNetworkPersistor = AgentNetworkPersistorFactory.create_persistor(
             {"reservationist": self.reservationist},

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -57,7 +57,13 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
 
         # Get infos from the agent network editor's tools. Subnetwork names
         # and toolbox info come from their process-wide caches; MCP servers
-        # are still cached in sly_data by their tool.
+        # are still cached in sly_data by their tool. Validating against the
+        # shared subnetwork cache (rather than the per-session snapshot used
+        # before the process-wide cache) cannot contradict the list the LLM
+        # was shown, because the manifest does not change mid-conversation:
+        # server deployments never write it at runtime — generated networks
+        # are only saved into the local manifest on local runs, where the
+        # fingerprint TTL bounds any staleness from the designer's own saves.
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names()
         mcp_servers: list[str] = await GetMcpTool.get_mcp_servers(self.sly_data)
         toolbox_tools: dict[str, Any] = await GetToolbox.get_toolbox_info()

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -55,10 +55,10 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
         :return: A list of error strings (empty if valid)
         """
 
-        # Get infos from the agent network editor's tools. Subnetwork names and
-        # MCP servers are cached in sly_data by their respective tools; toolbox
-        # info comes from GetToolbox's process-wide cache.
-        subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names(self.sly_data)
+        # Get infos from the agent network editor's tools. Subnetwork names
+        # and toolbox info come from their process-wide caches; MCP servers
+        # are still cached in sly_data by their tool.
+        subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names()
         mcp_servers: list[str] = await GetMcpTool.get_mcp_servers(self.sly_data)
         toolbox_tools: dict[str, Any] = await GetToolbox.get_toolbox_info()
 

--- a/tests/coded_tools/agent_network_editor/test_globals.py
+++ b/tests/coded_tools/agent_network_editor/test_globals.py
@@ -1,0 +1,69 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for the ProcessGlobals registry of process-wide caches.
+
+Deliberately stdlib-only (no neuro-san imports), so the registry mechanics
+are testable in any environment that can collect the suite; the real owner
+modules are only validated when a test run happens to have imported them.
+"""
+
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+
+from coded_tools.agent_network_editor.globals import ProcessGlobals
+
+
+class TestProcessGlobals(TestCase):
+    """Tests for the registry triples and the clear-all helper."""
+
+    def test_clear_all_clears_imported_owners_and_skips_unimported(self):
+        """The registry clears imported owners and skips unimported ones."""
+        cleared: list[str] = []
+
+        class FakeOwner:  # pylint: disable=too-few-public-methods
+            """Stand-in owner class exposing a clear method like the real caches."""
+
+            @classmethod
+            def clear_fake_for_testing(cls):
+                """Record that the registry reached this clear method."""
+                cleared.append("cleared")
+
+        fake_module = types.ModuleType("fake_process_globals_owner_module")
+        fake_module.FakeOwner = FakeOwner
+        registry = [
+            ("fake_process_globals_owner_module", "FakeOwner", "clear_fake_for_testing"),
+            # Never imported: must be skipped silently (an unimported module
+            # cannot have a populated cache), not raise.
+            ("module_that_was_never_imported_for_test", "Nope", "clear_nope_for_testing"),
+        ]
+        with patch.dict(sys.modules, {"fake_process_globals_owner_module": fake_module}):
+            with patch.object(ProcessGlobals, "REGISTRY", registry):
+                ProcessGlobals.clear_all_for_testing()
+        self.assertEqual(cleared, ["cleared"])
+
+    def test_registry_entries_resolve_when_imported(self):
+        """Registry triples must resolve against any imported owner module."""
+        for module_name, class_name, clear_method_name in ProcessGlobals.REGISTRY:
+            self.assertTrue(module_name.startswith("coded_tools."))
+            # Owner modules need neuro-san, so only validate the ones this test
+            # run happens to have imported; a typo'd class or method name in an
+            # imported module must fail here rather than being skipped silently.
+            module = sys.modules.get(module_name)
+            if module is not None:
+                self.assertTrue(callable(getattr(getattr(module, class_name), clear_method_name)))

--- a/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
+++ b/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
@@ -14,7 +14,7 @@
 #
 # END COPYRIGHT
 """
-Tests for SharedProcessCache and the process-globals registry.
+Tests for SharedProcessCache.
 
 Deliberately stdlib-only (no neuro-san imports): the cache is the shared
 concurrency mechanism under every process-wide cache in the Agent Network
@@ -24,230 +24,179 @@ rather than depending on an asyncio pytest plugin.
 """
 
 import asyncio
-import sys
 import threading
 import time
-import types
+from unittest import TestCase
 
-import pytest
-
-from coded_tools.agent_network_editor import globals as process_globals
 from coded_tools.agent_network_editor.shared_process_cache import SharedProcessCache
 
 
-def test_get_loads_once_and_peek_reflects_state():
-    """Loader runs once; peek() mirrors loaded/unloaded state."""
-    calls: list[int] = []
+class TestSharedProcessCache(TestCase):
+    """Behavioral and regression tests for the shared cache mechanism."""
 
-    def loader() -> str:
-        calls.append(1)
-        return "value"
+    def test_get_loads_once_and_peek_reflects_state(self):
+        """Loader runs once; peek() mirrors loaded/unloaded state."""
+        calls: list[int] = []
 
-    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
-    assert cache.peek() is None
-    assert cache.get() == "value"
-    assert cache.get() == "value"
-    assert cache.peek() == "value"
-    assert len(calls) == 1
+        def loader() -> str:
+            calls.append(1)
+            return "value"
 
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+        self.assertIsNone(cache.peek())
+        self.assertEqual(cache.get(), "value")
+        self.assertEqual(cache.get(), "value")
+        self.assertEqual(cache.peek(), "value")
+        self.assertEqual(len(calls), 1)
 
-def test_loader_failure_publishes_nothing_and_next_call_retries():
-    """A raising loader publishes nothing, so the next get() retries."""
-    attempts = {"count": 0}
+    def test_loader_failure_publishes_nothing_and_next_call_retries(self):
+        """A raising loader publishes nothing, so the next get() retries."""
+        attempts = {"count": 0}
 
-    def loader() -> str:
-        attempts["count"] += 1
-        if attempts["count"] == 1:
-            raise RuntimeError("boom")
-        return "healed"
+        def loader() -> str:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("boom")
+            return "healed"
 
-    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
-    with pytest.raises(RuntimeError):
-        cache.get()
-    assert cache.peek() is None
-    assert cache.get() == "healed"
-    assert attempts["count"] == 2
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+        with self.assertRaises(RuntimeError):
+            cache.get()
+        self.assertIsNone(cache.peek())
+        self.assertEqual(cache.get(), "healed")
+        self.assertEqual(attempts["count"], 2)
 
+    def test_fingerprint_controls_freshness(self):
+        """A fingerprint change turns warm reads into a miss and reload."""
+        source = {"fingerprint": 1, "loads": 0}
 
-def test_fingerprint_controls_freshness():
-    """A fingerprint change turns warm reads into a miss and reload."""
-    source = {"fingerprint": 1, "loads": 0}
+        def loader() -> str:
+            source["loads"] += 1
+            return f"value-{source['fingerprint']}"
 
-    def loader() -> str:
-        source["loads"] += 1
-        return f"value-{source['fingerprint']}"
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=loader, fingerprint=lambda: source["fingerprint"])
+        self.assertEqual(cache.get(), "value-1")
+        self.assertEqual(cache.get(), "value-1")
+        self.assertEqual(source["loads"], 1)
 
-    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader, fingerprint=lambda: source["fingerprint"])
-    assert cache.get() == "value-1"
-    assert cache.get() == "value-1"
-    assert source["loads"] == 1
-
-    # The source moved on: peek() reports a miss and get() rebuilds.
-    source["fingerprint"] = 2
-    assert cache.peek() is None
-    assert cache.get() == "value-2"
-    assert source["loads"] == 2
-
-
-def test_fingerprint_is_captured_before_the_loader_runs():
-    """A mid-load source change leaves the published entry stale."""
-    # If the source changes while the loader runs, the published entry must
-    # already be stale so the next read rebuilds it instead of a torn value
-    # living forever.
-    source = {"fingerprint": 1}
-
-    def loader() -> str:
+        # The source moved on: peek() reports a miss and get() rebuilds.
         source["fingerprint"] = 2
-        return "torn"
+        self.assertIsNone(cache.peek())
+        self.assertEqual(cache.get(), "value-2")
+        self.assertEqual(source["loads"], 2)
 
-    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader, fingerprint=lambda: source["fingerprint"])
-    assert cache.get() == "torn"
-    assert cache.peek() is None
+    def test_fingerprint_is_captured_before_the_loader_runs(self):
+        """A mid-load source change leaves the published entry stale."""
+        # If the source changes while the loader runs, the published entry must
+        # already be stale so the next read rebuilds it instead of a torn value
+        # living forever.
+        source = {"fingerprint": 1}
 
+        def loader() -> str:
+            source["fingerprint"] = 2
+            return "torn"
 
-def test_aget_shares_one_load_across_concurrent_cold_callers():
-    """Concurrent cold aget() callers share a single loader run."""
-    calls = {"count": 0}
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=loader, fingerprint=lambda: source["fingerprint"])
+        self.assertEqual(cache.get(), "torn")
+        self.assertIsNone(cache.peek())
 
-    def loader() -> str:
-        calls["count"] += 1
-        time.sleep(0.05)
-        return "shared"
+    def test_aget_shares_one_load_across_concurrent_cold_callers(self):
+        """Concurrent cold aget() callers share a single loader run."""
+        calls = {"count": 0}
 
-    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+        def loader() -> str:
+            calls["count"] += 1
+            time.sleep(0.05)
+            return "shared"
 
-    async def run() -> list[str]:
-        return await asyncio.gather(*[cache.aget() for _ in range(20)])
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
 
-    assert asyncio.run(run()) == ["shared"] * 20
-    assert calls["count"] == 1
+        async def run() -> list[str]:
+            return await asyncio.gather(*[cache.aget() for _ in range(20)])
 
+        self.assertEqual(asyncio.run(run()), ["shared"] * 20)
+        self.assertEqual(calls["count"], 1)
 
-def test_aget_load_survives_one_awaiter_being_cancelled():
-    """Cancelling one aget() awaiter must not cancel the shared load."""
-    # Regression test for the unshielded await: cancelling one awaiter must
-    # not cancel the shared load out from under the other awaiters.
-    loader_started = threading.Event()
-    release_loader = threading.Event()
+    def test_aget_load_survives_one_awaiter_being_cancelled(self):
+        """Cancelling one aget() awaiter must not cancel the shared load."""
+        # Regression test for the unshielded await: cancelling one awaiter must
+        # not cancel the shared load out from under the other awaiters.
+        loader_started = threading.Event()
+        release_loader = threading.Event()
 
-    def loader() -> str:
-        loader_started.set()
-        release_loader.wait(timeout=5)
-        return "survived"
+        def loader() -> str:
+            loader_started.set()
+            release_loader.wait(timeout=5)
+            return "survived"
 
-    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
 
-    async def run() -> str:
-        first = asyncio.create_task(cache.aget())
-        second = asyncio.create_task(cache.aget())
-        await asyncio.to_thread(loader_started.wait, 5)
-        first.cancel()
-        release_loader.set()
-        with pytest.raises(asyncio.CancelledError):
-            await first
-        return await second
+        async def run() -> str:
+            first = asyncio.create_task(cache.aget())
+            second = asyncio.create_task(cache.aget())
+            await asyncio.to_thread(loader_started.wait, 5)
+            first.cancel()
+            release_loader.set()
+            with self.assertRaises(asyncio.CancelledError):
+                await first
+            return await second
 
-    assert asyncio.run(run()) == "survived"
+        self.assertEqual(asyncio.run(run()), "survived")
 
+    def test_aget_failure_is_shared_and_next_call_retries(self):
+        """A failing shared load raises for all awaiters; next aget() retries."""
+        attempts = {"count": 0}
 
-def test_aget_failure_is_shared_and_next_call_retries():
-    """A failing shared load raises for all awaiters; next aget() retries."""
-    attempts = {"count": 0}
+        def loader() -> str:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("boom")
+            return "healed"
 
-    def loader() -> str:
-        attempts["count"] += 1
-        if attempts["count"] == 1:
-            raise RuntimeError("boom")
-        return "healed"
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
 
-    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+        async def run() -> str:
+            results = await asyncio.gather(*[cache.aget() for _ in range(3)], return_exceptions=True)
+            self.assertTrue(all(isinstance(result, RuntimeError) for result in results))
+            return await cache.aget()
 
-    async def run() -> str:
-        results = await asyncio.gather(*[cache.aget() for _ in range(3)], return_exceptions=True)
-        assert all(isinstance(result, RuntimeError) for result in results)
-        return await cache.aget()
+        self.assertEqual(asyncio.run(run()), "healed")
+        self.assertEqual(attempts["count"], 2)
 
-    assert asyncio.run(run()) == "healed"
-    assert attempts["count"] == 2
+    def test_aget_cleans_up_in_flight_bookkeeping_across_event_loops(self):
+        """The once-gate map must not pin dead event loops (leak regression)."""
+        # Regression test for the once-gate leak: a Task strongly references the
+        # event loop it runs on (its own dictionary key), so without the done
+        # callback the weak keying never reclaims entries and one loop + task
+        # would be pinned per event loop that ever cold-loaded.
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=lambda: "value")
+        for _ in range(5):
+            cache.clear_for_testing()
+            self.assertEqual(asyncio.run(cache.aget()), "value")
+        self.assertEqual(len(cache._loads_in_flight), 0)  # pylint: disable=protected-access
 
+    def test_clear_for_testing_drops_entry_and_pending_loads(self):
+        """clear_for_testing() drops the entry AND forgets pending loads."""
+        calls = {"count": 0}
 
-def test_aget_cleans_up_in_flight_bookkeeping_across_event_loops():
-    """The once-gate map must not pin dead event loops (leak regression)."""
-    # Regression test for the once-gate leak: a Task strongly references the
-    # event loop it runs on (its own dictionary key), so without the done
-    # callback the weak keying never reclaims entries and one loop + task
-    # would be pinned per event loop that ever cold-loaded.
-    cache: SharedProcessCache[str] = SharedProcessCache(loader=lambda: "value")
-    for _ in range(5):
-        cache.clear_for_testing()
-        assert asyncio.run(cache.aget()) == "value"
-    assert len(cache._loads_in_flight) == 0  # pylint: disable=protected-access
+        def loader() -> str:
+            calls["count"] += 1
+            return f"load-{calls['count']}"
 
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+        self.assertEqual(cache.get(), "load-1")
 
-def test_clear_for_testing_drops_entry_and_pending_loads():
-    """clear_for_testing() drops the entry AND forgets pending loads."""
-    calls = {"count": 0}
+        async def run() -> str:
+            loop = asyncio.get_running_loop()
+            # Stand-in for a load still in flight when the clear happens: if
+            # clear_for_testing() left it behind, aget() would adopt it (it is
+            # not done) and time out below instead of starting a fresh load.
+            pending = loop.create_task(asyncio.sleep(60))
+            cache._loads_in_flight[loop] = pending  # pylint: disable=protected-access
+            cache.clear_for_testing()
+            self.assertIsNone(cache.peek())
+            value = await asyncio.wait_for(cache.aget(), timeout=5)
+            pending.cancel()
+            return value
 
-    def loader() -> str:
-        calls["count"] += 1
-        return f"load-{calls['count']}"
-
-    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
-    assert cache.get() == "load-1"
-
-    async def run() -> str:
-        loop = asyncio.get_running_loop()
-        # Stand-in for a load still in flight when the clear happens: if
-        # clear_for_testing() left it behind, aget() would adopt it (it is
-        # not done) and time out below instead of starting a fresh load.
-        pending = loop.create_task(asyncio.sleep(60))
-        cache._loads_in_flight[loop] = pending  # pylint: disable=protected-access
-        cache.clear_for_testing()
-        assert cache.peek() is None
-        value = await asyncio.wait_for(cache.aget(), timeout=5)
-        pending.cancel()
-        return value
-
-    assert asyncio.run(run()) == "load-2"
-
-
-def test_clear_all_process_globals_clears_imported_and_skips_unimported(monkeypatch):
-    """The registry clears imported owners and skips unimported ones."""
-    cleared: list[str] = []
-
-    class FakeOwner:  # pylint: disable=too-few-public-methods
-        """Stand-in owner class exposing a clear method like the real caches."""
-
-        @classmethod
-        def clear_fake_for_testing(cls):
-            """Record that the registry reached this clear method."""
-            cleared.append("cleared")
-
-    fake_module = types.ModuleType("fake_process_globals_owner_module")
-    fake_module.FakeOwner = FakeOwner
-    monkeypatch.setitem(sys.modules, "fake_process_globals_owner_module", fake_module)
-    monkeypatch.setattr(
-        process_globals,
-        "PROCESS_GLOBALS",
-        [
-            ("fake_process_globals_owner_module", "FakeOwner", "clear_fake_for_testing"),
-            # Never imported: must be skipped silently (an unimported module
-            # cannot have a populated cache), not raise.
-            ("module_that_was_never_imported_for_test", "Nope", "clear_nope_for_testing"),
-        ],
-    )
-
-    process_globals.clear_all_process_globals_for_testing()
-    assert cleared == ["cleared"]
-
-
-def test_process_globals_registry_entries_resolve_when_imported():
-    """Registry triples must resolve against any imported owner module."""
-    for module_name, class_name, clear_method_name in process_globals.PROCESS_GLOBALS:
-        assert module_name.startswith("coded_tools.")
-        # Owner modules need neuro-san, so only validate the ones this test
-        # run happens to have imported; a typo'd class or method name in an
-        # imported module must fail here rather than being skipped silently.
-        module = sys.modules.get(module_name)
-        if module is not None:
-            assert callable(getattr(getattr(module, class_name), clear_method_name))
+        self.assertEqual(asyncio.run(run()), "load-2")

--- a/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
+++ b/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
@@ -1,0 +1,253 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for SharedProcessCache and the process-globals registry.
+
+Deliberately stdlib-only (no neuro-san imports): the cache is the shared
+concurrency mechanism under every process-wide cache in the Agent Network
+Designer family, so these tests must run in any environment that can
+collect the suite. Async cases drive their own event loops via asyncio.run()
+rather than depending on an asyncio pytest plugin.
+"""
+
+import asyncio
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+from coded_tools.agent_network_editor import globals as process_globals
+from coded_tools.agent_network_editor.shared_process_cache import SharedProcessCache
+
+
+def test_get_loads_once_and_peek_reflects_state():
+    """Loader runs once; peek() mirrors loaded/unloaded state."""
+    calls: list[int] = []
+
+    def loader() -> str:
+        calls.append(1)
+        return "value"
+
+    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+    assert cache.peek() is None
+    assert cache.get() == "value"
+    assert cache.get() == "value"
+    assert cache.peek() == "value"
+    assert len(calls) == 1
+
+
+def test_loader_failure_publishes_nothing_and_next_call_retries():
+    """A raising loader publishes nothing, so the next get() retries."""
+    attempts = {"count": 0}
+
+    def loader() -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise RuntimeError("boom")
+        return "healed"
+
+    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+    with pytest.raises(RuntimeError):
+        cache.get()
+    assert cache.peek() is None
+    assert cache.get() == "healed"
+    assert attempts["count"] == 2
+
+
+def test_fingerprint_controls_freshness():
+    """A fingerprint change turns warm reads into a miss and reload."""
+    source = {"fingerprint": 1, "loads": 0}
+
+    def loader() -> str:
+        source["loads"] += 1
+        return f"value-{source['fingerprint']}"
+
+    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader, fingerprint=lambda: source["fingerprint"])
+    assert cache.get() == "value-1"
+    assert cache.get() == "value-1"
+    assert source["loads"] == 1
+
+    # The source moved on: peek() reports a miss and get() rebuilds.
+    source["fingerprint"] = 2
+    assert cache.peek() is None
+    assert cache.get() == "value-2"
+    assert source["loads"] == 2
+
+
+def test_fingerprint_is_captured_before_the_loader_runs():
+    """A mid-load source change leaves the published entry stale."""
+    # If the source changes while the loader runs, the published entry must
+    # already be stale so the next read rebuilds it instead of a torn value
+    # living forever.
+    source = {"fingerprint": 1}
+
+    def loader() -> str:
+        source["fingerprint"] = 2
+        return "torn"
+
+    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader, fingerprint=lambda: source["fingerprint"])
+    assert cache.get() == "torn"
+    assert cache.peek() is None
+
+
+def test_aget_shares_one_load_across_concurrent_cold_callers():
+    """Concurrent cold aget() callers share a single loader run."""
+    calls = {"count": 0}
+
+    def loader() -> str:
+        calls["count"] += 1
+        time.sleep(0.05)
+        return "shared"
+
+    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+
+    async def run() -> list[str]:
+        return await asyncio.gather(*[cache.aget() for _ in range(20)])
+
+    assert asyncio.run(run()) == ["shared"] * 20
+    assert calls["count"] == 1
+
+
+def test_aget_load_survives_one_awaiter_being_cancelled():
+    """Cancelling one aget() awaiter must not cancel the shared load."""
+    # Regression test for the unshielded await: cancelling one awaiter must
+    # not cancel the shared load out from under the other awaiters.
+    loader_started = threading.Event()
+    release_loader = threading.Event()
+
+    def loader() -> str:
+        loader_started.set()
+        release_loader.wait(timeout=5)
+        return "survived"
+
+    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+
+    async def run() -> str:
+        first = asyncio.create_task(cache.aget())
+        second = asyncio.create_task(cache.aget())
+        await asyncio.to_thread(loader_started.wait, 5)
+        first.cancel()
+        release_loader.set()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        return await second
+
+    assert asyncio.run(run()) == "survived"
+
+
+def test_aget_failure_is_shared_and_next_call_retries():
+    """A failing shared load raises for all awaiters; next aget() retries."""
+    attempts = {"count": 0}
+
+    def loader() -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise RuntimeError("boom")
+        return "healed"
+
+    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+
+    async def run() -> str:
+        results = await asyncio.gather(*[cache.aget() for _ in range(3)], return_exceptions=True)
+        assert all(isinstance(result, RuntimeError) for result in results)
+        return await cache.aget()
+
+    assert asyncio.run(run()) == "healed"
+    assert attempts["count"] == 2
+
+
+def test_aget_cleans_up_in_flight_bookkeeping_across_event_loops():
+    """The once-gate map must not pin dead event loops (leak regression)."""
+    # Regression test for the once-gate leak: a Task strongly references the
+    # event loop it runs on (its own dictionary key), so without the done
+    # callback the weak keying never reclaims entries and one loop + task
+    # would be pinned per event loop that ever cold-loaded.
+    cache: SharedProcessCache[str] = SharedProcessCache(loader=lambda: "value")
+    for _ in range(5):
+        cache.clear_for_testing()
+        assert asyncio.run(cache.aget()) == "value"
+    assert len(cache._loads_in_flight) == 0  # pylint: disable=protected-access
+
+
+def test_clear_for_testing_drops_entry_and_pending_loads():
+    """clear_for_testing() drops the entry AND forgets pending loads."""
+    calls = {"count": 0}
+
+    def loader() -> str:
+        calls["count"] += 1
+        return f"load-{calls['count']}"
+
+    cache: SharedProcessCache[str] = SharedProcessCache(loader=loader)
+    assert cache.get() == "load-1"
+
+    async def run() -> str:
+        loop = asyncio.get_running_loop()
+        # Stand-in for a load still in flight when the clear happens: if
+        # clear_for_testing() left it behind, aget() would adopt it (it is
+        # not done) and time out below instead of starting a fresh load.
+        pending = loop.create_task(asyncio.sleep(60))
+        cache._loads_in_flight[loop] = pending  # pylint: disable=protected-access
+        cache.clear_for_testing()
+        assert cache.peek() is None
+        value = await asyncio.wait_for(cache.aget(), timeout=5)
+        pending.cancel()
+        return value
+
+    assert asyncio.run(run()) == "load-2"
+
+
+def test_clear_all_process_globals_clears_imported_and_skips_unimported(monkeypatch):
+    """The registry clears imported owners and skips unimported ones."""
+    cleared: list[str] = []
+
+    class FakeOwner:  # pylint: disable=too-few-public-methods
+        """Stand-in owner class exposing a clear method like the real caches."""
+
+        @classmethod
+        def clear_fake_for_testing(cls):
+            """Record that the registry reached this clear method."""
+            cleared.append("cleared")
+
+    fake_module = types.ModuleType("fake_process_globals_owner_module")
+    fake_module.FakeOwner = FakeOwner
+    monkeypatch.setitem(sys.modules, "fake_process_globals_owner_module", fake_module)
+    monkeypatch.setattr(
+        process_globals,
+        "PROCESS_GLOBALS",
+        [
+            ("fake_process_globals_owner_module", "FakeOwner", "clear_fake_for_testing"),
+            # Never imported: must be skipped silently (an unimported module
+            # cannot have a populated cache), not raise.
+            ("module_that_was_never_imported_for_test", "Nope", "clear_nope_for_testing"),
+        ],
+    )
+
+    process_globals.clear_all_process_globals_for_testing()
+    assert cleared == ["cleared"]
+
+
+def test_process_globals_registry_entries_resolve_when_imported():
+    """Registry triples must resolve against any imported owner module."""
+    for module_name, class_name, clear_method_name in process_globals.PROCESS_GLOBALS:
+        assert module_name.startswith("coded_tools.")
+        # Owner modules need neuro-san, so only validate the ones this test
+        # run happens to have imported; a typo'd class or method name in an
+        # imported module must fail here rather than being skipped silently.
+        module = sys.modules.get(module_name)
+        if module is not None:
+            assert callable(getattr(getattr(module, class_name), clear_method_name))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,58 +17,21 @@
 # fixtures that apply automatically to every test under this directory —
 # pytest discovers and loads it by name, so it cannot be renamed to something
 # more descriptive without the autouse fixture below silently ceasing to run.
-import sys
-
+# The inventory of the process-wide globals this fixture resets lives in
+# coded_tools/agent_network_editor/globals.py.
 import pytest
 
-# Central inventory of the process-wide caches used by the Agent Network
-# Designer family, as (module, class, test-only clear method) triples. Each
-# cache lives on its owning class as a peek / get / clear-for-testing triple
-# (see ConnectivityDictionaryConverter.get_shared_toolbox_factory() for the
-# canonical pattern). Each captures file/env-var state at its first load and
-# is never refreshed, so a test that populates one would otherwise leak that
-# state into every later test in the same process, producing order-dependent
-# results. Add an entry here whenever a new shared cache is introduced.
-_PROCESS_CACHE_CLEARERS: list[tuple[str, str, str]] = [
-    # The loaded ToolboxFactory used for connectivity-style conversion
-    # of agent network definitions (issue #1262).
-    (
-        "coded_tools.agent_network_editor.connectivity_dictionary_converter",
-        "ConnectivityDictionaryConverter",
-        "clear_shared_toolbox_factory_for_testing",
-    ),
-    # The {tool_name: description} mapping parsed from the designer's
-    # toolbox info file (issue #1268).
-    (
-        "coded_tools.agent_network_editor.get_toolbox",
-        "GetToolbox",
-        "clear_shared_toolbox_info_for_testing",
-    ),
-]
-
-
-def _clear_process_caches():
-    """
-    Clear every registered process-wide cache.
-
-    Modules are looked up via sys.modules instead of imported directly so
-    tests that never touch these classes don't pay for importing neuro-san
-    internals at collection time.
-    """
-    for module_name, class_name, clear_method_name in _PROCESS_CACHE_CLEARERS:
-        module = sys.modules.get(module_name)
-        if module is not None:
-            getattr(getattr(module, class_name), clear_method_name)()
+from coded_tools.agent_network_editor.globals import clear_all_process_globals_for_testing
 
 
 @pytest.fixture(autouse=True)
-def reset_process_caches():
+def reset_process_globals():
     """
     Clear the process-wide caches before and after each test.
 
     Clearing before the test as well guards against state populated outside
     any test, e.g. during collection or session setup.
     """
-    _clear_process_caches()
+    clear_all_process_globals_for_testing()
     yield
-    _clear_process_caches()
+    clear_all_process_globals_for_testing()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@
 # coded_tools/agent_network_editor/globals.py.
 import pytest
 
-from coded_tools.agent_network_editor.globals import clear_all_process_globals_for_testing
+from coded_tools.agent_network_editor.globals import ProcessGlobals
 
 
 @pytest.fixture(autouse=True)
@@ -32,6 +32,6 @@ def reset_process_globals():
     Clearing before the test as well guards against state populated outside
     any test, e.g. during collection or session setup.
     """
-    clear_all_process_globals_for_testing()
+    ProcessGlobals.clear_all_for_testing()
     yield
-    clear_all_process_globals_for_testing()
+    ProcessGlobals.clear_all_for_testing()


### PR DESCRIPTION
## Description

Fixes #1267

`GetSubnetwork` cached subnetwork names per `sly_data` scope, so a server handling N concurrent conversations re-parsed the same designer manifest N times — synchronously, on the event loop, once per conversation plus once per validation pass. This PR moves the `"/<network_name>"` list into a process-wide cache, following the pattern of #1262 (shared ToolboxFactory) and #1268 (shared toolbox info), with one difference: unlike those immortal caches, this source legitimately changes at runtime on local runs (the designer saves generated networks into a manifest the top file `include`s), so the cache carries a freshness fingerprint — `(manifest path, mtime, 10s TTL bucket)`. Env-var and direct manifest edits invalidate immediately; the TTL bounds staleness from `include`d files a cheap probe cannot see (notably `registries/generated/manifest.hocon`).

Since this is the third copy of the same locking/publish discipline, the mechanism is extracted into a generic **`SharedProcessCache`**: lock-free warm reads, double-checked-lock loading with publish-after-success, the optional fingerprint hook, and an async `aget()` accessor whose cold load runs in a worker thread and is shared (`shield()`-ed) by every concurrent cold caller on the loop. `ConnectivityDictionaryConverter` and `GetToolbox` now delegate to it, and the hand-rolled peek-then-`to_thread` pre-warm dances in `ProgressHandler` and the persistence middleware collapse into one-line `await`s.

Also adds **`globals.py`** as requested in #1276 review: an inventory of every process-wide cache (what it holds, where it lives, how it expires, who reads it) plus the machine-readable registry `tests/conftest.py` uses to clear them between tests.

Self-review findings fixed before this PR went up:
- The loader catches `ValueError` — neuro-san re-wraps HOCON parse errors as `ValueError`, so a `ParseException`-only catch was dead code and a malformed manifest would have crashed every call instead of publishing the documented self-expiring empty list.
- `aget()` shields the shared load task (one cancelled caller no longer cancels everyone else's load), unpins its per-loop bookkeeping via a done callback (a `Task` strongly references its own `WeakKeyDictionary` key, so entries never collected), and `clear_for_testing()` forgets in-flight loads.
- Subnetwork names are derived via neuro-san's canonical `RegistryManifestRestorer.find_external_network_names()` instead of re-rolling its mapper walk (verified identical output on the real manifest).
- `GetToolbox`'s loader treats an **empty toolbox mapping as a failed load** (warn + raise, publish nothing). This fixed a live incident: a one-off `restore()` returning `{}` was published into the fingerprint-less cache and pinned an empty toolbox until server restart. Now the failing call degrades to an empty toolbox and the next call retries and heals — verified end to end (empty read → `{}` returned, nothing cached; file reads correctly → next call gets all 9 tools, no restart).

## Impact

- **Performance**: steady-state reads are lock-free attribute probes; the manifest is parsed at most once per 10s window (or edit) process-wide, off the event loop, instead of once per conversation on it.
- **API**: `GetSubnetwork.get_subnetwork_names()` is now no-arg (both middleware callers updated); the `SUBNETWORK_NAMES` sly_data key is gone — it was purely internal, never exposed in any hocon `to_upstream`/`from_downstream` allowlist. The per-session descriptions cache in `get_subnetworks()` stays, since it needs a live `run_context`.
- **Removed accessors**: `peek_shared_toolbox_factory`, `peek_/get_shared_toolbox_info`, and the new cache's peek were orphaned when call sites moved to the async accessors, and are deleted rather than shipped dead.
- **Freshness semantics** (documented in code comments): a missing manifest heals the moment the file appears; a malformed one serves an empty list for at most one TTL window, then retries; an empty toolbox read is never cached. Validation now reads the shared list rather than a per-session snapshot — safe under the deployment assumption that server deployments never write the manifest at runtime (generated networks are only saved into the local manifest on local runs, where the TTL bounds staleness after a save).

## Screenshots / Logs / Examples (optional)

New stdlib-only test suite for the shared mechanism (runs without neuro-san imports):

```
$ pytest tests/coded_tools/agent_network_editor/ -q
11 passed
```

Covers load-once, failure-retry, fingerprint freshness (including capture-before-load), once-gate sharing, cancellation shielding, the leak regression, clear-with-pending-loads, and the globals registry.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

