### PR TITLE
Address post-merge review feedback on the shared process caches

### DIFF
--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -108,7 +108,8 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         Get the process-wide ToolboxFactory, creating and load()-ing it on
         the first call in the process: that one cold load (file I/O + HOCON
         parse) runs off the event loop, shared by concurrent cold callers;
-        warm calls return via the lock-free peek without awaiting.
+        warm calls resolve via the lock-free peek without suspending the
+        caller (the await completes immediately).
 
         This is the accessor call sites should use — hand-rolling the
         peek-then-to_thread dance per caller is how a caller forgets the

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -103,29 +103,18 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         self.toolbox_factory: ContextTypeToolboxFactory | None = toolbox_factory
 
     @classmethod
-    def get_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory:
+    async def get_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory:
         """
-        Get the process-wide ToolboxFactory, creating and load()-ing it on first call.
+        Get the process-wide ToolboxFactory, creating and load()-ing it on
+        the first call in the process: that one cold load (file I/O + HOCON
+        parse) runs off the event loop, shared by concurrent cold callers;
+        warm calls return via the lock-free peek without awaiting.
 
-        The first call in the process does file I/O plus a HOCON parse, so
-        this must not be called on an event loop — async callers use
-        aget_shared_toolbox_factory(), which keeps the cold load in a worker
-        thread. Once loaded, calls return via a lock-free read.
-
-        :return: The shared, already-load()-ed ToolboxFactory instance.
-        """
-        return ConnectivityDictionaryConverter._shared_toolbox_factory_cache.get()
-
-    @classmethod
-    async def aget_shared_toolbox_factory(cls) -> ContextTypeToolboxFactory:
-        """
-        Async accessor for the process-wide ToolboxFactory: the one cold load
-        runs off the event loop (shared by concurrent cold callers); warm
-        calls return via the lock-free peek without awaiting.
-
-        This is the accessor async call sites should use — hand-rolling the
+        This is the accessor call sites should use — hand-rolling the
         peek-then-to_thread dance per caller is how a caller forgets the
-        pre-warm and silently blocks the event loop on a cold process.
+        pre-warm and silently blocks the event loop on a cold process. (The
+        synchronous from_dict() is the one exception: it reads the
+        underlying cache directly.)
 
         :return: The shared, already-load()-ed ToolboxFactory instance.
         """
@@ -200,7 +189,12 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         # caller benefits from the cache without having to pass one in.
         toolbox_factory: ContextTypeToolboxFactory | None = self.toolbox_factory
         if toolbox_factory is None:
-            toolbox_factory = self.get_shared_toolbox_factory()
+            # from_dict() is synchronous (DictionaryConverter interface), so
+            # it reads the shared cache directly — a lock-free hit once warm.
+            # Async call sites pre-warm via get_shared_toolbox_factory(), so
+            # in practice the blocking first load has already happened off
+            # the event loop by the time this line runs.
+            toolbox_factory = ConnectivityDictionaryConverter._shared_toolbox_factory_cache.get()
 
         reporter: ConnectivityReporter = ConnectivityReporter(inspector, toolbox_factory)
         connectivity = reporter.report_network_connectivity()

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -37,15 +37,6 @@ from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 DEFAULT_MANIFEST_FILE = os.path.join("registries", "manifest_and.hocon")
 
-# Upper bound on how stale the shared subnetwork-names list can get from
-# changes a cheap probe cannot see (see _manifest_fingerprint below). One
-# manifest parse per window (~15-20ms, off the event loop) is the whole
-# steady-state refresh cost. Deployment assumption: server deployments never
-# write the manifest at runtime — generated networks are only saved into the
-# local manifest on local runs — so this TTL exists to keep local runs fresh
-# after a save and otherwise acts as a safety net.
-SUBNETWORK_NAMES_TTL_SECONDS: float = 10.0
-
 logger = AndLogger(logging.getLogger(__name__))
 
 
@@ -81,6 +72,29 @@ class GetSubnetwork(BranchActivation, CodedTool):
         return os.getenv("AGENT_NETWORK_DESIGNER_MANIFEST_FILE") or DEFAULT_MANIFEST_FILE
 
     @staticmethod
+    def _manifest_update_period_seconds() -> float:
+        """
+        :return: The manifest refresh period, read from the same
+                AGENT_MANIFEST_UPDATE_PERIOD_SECONDS setting that drives the
+                neuro-san server's own periodic manifest updates (<= 0
+                disables them; unset mirrors the server's default of 0, and
+                the studio's local runner exports 5). Keying the shared
+                subnetwork-names cache to this signal keeps the designer's
+                view aligned with what the server can actually serve: when
+                the server never picks up new manifest entries, a fresher
+                name list would only advertise networks that are not
+                reachable yet — so on a static server the cached list goes
+                static too (a manifest path or mtime change still refreshes
+                it). When updates are enabled, one manifest parse per period
+                (~15-20ms, off the event loop, and only if a caller actually
+                reads in that period) is the whole steady-state refresh cost.
+        """
+        try:
+            return float(os.getenv("AGENT_MANIFEST_UPDATE_PERIOD_SECONDS", "0"))
+        except ValueError:
+            return 0.0
+
+    @staticmethod
     def _manifest_fingerprint() -> tuple[str, int | None, int]:
         """
         Freshness probe for the shared subnetwork-names cache (see
@@ -91,12 +105,15 @@ class GetSubnetwork(BranchActivation, CodedTool):
         * the resolved path — an env-var change takes effect on the next read;
         * the manifest file's mtime — a direct edit invalidates immediately, and
           a missing manifest (mtime None) self-heals the moment the file appears;
-        * a time bucket that rolls every SUBNETWORK_NAMES_TTL_SECONDS — the
-          manifest composes other manifests via `include` (notably
-          registries/generated/manifest.hocon, which grows every time the
-          designer saves a network on a local run; server deployments never
-          write the manifest), and a cheap probe cannot see those included
-          files, so the TTL bounds that staleness instead.
+        * a time bucket that rolls once per manifest-update period (see
+          _manifest_update_period_seconds) — the manifest composes other
+          manifests via `include` (notably registries/generated/manifest.hocon,
+          which grows every time the designer saves a network on a local run;
+          server deployments never write the manifest), and a cheap probe
+          cannot see those included files, so the rolling bucket bounds that
+          staleness instead. With updates disabled (period <= 0, the
+          static-server default) the bucket is constant, so only a path or
+          mtime change invalidates.
 
         :return: (path, mtime_ns or None, time bucket) tuple.
         """
@@ -105,7 +122,8 @@ class GetSubnetwork(BranchActivation, CodedTool):
             mtime_ns: int | None = os.stat(manifest_file).st_mtime_ns
         except OSError:
             mtime_ns = None
-        time_bucket: int = int(monotonic() / SUBNETWORK_NAMES_TTL_SECONDS)
+        period: float = GetSubnetwork._manifest_update_period_seconds()
+        time_bucket: int = int(monotonic() / period) if period > 0 else 0
         return (manifest_file, mtime_ns, time_bucket)
 
     @staticmethod
@@ -121,10 +139,12 @@ class GetSubnetwork(BranchActivation, CodedTool):
         :return: List of subnetwork name strings (in "/<network_name>" form).
                 A missing or unparseable manifest returns an empty list, which IS
                 published: unlike an immortal cache this entry expires on its own
-                (mtime change or TTL bucket roll, whichever comes first), so a
-                bad manifest cannot poison the process beyond one TTL window —
-                and publishing the empty result prevents a per-call parse storm
-                within that window.
+                (mtime change or manifest-update-period roll, whichever comes
+                first), so a bad manifest cannot poison the process beyond one
+                refresh period — and publishing the empty result prevents a
+                per-call parse storm within it. (On a static server with
+                updates disabled, healing relies on the mtime/path change that
+                fixing the manifest entails.)
         """
         manifest_file: str = GetSubnetwork._resolve_manifest_file()
 
@@ -186,9 +206,11 @@ class GetSubnetwork(BranchActivation, CodedTool):
     # caches, this source legitimately changes at runtime on local runs —
     # the designer saves every generated network into a manifest the top
     # file `include`s; server deployments persist elsewhere and never write
-    # it — so the fingerprint (path + mtime + TTL bucket, see
-    # _manifest_fingerprint) keeps the list at most SUBNETWORK_NAMES_TTL_SECONDS
-    # stale. Locking, publish ordering, and the async once-gate live in
+    # it — so the fingerprint (path + mtime + a manifest-update-period
+    # bucket, see _manifest_fingerprint) keeps the list at most one
+    # AGENT_MANIFEST_UPDATE_PERIOD_SECONDS period stale, the same cadence at
+    # which the server itself picks up new manifest entries.
+    # Locking, publish ordering, and the async once-gate live in
     # SharedProcessCache; access goes through the class by name (not cls) so
     # a hypothetical subclass shares the one cache instead of splitting it.
     _shared_subnetwork_names_cache: SharedProcessCache[list[str]] = SharedProcessCache(
@@ -216,7 +238,7 @@ class GetSubnetwork(BranchActivation, CodedTool):
         Used by callers (e.g. middleware) that need to validate subnetwork references
         but do not have access to a run_context. Reads only the manifest HOCON, not
         each subnetwork's HOCON — and at most once per process per
-        SUBNETWORK_NAMES_TTL_SECONDS (or manifest edit), off the event loop,
+        manifest-update period (or manifest edit), off the event loop,
         shared by concurrent cold callers.
 
         :return: List of subnetwork name strings (in "/<network_name>" form), or an
@@ -257,7 +279,7 @@ class GetSubnetwork(BranchActivation, CodedTool):
 
             # Get the curated subset of names from the designer manifest.
             # Cheap: served from the process-wide cache.
-            names: list[str] = await GetSubnetwork.get_subnetwork_names()
+            names: list[str] = await self.get_subnetwork_names()
             if not names:
                 sly_data[SUBNETWORKS] = {}
                 return {}

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -44,7 +44,7 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #    Holds:   a load()-ed neuro-san ContextTypeToolboxFactory used to render
     #             connectivity-style views of agent network definitions.
     #    Lives:   connectivity_dictionary_converter.ConnectivityDictionaryConverter
-    #             (get_/aget_shared_toolbox_factory)
+    #             (async get_shared_toolbox_factory)
     #    Expiry:  none — loaded once; restart to pick up an edited
     #             AGENT_TOOLBOX_INFO_FILE.
     #    Used by: ConnectivityDictionaryConverter.from_dict() (fallback when no
@@ -68,12 +68,15 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #    Holds:   the "/<network_name>" list parsed from the designer manifest
     #             (AGENT_NETWORK_DESIGNER_MANIFEST_FILE).
     #    Lives:   get_subnetwork.GetSubnetwork (async get_subnetwork_names)
-    #    Expiry:  manifest path/mtime change, or at most
-    #             get_subnetwork.SUBNETWORK_NAMES_TTL_SECONDS (the manifest
+    #    Expiry:  manifest path/mtime change, or one
+    #             AGENT_MANIFEST_UPDATE_PERIOD_SECONDS period when manifest
+    #             updates are enabled — the same setting that drives the
+    #             server's own manifest refresh; <= 0 (static server) means no
+    #             time-based expiry. The period matters because the manifest
     #             `include`s other manifests a cheap probe cannot see, notably
     #             registries/generated/manifest.hocon which grows as the designer
     #             saves networks on local runs; server deployments never write
-    #             the manifest at runtime).
+    #             the manifest at runtime.
     #    Used by: GetSubnetwork.get_subnetworks() (the coded tool path);
     #             agent_network_structure_validation_middleware
     #             .AgentNetworkStructureValidationMiddleware.validate();

--- a/coded_tools/agent_network_editor/progress_handler.py
+++ b/coded_tools/agent_network_editor/progress_handler.py
@@ -273,11 +273,11 @@ class ProgressHandler:
 
             # Warm the process-wide ToolboxFactory cache that from_dict()
             # falls back to. Only the first call in the process pays for the
-            # file read + HOCON parse, off the event loop; once warm, aget's
+            # file read + HOCON parse, off the event loop; once warm, its
             # peek and the fallback inside from_dict() are lock-free reads
             # with no thread hop, no lock traffic, and no actual suspension
             # between the throttle stamp and the conversion snapshot.
-            await ConnectivityDictionaryConverter.aget_shared_toolbox_factory()
+            await ConnectivityDictionaryConverter.get_shared_toolbox_factory()
 
             # Do the conversion
             use_key: str = "connectivity_info"

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -157,9 +157,10 @@ class SharedProcessCache(Generic[CachedValue]):
 
     async def aget(self) -> CachedValue:
         """
-        Async get(): warm reads return via the lock-free peek with no
-        awaiting at all; a cold load runs in a worker thread, shared by every
-        concurrent cold caller on this event loop.
+        Async get(): warm reads resolve via the lock-free peek without
+        suspending the caller (the await completes immediately); a cold load
+        runs in a worker thread, shared by every concurrent cold caller on
+        this event loop.
 
         :return: The cached or freshly loaded value. Loader exceptions
                 propagate to every caller awaiting that load, and the next

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -36,10 +36,10 @@ from typing import Generic
 from typing import TypeVar
 from weakref import WeakKeyDictionary
 
-T = TypeVar("T")
+CachedValue = TypeVar("CachedValue")
 
 
-class SharedProcessCache(Generic[T]):
+class SharedProcessCache(Generic[CachedValue]):
     """
     Process-wide cache of a single expensive value, safe across threads and
     event loops.
@@ -76,7 +76,7 @@ class SharedProcessCache(Generic[T]):
       load out from under the others.
     """
 
-    def __init__(self, loader: Callable[[], T], fingerprint: Callable[[], Any] | None = None):
+    def __init__(self, loader: Callable[[], CachedValue], fingerprint: Callable[[], Any] | None = None):
         """
         Constructor
 
@@ -89,7 +89,7 @@ class SharedProcessCache(Generic[T]):
         self._fingerprint = fingerprint
         # The one shared slot: None, or a (value, fingerprint-at-load) pair
         # stored as a single tuple so lock-free readers see it atomically.
-        self._entry: tuple[T, Any] | None = None
+        self._entry: tuple[CachedValue, Any] | None = None
         self._lock = Lock()
         # Per-event-loop in-flight load task, so concurrent async callers on
         # one loop share a single to_thread() dispatch. Entries are removed
@@ -100,7 +100,7 @@ class SharedProcessCache(Generic[T]):
         # the lock in get() still serializes the actual work.
         self._loads_in_flight: WeakKeyDictionary = WeakKeyDictionary()
 
-    def peek(self) -> T | None:
+    def peek(self) -> CachedValue | None:
         """
         :return: The cached value if it is present and still fresh per the
                 fingerprint, else None. Lock-free and safe to call from any
@@ -109,7 +109,7 @@ class SharedProcessCache(Generic[T]):
                 result as read-only unless the owner documents otherwise — it
                 is the live shared value, not a copy.
         """
-        entry: tuple[T, Any] | None = self._entry
+        entry: tuple[CachedValue, Any] | None = self._entry
         if entry is None:
             return None
         value, loaded_fingerprint = entry
@@ -119,7 +119,7 @@ class SharedProcessCache(Generic[T]):
             return None
         return value
 
-    def get(self) -> T:
+    def get(self) -> CachedValue:
         """
         Get the value, running the loader on a miss (first call in the
         process, or the fingerprint went stale).
@@ -132,7 +132,7 @@ class SharedProcessCache(Generic[T]):
                 propagate without publishing anything, so the next call
                 retries.
         """
-        value: T | None = self.peek()
+        value: CachedValue | None = self.peek()
         if value is not None:
             return value
 
@@ -142,7 +142,7 @@ class SharedProcessCache(Generic[T]):
             # waited for the lock, and as the freshness capture stored with
             # the value below — so a stat-style probe runs once, not twice.
             current_fingerprint: Any = self._fingerprint() if self._fingerprint is not None else None
-            entry: tuple[T, Any] | None = self._entry
+            entry: tuple[CachedValue, Any] | None = self._entry
             if entry is not None and (self._fingerprint is None or entry[1] == current_fingerprint):
                 return entry[0]
 
@@ -155,7 +155,7 @@ class SharedProcessCache(Generic[T]):
 
         return value
 
-    async def aget(self) -> T:
+    async def aget(self) -> CachedValue:
         """
         Async get(): warm reads return via the lock-free peek with no
         awaiting at all; a cold load runs in a worker thread, shared by every
@@ -165,7 +165,7 @@ class SharedProcessCache(Generic[T]):
                 propagate to every caller awaiting that load, and the next
                 aget() starts a fresh attempt.
         """
-        value: T | None = self.peek()
+        value: CachedValue | None = self.peek()
         if value is not None:
             return value
 

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -207,7 +207,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             # the export would otherwise pay the one-time toolbox file read
             # and HOCON parse on the event loop.
             if agent_progress_style == "connectivity":
-                await ConnectivityDictionaryConverter.aget_shared_toolbox_factory()
+                await ConnectivityDictionaryConverter.get_shared_toolbox_factory()
             self._determine_exported_network_definition(self.sly_data, agent_progress_style)
 
             self.logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)


### PR DESCRIPTION
## Description

Follow-ups from the post-merge review of #1277, kept separate from the upcoming GetMcpTool work (#1269) so each maps 1:1 to a review comment:

- **Rename the cache generic `T` → `CachedValue`** — descriptive and greppable, per the review summary. (`CachedType` was also suggested inline, but pylint's TypeVar naming rule rejects names ending in `Type`; `CachedValue` passes.)
- **Key the subnetwork-names refresh to `AGENT_MANIFEST_UPDATE_PERIOD_SECONDS`** instead of a fixed 10s TTL — the same setting that drives the neuro-san server's own periodic manifest updates (`<= 0`/unset disables them; the studio's local runner exports 5). To answer the review question directly: there is **no background process** either way — the fingerprint probe runs on demand when a read arrives, so an idle server does nothing. What changes is the on-demand staleness rule: on a static server (period `<= 0`) the time bucket is frozen and only a manifest path/mtime change triggers a re-parse — correctly so, because when the server never picks up new manifest entries, a fresher name list would only advertise networks that aren't reachable yet. When updates are enabled, the designer's view now refreshes on exactly the cadence at which the server starts serving new networks (locally: 5s, previously mismatched at 10s).
- **One async accessor per cache, consistently named**: `get_shared_toolbox_factory()`/`aget_shared_toolbox_factory()` collapse into a single async `get_shared_toolbox_factory()`, matching `get_subnetwork_names()` and `get_toolbox_info()`. The synchronous `from_dict()` (bound by the `DictionaryConverter` interface) reads the underlying cache directly, with a comment explaining why.
- **`self.get_subnetwork_names()`** inside `get_subnetworks()`, per the nit.

One review comment deliberately **not** changed: the `list(...)` copy in `get_subnetwork_names()` stays — the stored list is the live shared cache, and returning it directly would let any caller's mutation corrupt every conversation in the process; a shallow copy of ~17 strings is the cheap insurance.

Note on history: this change briefly landed on `main` directly as 04b9dd9f (admin push, no PR) and was reverted in 1c779a7f; this PR re-applies it as a fresh commit so it goes through review normally.

## Impact

- No public API change outside the designer family: the renamed accessor's only callers (progress handler, persistence middleware) are updated in this PR; no hocon or sly_data changes.
- Refresh behavior: static deployments (env unset or `<= 0`) no longer re-parse the manifest every 10s under traffic — they never re-parse until the manifest path/mtime changes. Local studio runs refresh every 5s (the runner's default) instead of 10s.
- A malformed manifest on a static server now heals via the mtime/path change that fixing it entails, rather than by TTL expiry (documented in the loader docstring).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
