### PR TITLE
Add AGENTS.md contribution guide for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,22 @@
-# CLAUDE.md
+# AGENTS.md
 
-Guidance for Claude working with **neuro-san-studio** — a playground for the
+Guidance for coding agents (Claude, and others) working with **neuro-san-studio** — a playground for the
 [neuro-san](https://github.com/cognizant-ai-lab/neuro-san) framework. You build **multi-agent networks**
 declaratively in **HOCON** config files; add Python (a "coded tool") only when an agent needs deterministic logic
 (API calls, DB queries, math).
 
 Sections link the real docs — open them for detail instead of trusting this summary.
-**Start here:** [tutorial.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/tutorial.md)
+**Start here:** [tutorial.md](docs/tutorial.md)
 (build your first network) ·
-[examples.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples.md)
+[examples.md](docs/examples.md)
 (one example per feature — fastest way to find how to build something).
 
 ---
 
 ## 0. First-time setup
 
-**Inside this repo** (not installed yet; needs Python 3.12/3.13 + `make`, macOS/Linux — Windows steps in
+**Inside this repo** (not installed yet; needs Python 3.12/3.13 — the version CONTRIBUTING.md recommends for
+development, though `pyproject.toml`'s installable floor is 3.10 — + `make`, macOS/Linux — Windows steps in
 [CONTRIBUTING.md](CONTRIBUTING.md)):
 
 ```bash
@@ -34,23 +35,29 @@ ns init             # scaffolds config/, mcp/, registries/ + shared aaosa*.hocon
 Either way: ask which LLM provider(s) the user wants, have them set the key in `.env`
 (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`, §6), then verify with
 `ns check-llm-keys && ns check-config`. Full CLI:
-[cli.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cli.md).
+[cli.md](docs/cli.md).
 
 ## 1. Repository layout
 
-| Path | Purpose |
-|------|---------|
-| `registries/` | HOCON networks + `manifest.hocon`, plus shared includes (`aaosa.hocon`, `llm_config.hocon`). Curated examples in `basic/`, `tools/`, `industry/`, `experimental/`; your networks go in `generated/`. |
-| `coded_tools/<agent_name>/` | Python `CodedTool` implementations (resolved via `AGENT_TOOL_PATH`, default `coded_tools/`). |
-| `neuro_san_studio/` | The framework: `ns` CLI, server runner, importer/exporter, toolbox, MCP, plugins. |
-| `middleware/` | Reusable `AgentMiddleware` implementations: Designer, skills, persistent memory, checklist. |
-| `config/` | LLM config (`llm_config.hocon`) + plugin config (`plugins.hocon`); created by `ns init`. |
-| `apps/` | Example apps built on networks (Flask UIs, Slack app) — §12. |
-| `servers/` | Standalone **example** a2a / mcp servers (e.g. a demo MCP server to test against) — not needed to use MCP. |
-| `skills/` | Example skill folders (each a `SKILL.md`) for `AgentSkillsMiddleware` (§10). |
-| `deploy/` | Container/deploy assets: `Dockerfile`, `build.sh`, `entrypoint.sh`, `run.sh`. |
-| `docs/` | Tutorials, examples, CLI docs, dev guide. |
-| `tests/fixtures/` | HOCON test cases; `tests/integration/` drives them. |
+- `registries/` — HOCON networks + `manifest.hocon`, plus the shared `aaosa.hocon` substitution file. Curated
+  examples in `basic/`, `tools/`, `industry/`, `experimental/`; your networks go in `generated/` (git-ignored —
+  absent on a fresh clone, only appears once you or the Designer create something there).
+- `coded_tools/<agent_name>/` — Python `CodedTool` implementations (resolved via `AGENT_TOOL_PATH`, default
+  `coded_tools/`).
+- `neuro_san_studio/` — the framework: `ns` CLI, server runner, importer/exporter, toolbox, MCP, plugins.
+- `middleware/` — reusable `AgentMiddleware` implementations: Designer, skills, persistent memory, checklist.
+- `config/` — LLM config (`llm_config.hocon`, §6) + plugin config (`plugins.hocon`, §11); already present if you
+  cloned this repo, otherwise scaffolded by `ns init`.
+- `apps/` — example apps built on networks (Flask UIs, Slack app) — §12.
+- `servers/` — standalone **example** a2a / mcp servers (e.g. a demo MCP server to test against) — not needed to
+  use MCP.
+- `skills/` — example skill folders (each a `SKILL.md`) for `AgentSkillsMiddleware` (§10).
+- `deploy/` — container/deploy assets: `Dockerfile`, `build.sh`, `entrypoint.sh`, `run.sh`.
+- `docs/` — tutorials, examples, CLI docs, dev guide.
+- `tests/fixtures/` — HOCON test cases; `tests/integration/` drives them.
+
+> `registries/llm_config.hocon` is a **deprecated backward-compatibility shim** pointing at `config/llm_config.hocon`
+> (§6) — don't treat it as a convention to `include`; use `config/llm_config.hocon` directly.
 
 ## 2. Delegation between agents (AAOSA)
 
@@ -65,7 +72,7 @@ include "registries/aaosa.hocon",
 "instructions": ${instructions_prefix} """Your name is TV. ...""" ${aaosa_instructions},
 ```
 
-Docs: [user_guide.md → AAOSA](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#aaosa).
+Docs: [user_guide.md → AAOSA](docs/user_guide.md#aaosa).
 
 ## 3. The build loop
 
@@ -74,8 +81,8 @@ To build a new network:
 1. **Generate a baseline** with the Agent Network Designer (§4) from a plain-English use case.
 2. **Refine the HOCON by hand** (§5): improve instructions, add branch agents, and wire in
    tools/mcp/middleware/apps as required.
-3. **Register and enable** it in `registries/generated/manifest.hocon` (§5) — the Designer usually does this, but
-   verify.
+3. **Register and enable** it in `registries/generated/manifest.hocon` (§5, create the file if it's not there yet)
+   — the Designer usually does this, but verify.
 4. **Lint and load it** to confirm the HOCON parses and runs correctly (`ns run` / `ns chat`, §13).
 5. **Add test fixtures** with ANTeGen to check the network behaves as required; if not, refine it (§14).
 6. **Documentation** is opt-in — ask the user first (§15).
@@ -97,14 +104,13 @@ ns chat agent_network_designer --one-shot --first_prompt_file /tmp/prompt.txt \
   --sly_data '{"agent_network_hocon_file": "registries/generated/coffee_shop.hocon"}'
 ```
 
-The Designer gives a baseline only — refining the `.hocon` yourself (§5) is expected. Docs:
-[cli/chat.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cli/chat.md).
+The Designer gives a baseline only — refining the `.hocon` yourself (§5) is expected.
+Docs: [cli/chat.md](docs/cli/chat.md).
 
 ## 5. Agent network HOCON
 
-A network is one `.hocon` file (JSON + comments, multi-line strings, `${}` substitutions). Docs:
-[agent HOCON reference](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md),
-[user_guide.md → Hocon files](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#hocon-files).
+A network is one `.hocon` file (JSON + comments, multi-line strings, `${}` substitutions).
+Docs: [agent HOCON reference](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md), [user_guide.md → Hocon files](docs/user_guide.md#hocon-files).
 
 ### Agent types
 
@@ -129,25 +135,28 @@ A network is one `.hocon` file (JSON + comments, multi-line strings, `${}` subst
 
 ### Registering the network (manifest)
 
-`registries/manifest.hocon` includes per-group manifests. Add yours to `registries/generated/manifest.hocon` as
-`"my_network.hocon": true` (serve + list), or the detailed form
+`registries/manifest.hocon` includes per-group manifests, including `registries/generated/manifest.hocon` — that
+directory/file is git-ignored (§1) and **absent on a fresh clone**; create both if they don't exist yet (an empty
+`{}` is a valid starting manifest). Add yours as `"my_network.hocon": true` (serve + list), or the detailed form
 `{ "serve": true, "public": false, "mcp": true }` — `serve` loads/runs it, `public` lists it in `/list` (set
 `false` to keep it reachable but unlisted, e.g. a support network), `mcp` exposes it as an MCP tool (§9).
-Docs:
-[manifest_hocon_reference.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/manifest_hocon_reference.md).
+Docs: [manifest_hocon_reference.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/manifest_hocon_reference.md).
+
+A manifest key registered from a subfolder's manifest (e.g. `"my_network.hocon": true` inside
+`registries/generated/manifest.hocon`) registers the runtime agent name **with that folder prefix** —
+`generated/my_network`. Run/chat with the prefixed name (`ns chat generated/my_network`, §13) always.
 
 ## 6. LLM configuration
 
-All example/generated networks import a top-level `llm_config` file (§5) so model choice lives in one place. What it resolves to
-(provider, model, fallback order) is in [config/llm_config.hocon](config/llm_config.hocon) which in turn points to
-[developer_llm_config.hocon](config/developer_llm_config.hocon).
+All example/generated networks import a top-level `llm_config` file (§5) so model choice lives in one place. What it
+resolves to (provider, model, fallback order) is in [config/llm_config.hocon](config/llm_config.hocon), which in
+turn points to [developer_llm_config.hocon](config/developer_llm_config.hocon).
 Compatible providers include `openai`, `anthropic`, `azure-openai`, `gemini`, `nvidia`, `ollama`, `bedrock`, or a
 custom LangChain `class` (key setup in §0). The built-in model catalog is
 [default_llm_info.hocon](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon).
-End-users can also pass their own keys at request time via `sly_data.llm_config` (§8; see `byok_llm_config.hocon`).
-
-Docs:
-[agent HOCON reference → llm_config](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#llm_config).
+End-users can also pass their own keys at request time via `sly_data.llm_config` (§8; see
+[config/byok_llm_config.hocon](config/byok_llm_config.hocon) for the pattern).
+Docs: [llm_config](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#llm_config).
 
 ## 7. Toolbox: pre-built tools
 
@@ -158,10 +167,8 @@ Gmail/Jira, …). Reference by name; pass settings via `args` (merged over the t
 { "name": "policy_web_search", "toolbox": "ddgs_search", "args": { "num_results": 3 } }
 ```
 
-Catalog:
-[toolbox_info.hocon](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/neuro_san_studio/toolbox/toolbox_info.hocon)
-Defining/Customizing:
-[toolbox_info_hocon_reference.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/toolbox_info_hocon_reference.md).
+Available tools: [toolbox_info.hocon](neuro_san_studio/toolbox/toolbox_info.hocon)
+Defining/Customizing tools: [toolbox_info_hocon_reference.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/toolbox_info_hocon_reference.md).
 
 ## 8. Coded tools, sly_data, external APIs
 
@@ -173,20 +180,29 @@ class inside it (snake_case → PascalCase). So `order_lookup.py` with `class Or
 loop.
 
 ```python
+from typing import Any, Dict
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+
 class OrderLookup(CodedTool):
+    """Looks up order status by order ID."""
+
     async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Any:
-        return f"Order {args['order_id']} is shipped"
+        order_id = args.get("order_id")
+        return f"Order {order_id} is shipped"
 ```
 
 `args` comes from `function.parameters`; `sly_data` is the private dict below. No-args constructor, JSON-friendly
 return, wrap blocking I/O in `asyncio.to_thread(...)`. Docs:
-[user_guide.md → Coded tools](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#coded-tools).
+[user_guide.md → Coded tools](docs/user_guide.md#coded-tools).
 
 **sly_data** — network-wide private channel for secrets/inter-agent state: client passes it in, any coded tool
 reads/writes it, never reaches the LLM stream. Use a distinct key per purpose (any tool that reads sly_data reads
 all of it). Doesn't cross into external/other-network agents without an explicit `allow` policy; schemas are
-Front-Man-only. Also carries MCP auth headers (§9). `allow` schema:
-[agent HOCON reference → allow](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#allow).
+Front-Man-only. Also carries MCP auth headers (§9). **Never log or print sly_data** — that defeats the entire
+point of keeping secrets out of the chat stream. `allow` schema, agent HOCON reference:
+[allow](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#allow).
 
 **Finding a new API** — reuse the toolbox (§7) and `registries/tools/` vendor adapters (§9) first. Else search
 [public-apis](https://github.com/public-apis/public-apis), [APIs.guru](https://apis.guru/),
@@ -201,7 +217,7 @@ An agent can consume/expose **MCP** tools, delegate to **other networks**, or br
 
 1. **MCP** — reference a server by URL (starts `https://mcp` or ends `/mcp`); its tools become callable. Auth
    headers travel via `sly_data.http_headers` (keyed by MCP URL) or server-side in
-   [mcp_info.hocon](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/neuro_san_studio/mcp/mcp_info.hocon)
+   [mcp_info.hocon](neuro_san_studio/mcp/mcp_info.hocon)
    (`MCP_SERVERS_INFO_FILE`). Expose your own network as MCP with `"mcp": true` in its manifest (§5). Docs:
    [mcp_service.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/mcp_service.md).
 2. **Other neuro-san networks** — list one as a tool to hand off a query (compose "agent webs"). sly_data only
@@ -213,137 +229,154 @@ An agent can consume/expose **MCP** tools, delegate to **other networks**, or br
    ```
 
 3. **Other frameworks** (A2A, CrewAI, LangGraph) — bridge with a coded tool acting as a client, e.g. the
-   [A2A research report](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/a2a_research_report.md).
+   [A2A research report](docs/examples/tools/a2a_research_report.md).
 4. **SaaS adapters** in `registries/tools/` — copy one as a starting point: Salesforce
-   [Agentforce](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/agentforce.md)
+   [Agentforce](docs/examples/tools/agentforce.md)
    (`agentforce.hocon`), Google
-   [Agentspace](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/agentspace_adapter.md)
+   [Agentspace](docs/examples/tools/agentspace_adapter.md)
    (`agentspace_adapter.hocon`),
-   [ServiceNow](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/now_agents.md),
+   [ServiceNow](docs/examples/tools/now_agents.md),
    and others.
 
 ## 10. Middleware (skills, memory, checklist)
 
 **Middleware** injects code at agent hook points (`abefore_agent`/`aafter_agent`, `abefore_model`/`aafter_model`,
 `awrap_model_call`, `awrap_tool_call` — async preferred). Attach per agent via `middleware` (order matters);
-class-based `AgentMiddleware` only. Docs:
-[user_guide.md → Middleware](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#middleware).
-Three commonly used middlewares ship with the repo:
+class-based `AgentMiddleware` only.
+Docs: [user_guide.md → Middleware](docs/user_guide.md#middleware).
 
+Three commonly used middlewares ship with the repo:
 - **Skills** (`agent_skills_middleware.AgentSkillsMiddleware`, args `skill_sources`/`keep_skill_in_context`) — a
   skill is a folder with a `SKILL.md`; metadata loads first, content pulls in on demand (progressive disclosure).
-  Example: [job_guessing_skill.hocon](registries/basic/job_guessing_skill.hocon). Docs:
-  [user_guide.md → Agent Skills](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#agent-skills).
+  Example: [job_guessing_skill.hocon](registries/basic/job_guessing_skill.hocon).
+  Docs: [user_guide.md → Agent Skills](docs/user_guide.md#agent-skills).
   **Security:** review any internet-sourced skill — it can reference untrusted tools/resources.
 - **Persistent memory** (`persistent_memory.persistent_memory_middleware.PersistentMemoryMiddleware`) — memory
   across sessions (create/read/append/delete/search/list). Attach to **your own** agent, don't import the
   reference network. Backends: `json_file`/`markdown_file` (local, per `(network, agent)`, **not** per user) or
   `mem0` (cloud, per end user — for shared/production). Refs: `registries/tools/persistent_memory_local.hocon`,
-  `persistent_memory_mem0.hocon`; docs
-  [local](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/persistent_memory_local.md)
-  ·
-  [mem0](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/persistent_memory_mem0.md).
+  `persistent_memory_mem0.hocon`.
+  Docs: [local](docs/examples/tools/persistent_memory_local.md), [mem0](docs/examples/tools/persistent_memory_mem0.md).
 - **Checklist** (`agent_checklist_middleware.AgentChecklistMiddleware`, args `checklist_title`/
   `keep_checklist_in_context`/`progress_reporter`) — `pending`/`in_progress`/`done`/`skipped` tracking for
-  multi-step tasks. Example:
-  [coding_assistant.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/basic/coding_assistant.md).
+  multi-step tasks.
+  Example: [coding_assistant.md](docs/examples/basic/coding_assistant.md).
 
 ## 11. Plugins (observability, logging, authorization)
 
-**Plugins** extend the server for deployment use-cases; registered in `config/plugins.hocon`, toggled by env var,
-never required to run. All extend `BasePlugin` (`neuro_san_studio/interfaces/base_plugin.py`). Docs (with links to
-each tool's own docs): [plugins.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/plugins.md).
+**Plugins** extend the server for deployment use-cases, never required to run.
+Docs (with links to each tool's own docs): [plugins.md](docs/plugins.md).
 
-- **Observability** — Langfuse / Arize Phoenix / LangSmith. Off by default (`LANGFUSE_ENABLED`, `PHOENIX_ENABLED`,
-  `LANGSMITH_TRACING`).
-- **Logging** — Log Bridge, Rich structured console logs. On by default (`LOGBRIDGE_ENABLED` to disable).
-- **Authorization** — Open FGA (ReBAC).
+- **Observability** — Langfuse and Arize Phoenix are `BasePlugin` (`neuro_san_studio/interfaces/base_plugin.py`)
+  subclasses registered in `config/plugins.hocon`, toggled by env var (`LANGFUSE_ENABLED`, `PHOENIX_ENABLED`; off by
+  default). LangSmith needs **no plugin at all** — LangChain's own tracing works out of the box, just set
+  `LANGSMITH_TRACING=true` / `LANGSMITH_API_KEY`.
+- **Logging** — Log Bridge is a `BasePlugin` in `config/plugins.hocon`, on by default (`LOGBRIDGE_ENABLED` to
+  disable); gives Rich structured console logs.
+- **Authorization** — Open FGA (ReBAC) is a separate integration (its own server + `authorize.py`), **not** a
+  `BasePlugin` and **not** registered in `config/plugins.hocon` — set it up per its own README.
 
 ## 12. Building an app on a network
 
 Wrap a network in your own app via the neuro-san **session client** — `DirectAgentSession` runs it in-process (no
-server; async variants exist). Docs:
-[clients.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/clients.md),
-[integration quick start](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/integration_quickstart.md).
-Examples in `apps/` (each with its own `requirements.txt`): `slack/` (Slack app), `conscious_assistant/` + `cruse/`
-(Flask UIs), `log_analyzer/`, `wwaw/`.
+server; async variants exist).
+Docs: [clients.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/clients.md),
+[integration quick start](docs/integration_quickstart.md).
+Examples in `apps/`: `slack/` (Slack app), `conscious_assistant/` + `cruse/` (Flask UIs), and `wwaw/` — each with its
+own `requirements.txt`. `log_analyzer/` is also there but has no separate `requirements.txt` of its own.
 
 **CRUSE** (Context-React User Experience) is a built-in dynamic UI that adapts to the network (AI-generated themes,
 form widgets, threads). Enable by importing the experimental `cruse_theme_agent` / `cruse_widget_agent`
-(`ns import`), then open the Cruse page. Docs:
-[cruse_interface.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cruse_interface.md).
+(`ns import`), then open the Cruse page.
+Docs: [cruse_interface.md](docs/cruse_interface.md).
 
-## 13. Running, linting, testing
+## 13. Running, linting, validating
 
 ```bash
-ns run                     # server (localhost:8080) + nsflow UI (localhost:4173)
-ns chat my_network         # chat directly, no server
-ns chat --list             # list networks
-ns check-llm-keys          # validate provider keys
-ns check-config            # validate config/llm_config.hocon
+ns run                          # server (localhost:8080) + nsflow UI (localhost:4173)
+ns chat folder_name/my_network  # chat directly, no server, use the folder-prefixed name
+ns chat --list                  # list networks
+ns check-llm-keys               # validate provider keys
+ns check-config                 # validate config/llm_config.hocon
+ns validate my_network.hocon    # validate HOCON structure — no LLM calls, no API keys needed
 ```
 
 `ns <command> --help` for flags. Logs under `logs/` (`server.log`, `nsflow.log`, `thinking_dir/`); verbose coded-
 tool logging via `export AGENT_SERVICE_LOG_JSON=logging.hocon`.
 
-Before finishing, everything must lint and pass (line length **119**):
+`ns validate` ([docs/cli/validate.md](docs/cli/validate.md)) wraps neuro-san's own
+[HOCON validator CLI](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/hocon_validator_cli.md) — prefer
+it over calling that CLI directly, it stays in sync with this repo's setup.
+
+Before finishing, everything must lint and pass (line length **119** for Python; markdown is **120** per
+`.pymarkdownlint.yaml` — see
+[dev_guide.md → Note on Markdown Linting](docs/dev_guide.md#note-on-markdown-linting)):
 
 ```bash
-make lint    # ruff format + ruff check + pylint, source and tests
+make lint    # ruff format + ruff check + pylint (source and tests), plus pymarkdown over docs/
+```
+
+**Import/export:** `ns import` pulls example networks (by group/name, or from a file/`.zip`); `ns export
+my_network` bundles a network + all dependencies into one shareable file.
+Docs: [import](docs/cli/import.md), [export](docs/cli/export.md).
+
+## 14. Testing (unit, fixtures + ANTeGen)
+
+```bash
 make test    # runs make lint, then pytest with coverage (excludes integration tests)
 ```
 
-Integration tests (`tests/fixtures/`, §14) run via `make test-integration`, which sets the required env vars
-(`AGENT_TOOL_PATH=coded_tools/`, `AGENT_MANIFEST_FILE=registries/manifest.hocon`) for you — export those same
-values first if you call pytest directly (`pytest -s -m "integration_basic"` narrows to one group).
-
-Validate a network before running with the
-[HOCON validator CLI](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/hocon_validator_cli.md); docs
-are markdown-linted (`pymarkdown --config ./.pymarkdownlint.yaml scan ./docs ./README.md`).
-
-**Import/export:** `ns import` pulls example networks (by group/name, or from a file/`.zip`); `ns export
-my_network` bundles a network + all dependencies into one shareable file. Docs:
-[import](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cli/import.md),
-[export](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cli/export.md).
-
-## 14. Test cases (fixtures + ANTeGen)
-
 Fixtures are HOCON under `tests/fixtures/<group>/<network>/*.hocon`, run by
 `tests/integration/test_integration_test_hocons.py`. A fixture names the `agent` and lists `interactions` (input
-`text` → expected `response`, e.g. `keywords` or a `structure`). Spec:
-[test_case_hocon_reference.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/test_case_hocon_reference.md).
+`text` → expected `response`, e.g. `keywords` or a `structure`).
+Spec: [test_case_hocon_reference.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/test_case_hocon_reference.md).
+
+Run via `make test-integration`, which sets the required env vars (`AGENT_TOOL_PATH=coded_tools/`,
+`AGENT_MANIFEST_FILE=registries/manifest.hocon`, `PYTHONPATH=$(pwd)`) for you — export those same values first if
+you call pytest directly (`pytest -s -m "integration_basic"` narrows to one group). To narrow further (by
+network, or to a single test case), see
+[user_guide.md → Integration Test](docs/user_guide.md#integration-test).
 
 Generate with **ANTeGen**: `ns chat agent_network_test_generator`, ask e.g. *"Generate test cases for
 basic/music_nerd_pro"*. Two follow-ups are on you: **review** the generated `keywords`/`gist`/`value`/`sly_data`
-(LLM-generated, not always right), and **register** the fixture in `test_integration_test_hocons.py` for CI. Docs:
-[agent_network_test_generator.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/agent_network_test_generator.md).
+(LLM-generated, not always right), and **register** the fixture in `test_integration_test_hocons.py` for CI.
+Docs: [agent_network_test_generator.md](docs/agent_network_test_generator.md).
 
 ## 15. Conventions, docs, pitfalls
 
 **Documentation is opt-in — ask first, don't write by default.** When asked:
 
-- Network in `generated/`: short doc at `docs/examples/generated/<network>.md` (intro, `## Prerequisites`,
-  `## File`, `## Description`, optional `## Example conversation`) + a line/TOC entry in
-  [examples.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples.md).
-- Curated example (`basic/`, `industry/`, `tools/`): heavier — follow the
-  [dev_guide.md checklist](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/dev_guide.md#checklist)
-  (metadata, per-network doc, `examples.md` entry, registered test fixture).
+- Network in `generated/`: it's git-ignored and personal — no committed doc is needed unless the user wants to
+  contribute it permanently. To do that, move it into a curated folder first (`basic/`, `industry/`, `tools/`; see
+  the reorg checklist under House rules below), then follow the curated-example bullet next.
+- Curated example (`basic/`, `industry/`, `tools/`): heavier. `dev_guide.md` has no dedicated checklist for a *new*
+  example (its [`#checklist`](docs/dev_guide.md#checklist) section, linked under House rules below, is for
+  *reorganizing* an existing one) — instead do all of: add `metadata` (`description`/`tags`/`sample_queries`), write
+  a short per-network doc under `docs/examples/<group>/`, add a line + TOC entry to
+  [examples.md](docs/examples.md), and register a test fixture (§14).
 - A feature, not a network (toolbox tool, plugin, middleware): update the matching reference doc
-  ([toolbox.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/toolbox.md),
-  [plugins.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/plugins.md),
-  [search_tools.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/search_tools.md),
-  [user_guide.md → Middleware](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#middleware)).
+  ([toolbox.md](docs/toolbox.md),
+  [plugins.md](docs/plugins.md),
+  [search_tools.md](docs/search_tools.md),
+  [user_guide.md → Middleware](docs/user_guide.md#middleware)).
 
 **House rules:**
 
-- Every network sets `max_steps` and `max_execution_seconds` — never unbounded.
-- Long-form flags (`--force`, not `-f`); no secrets in HOCON (env/`.env`); `logging`, never `print`.
+- Every network **you build or edit** must set `max_steps` and `max_execution_seconds` — never unbounded. (Not yet
+  universal across older curated networks in this repo — don't treat a missing value elsewhere as precedent to skip
+  this.)
+- Long-form flags (`--force`, not `-f`); no secrets in HOCON (env/`.env`).
 - Keep changes minimal and focused — no unrequested refactors.
 - Moving a network between folders: follow the
-  [dev_guide.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/dev_guide.md) reorg checklist
+  [dev_guide.md](docs/dev_guide.md#checklist) reorg checklist
   (manifest, fixture, docs, cross-refs; tool refs become path-based like `/tools/ddgs_search`).
-- Branches `feature/…` `fix/…` `docs/…`; commits one line, issue number first (`#123: ...`). Full PR checklist:
-  [CONTRIBUTING.md](CONTRIBUTING.md).
+- This file **summarizes** docs that are the real source of truth (user_guide.md, dev_guide.md, CONTRIBUTING.md,
+  docs/cli/*) — it will drift if they change and this doesn't. When you touch one of those docs in a way that
+  changes what's summarized here, update this file in the same change.
+- Coding style (line length, naming, docstrings), logging (`logging`, never `print`), branch naming, and commit
+  message format are all defined once in
+  [CONTRIBUTING.md](CONTRIBUTING.md#coding-standards) — follow it rather than a restatement here. Full PR checklist
+  also there.
 
 **Pitfalls:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,12 @@ Contribution guide for coding agents working in **neuro-san-studio**.
 
 - **Every network you add or edit sets `max_steps` and `max_execution_seconds`.** Never unbounded. Older curated
   networks that lack them are not precedent.
-- **No secrets in HOCON** — use environment or `.env`. Never log or print `sly_data`.
+- **No secrets in HOCON** — use environment or `.env`. Never log or print `sly_data`. Don't claim generic keys like
+  `headers` in `sly_data` — it becomes a reserved word visible in every UI; use `http_headers`.
+- **It must work out of the box.** A dependency only some users need goes in a tool-specific
+  `coded_tools/<group>/<tool>/requirements.txt`, not the main `requirements.txt`; the tool or feature that needs
+  it is then *disabled by default* in the manifest. Dev-only packages go in `requirements-build.txt`. Don't add a
+  package that already arrives transitively with `neuro-san`. New feature flags default to off.
 - **Keep the diff focused.** No unrequested refactors, no drive-by reformatting of untouched files.
 - **Check the toolbox before writing Python.**
   [toolbox_info.hocon](neuro_san_studio/toolbox/toolbox_info.hocon) already has web search, RAG, code execution,
@@ -19,7 +24,8 @@ Contribution guide for coding agents working in **neuro-san-studio**.
 - **Tests mirror the tree they cover**, named `test_<functionality>_<scenario>`, arrange-act-assert, with
   external calls and file I/O mocked.
 - **A user-facing change ships its docs in the same PR.** A curated example (`basic/`, `industry/`, `tools/`)
-  needs `metadata` in the HOCON, a doc under `docs/examples/<group>/` named after it, a line plus TOC entry in
+  needs `metadata` (including realistic, self-contained `sample_queries` that don't assume data the network can't
+  see), a doc under `docs/examples/<group>/` named after it, a line plus TOC entry in
   [examples.md](docs/examples.md), and a registered fixture. A feature rather than a network updates its own
   reference doc — [toolbox.md](docs/toolbox.md), [plugins.md](docs/plugins.md), [search_tools.md](docs/search_tools.md),
   or [user_guide.md → Middleware](docs/user_guide.md#middleware). A network in `generated/` needs none; it is
@@ -50,7 +56,16 @@ Contribution guide for coding agents working in **neuro-san-studio**.
   reason in the PR.
 - **Tests**: prefer real fixture files over heavy mocking; keep timeouts realistic; don't make required parameters
   optional just for test convenience.
-- **Dependencies** float within a major/minor range — don't pin micro versions.
+- **Dependencies carry a version** (`pkg>=x.y.z` like the rest of `requirements.txt`; exact pins only where
+  neuro-san/nsflow already are). Never unversioned, never a stale or retired API.
+- **Keep `__init__.py` empty**; import modules explicitly. A class not meant to be instantiated extends `ABC` with
+  `@abstractmethod`. Fixed value sets are an `Enum`. Keep variables in the narrowest scope (inside `main`, not at
+  module level).
+- **Never fail silently.** A missing or unreadable file, a malformed input or an unknown choice is reported with
+  the full exception, not swallowed. LLM-supplied args can be `None` or the wrong type — default them defensively
+  and comment why. Conversely, a disabled plugin or feature does *nothing*, not even log.
+- **Don't duplicate config.** A second HOCON that mostly matches another uses `include`; an overlay carries only the
+  differences. Use `${ENV_VAR}` substitution instead of parallel overlay entries.
 
 ## 3. Things that bite
 
@@ -65,6 +80,10 @@ Contribution guide for coding agents working in **neuro-san-studio**.
 - Network-level `tools` (agent *definitions*) is not an agent's `tools` (down-chain agents it may *call*).
 - `sly_data` does not reach external or other-network agents without an explicit `allow` policy; its schemas are
   Front-Man-only.
+- `function.description` says *what* an agent does (so other agents know when to call it); `instructions` say
+  *how*. Don't mix them.
+- Paths in HOCON are relative to the repo root. Reference files in other repos (e.g. neuro-san) by HTTP link, not a
+  local path studio users won't have.
 - Review any internet-sourced agent skill before wiring it in — a `SKILL.md` can reference untrusted tools.
 
 ## 4. Opening the PR
@@ -101,10 +120,13 @@ Then, before you push:
 - [ ] **One concern per PR.** Split anything that needs the word "and" to describe.
 - [ ] **Read your own diff** (`git diff main...HEAD`). Remove debug prints, commented-out code, stray `TODO`s, files you
       touched by accident.
-- [ ] **Nothing unrelated committed** — no `.env`, no `logs/`, no editor or OS files, and nothing pasted from a
-      terminal that carries a key or an internal URL.
+- [ ] **Nothing unrelated committed** — no `.env`, no `logs/`, no `__pycache__`, no editor or OS files, and nothing pasted
+      from a terminal that carries a key or an internal URL.
 - [ ] **New behavior has a test** — unit test for a coded tool, integration fixture for a network.
-- [ ] **Links in any doc you touched still resolve.**
+- [ ] **Links in any doc you touched still resolve** — relative depth included. If you moved or renamed a file, grep
+      the whole repo (docs, README, test READMEs, other `.hocon`) for the old path.
+- [ ] **Markdown is well-formed**: heading levels nest (`##` then `###`), TOC regenerated, no blank lines between
+      list items, links cleaned of tracking params.
 - [ ] **Backward compatible**, or the break is called out in the description with the migration path.
 - [ ] **Rebased on current `main`**, conflicts resolved locally rather than merged from the GitHub UI.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,11 @@ Rules for coding agents in Neuro-san-studio. Follow them and the §4 gates pass 
 
 ---
 
-## 1. Rules
+## 1. Contribution rules
 
 - Check the toolbox before writing Python. [toolbox_info.hocon](neuro_san_studio/toolbox/toolbox_info.hocon)
   already provides web search, RAG, code execution, Gmail, Jira and more.
+- Review any internet-sourced agent skill before use; a `SKILL.md` can reference untrusted tools.
 - Every network sets `max_steps` and `max_execution_seconds`; never leave them unbounded. Older networks that
   lack them are not precedent.
 - No secrets in HOCON: use the environment or `.env`. Never log or print `sly_data`.
@@ -45,7 +46,7 @@ Rules for coding agents in Neuro-san-studio. Follow them and the §4 gates pass 
 - Use long-form flags (`--force`, not `-f`), and docstrings on functions, classes and modules.
 - Cover new behavior with a test: a unit test for a coded tool, an integration fixture for a network.
 
-## 3. Framework behavior
+## 3. Framework gotchas
 
 - The Front Man must be an LLM agent, never a coded or toolbox tool.
 - Network-level `tools` (agent definitions) is not an agent's `tools` (down-chain agents it may call).
@@ -60,7 +61,6 @@ Rules for coding agents in Neuro-san-studio. Follow them and the §4 gates pass 
   `generated/my_network`. Use the prefixed name in `ns chat` and in test fixtures.
 - In a manifest, `serve` loads the network, `public` lists it in `/list`, and `mcp` exposes it as an MCP tool.
   Paths resolve relative to `registries/`.
-- Review any internet-sourced agent skill before use; a `SKILL.md` can reference untrusted tools.
 
 ## 4. Opening the PR
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+Contribution guide for coding agents working in **neuro-san-studio**.
+
+---
+
+## 1. Rules
+
+- **Every network you add or edit sets `max_steps` and `max_execution_seconds`.** Never unbounded. Older curated
+  networks that lack them are not precedent.
+- **No secrets in HOCON** — use environment or `.env`. Never log or print `sly_data`.
+- **Keep the diff focused.** No unrequested refactors, no drive-by reformatting of untouched files.
+- **Check the toolbox before writing Python.**
+  [toolbox_info.hocon](neuro_san_studio/toolbox/toolbox_info.hocon) already has web search, RAG, code execution,
+  Gmail, Jira and more.
+- **Prefer `async_invoke`** in a `CodedTool`; `invoke()` blocks the event loop. Wrap blocking I/O in
+  `asyncio.to_thread(...)`.
+- **Use `logging`, never `print`.** Long-form flags (`--force`, not `-f`). Docstrings on functions, classes and modules.
+- **Tests mirror the tree they cover**, named `test_<functionality>_<scenario>`, arrange-act-assert, with
+  external calls and file I/O mocked.
+- **A user-facing change ships its docs in the same PR.** A curated example (`basic/`, `industry/`, `tools/`)
+  needs `metadata` in the HOCON, a doc under `docs/examples/<group>/` named after it, a line plus TOC entry in
+  [examples.md](docs/examples.md), and a registered fixture. A feature rather than a network updates its own
+  reference doc — [toolbox.md](docs/toolbox.md), [plugins.md](docs/plugins.md), [search_tools.md](docs/search_tools.md),
+  or [user_guide.md → Middleware](docs/user_guide.md#middleware). A network in `generated/` needs none; it is
+  git-ignored and personal.
+
+## 2. Things that bite
+
+- In a manifest, `serve` loads the network, `public` lists it in `/list`, `mcp` exposes it as an MCP tool. Paths
+  resolve relative to `registries/`.
+- A subfolder prefixes the runtime name: `"generated/my_network.hocon"` is addressed as `generated/my_network`.
+  Use the prefixed name in `ns chat` and in test fixtures.
+- Short-form `class` resolves via `AGENT_TOOL_PATH` (default `coded_tools/`) plus the network's path, so
+  `basic/my_network.hocon` with `"class": "order_lookup.OrderLookup"` finds
+  `coded_tools/basic/my_network/order_lookup.py`. Fully-qualify anything under `neuro_san_studio/coded_tools/`.
+- The Front Man must be an LLM agent, never a coded or toolbox tool.
+- Network-level `tools` (agent *definitions*) is not an agent's `tools` (down-chain agents it may *call*).
+- `sly_data` does not reach external or other-network agents without an explicit `allow` policy; its schemas are
+  Front-Man-only.
+- Review any internet-sourced agent skill before wiring it in — a `SKILL.md` can reference untrusted tools.
+
+## 3. Opening the PR
+
+Branch as `feature/short-name`, `fix/short-name` or `docs/short-name` — never commit to `main`. Commits are a
+one-line summary, prefixed with the issue number when there is one:
+
+```text
+#123: Add retry handling to the order lookup coded tool
+```
+
+All four gates must pass first. CI runs the same checks (`.github/workflows/tests.yml`, `integration.yml`).
+
+```bash
+ns validate registries/<group>/<name>.hocon   # HOCON structure; no LLM calls, no keys needed
+make lint                                     # ruff format + ruff check + pylint + pymarkdown over docs/
+make test                                     # runs make lint, then pytest with coverage (no integration)
+make test-integration                         # sets AGENT_TOOL_PATH / AGENT_MANIFEST_FILE / PYTHONPATH for you
+```
+
+Notes that save a round trip:
+
+- **Line length is 119** for Python (ruff and pylint enforce it), **120** for Markdown.
+- **`make lint` only scans `./docs` and `./README.md` for Markdown.** A `.md` anywhere else — this file included
+  — needs `pymarkdown --config ./.pymarkdownlint.yaml scan <path>` run by hand.
+- `ns validate` reports external-agent refs (`/industry/macys`) as errors unless you pass
+  `--external-agents "/industry/macys,…"`. Validator limitation, not a broken network.
+- Narrow integration runs with markers: `pytest -s -m "integration_basic"`.
+
+Then, before you push:
+
+- [ ] **One concern per PR.** Split anything that needs the word "and" to describe.
+- [ ] **Read your own diff** (`git diff main...HEAD`). Remove debug prints, commented-out code, stray `TODO`s, files you
+      touched by accident.
+- [ ] **Nothing unrelated committed** — no `.env`, no `logs/`, no editor or OS files, and nothing pasted from a
+      terminal that carries a key or an internal URL.
+- [ ] **New behavior has a test** — unit test for a coded tool, integration fixture for a network.
+- [ ] **Links in any doc you touched still resolve.**
+- [ ] **Backward compatible**, or the break is called out in the description with the migration path.
+- [ ] **Rebased on current `main`**, conflicts resolved locally rather than merged from the GitHub UI.
+
+Say what changed, why, and how you tested it — for a network, paste a real `ns chat` exchange.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ Contribution guide for coding agents working in **neuro-san-studio**.
 
 ## 3. Opening the PR
 
+The essentials are below; for more details go through [CONTRIBUTING.md](CONTRIBUTING.md).
+
 Branch as `feature/short-name`, `fix/short-name` or `docs/short-name` — never commit to `main`. Commits are a
 one-line summary, prefixed with the issue number when there is one:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,34 @@ Contribution guide for coding agents working in **neuro-san-studio**.
   or [user_guide.md → Middleware](docs/user_guide.md#middleware). A network in `generated/` needs none; it is
   git-ignored and personal.
 
-## 2. Things that bite
+## 2. Python style reviewers will flag
+
+- **Everything lives in a class.** No standalone helper functions — not in tests either. `main()` is a static method
+  on a class. No nested `def`s unless a comment explains why. Data-only classes stay data-only: no policy methods on
+  them. One class per file, file name matching the class name.
+- **`snake_case` for every identifier** (`fail_fast`, not `failfast`). If an external API forces `camelCase`,
+  comment why.
+- **Double quotes** for strings (`ruff format` enforces it). Imports one per line (`force-single-line`), only what is
+  used, no star imports.
+- **Dictionary access is always `.get()`**, never `dict[key]`.
+- **Catch specific exceptions**, never bare `except Exception`. Only catch what you can handle at that level.
+- **Logging**: lazy `%` formatting (`logger.info("Loaded %s", name)`), not f-strings. `WARNING` is reserved for
+  something an operator can act on — otherwise `INFO` or `DEBUG`. Write messages devops can understand.
+- **Use accessors, not internals.** Don't reach into another class's attributes; don't `isinstance` against concrete
+  classes — check the interface, or add an interface method that answers the question.
+- **Don't modify system env vars** and don't hardcode values that belong in one (`localhost`, ports, paths).
+- **Every `.py` starts with the Apache copyright header** ending in `# END COPYRIGHT`; put module comments and
+  docstrings *below* that block so the auto-updater does not clobber them.
+- **Comment the non-obvious**: which `_method`s are overrides vs. ours, threading and lifecycle behavior, design
+  decisions, and a breadcrumb pointing to related code or docs. Order lifecycle methods logically (`start()` before
+  `stop()`).
+- **Don't rename or remove public classes, interfaces, log lines or comments** without a compatibility layer or a
+  reason in the PR.
+- **Tests**: prefer real fixture files over heavy mocking; keep timeouts realistic; don't make required parameters
+  optional just for test convenience.
+- **Dependencies** float within a major/minor range — don't pin micro versions.
+
+## 3. Things that bite
 
 - In a manifest, `serve` loads the network, `public` lists it in `/list`, `mcp` exposes it as an MCP tool. Paths
   resolve relative to `registries/`.
@@ -40,7 +67,7 @@ Contribution guide for coding agents working in **neuro-san-studio**.
   Front-Man-only.
 - Review any internet-sourced agent skill before wiring it in — a `SKILL.md` can reference untrusted tools.
 
-## 3. Opening the PR
+## 4. Opening the PR
 
 The essentials are below; for more details go through [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,133 +1,85 @@
 # AGENTS.md
 
-Contribution guide for coding agents working in **neuro-san-studio**.
+Rules for coding agents in Neuro-san-studio. Follow them and the §4 gates pass on the first run.
 
 ---
 
 ## 1. Rules
 
-- **Every network you add or edit sets `max_steps` and `max_execution_seconds`.** Never unbounded. Older curated
-  networks that lack them are not precedent.
-- **No secrets in HOCON** — use environment or `.env`. Never log or print `sly_data`. Don't claim generic keys like
-  `headers` in `sly_data` — it becomes a reserved word visible in every UI; use `http_headers`.
-- **It must work out of the box.** A dependency only some users need goes in a tool-specific
-  `coded_tools/<group>/<tool>/requirements.txt`, not the main `requirements.txt`; the tool or feature that needs
-  it is then *disabled by default* in the manifest. Dev-only packages go in `requirements-build.txt`. Don't add a
-  package that already arrives transitively with `neuro-san`. New feature flags default to off.
-- **Keep the diff focused.** No unrequested refactors, no drive-by reformatting of untouched files.
-- **Check the toolbox before writing Python.**
-  [toolbox_info.hocon](neuro_san_studio/toolbox/toolbox_info.hocon) already has web search, RAG, code execution,
-  Gmail, Jira and more.
-- **Prefer `async_invoke`** in a `CodedTool`; `invoke()` blocks the event loop. Wrap blocking I/O in
-  `asyncio.to_thread(...)`.
-- **Use `logging`, never `print`.** Long-form flags (`--force`, not `-f`). Docstrings on functions, classes and modules.
-- **Tests mirror the tree they cover**, named `test_<functionality>_<scenario>`, arrange-act-assert, with
-  external calls and file I/O mocked.
-- **A user-facing change ships its docs in the same PR.** A curated example (`basic/`, `industry/`, `tools/`)
-  needs `metadata` (including realistic, self-contained `sample_queries` that don't assume data the network can't
-  see), a doc under `docs/examples/<group>/` named after it, a line plus TOC entry in
-  [examples.md](docs/examples.md), and a registered fixture. A feature rather than a network updates its own
-  reference doc — [toolbox.md](docs/toolbox.md), [plugins.md](docs/plugins.md), [search_tools.md](docs/search_tools.md),
-  or [user_guide.md → Middleware](docs/user_guide.md#middleware). A network in `generated/` needs none; it is
-  git-ignored and personal.
+- Check the toolbox before writing Python. [toolbox_info.hocon](neuro_san_studio/toolbox/toolbox_info.hocon)
+  already provides web search, RAG, code execution, Gmail, Jira and more.
+- Every network sets `max_steps` and `max_execution_seconds`; never leave them unbounded. Older networks that
+  lack them are not precedent.
+- No secrets in HOCON: use the environment or `.env`. Never log or print `sly_data`.
+- Add optional dependencies in `coded_tools/<group>/<agent_network>/requirements.txt`, and keep the network disabled
+  by default in the manifest.
+- Keep the diff focused: no unrequested refactors and no reformatting of untouched files. Review it before creating a
+  PR and remove debug prints, commented-out code, stray `TODO`s and files touched by accident.
+- Documentation ships in the same PR. A curated example (`basic/`, `industry/`, `tools/`) requires `metadata`,
+  documentation as `docs/examples/<group>/<agent_network>.md`, a line and a TOC entry in
+  [examples.md](docs/examples.md), and a registered fixture. A feature updates its own reference document
+  instead: [toolbox.md](docs/toolbox.md), [plugins.md](docs/plugins.md),
+  [search_tools.md](docs/search_tools.md), or [user_guide.md → Middleware](docs/user_guide.md#middleware).
+  A network in `generated/` is git-ignored and personal.
+  Verify every link in the documents you touch to check for broken links.
 
-## 2. Python style reviewers will flag
+## 2. Python style
 
-- **Everything lives in a class.** No standalone helper functions — not in tests either. `main()` is a static method
-  on a class. No nested `def`s unless a comment explains why. Data-only classes stay data-only: no policy methods on
-  them. One class per file, file name matching the class name.
-- **`snake_case` for every identifier** (`fail_fast`, not `failfast`). If an external API forces `camelCase`,
-  comment why.
-- **Double quotes** for strings (`ruff format` enforces it). Imports one per line (`force-single-line`), only what is
-  used, no star imports.
-- **Dictionary access is always `.get()`**, never `dict[key]`.
-- **Catch specific exceptions**, never bare `except Exception`. Only catch what you can handle at that level.
-- **Logging**: lazy `%` formatting (`logger.info("Loaded %s", name)`), not f-strings. `WARNING` is reserved for
-  something an operator can act on — otherwise `INFO` or `DEBUG`. Write messages devops can understand.
-- **Use accessors, not internals.** Don't reach into another class's attributes; don't `isinstance` against concrete
-  classes — check the interface, or add an interface method that answers the question.
-- **Don't modify system env vars** and don't hardcode values that belong in one (`localhost`, ports, paths).
-- **Every `.py` starts with the Apache copyright header** ending in `# END COPYRIGHT`; put module comments and
-  docstrings *below* that block so the auto-updater does not clobber them.
-- **Comment the non-obvious**: which `_method`s are overrides vs. ours, threading and lifecycle behavior, design
-  decisions, and a breadcrumb pointing to related code or docs. Order lifecycle methods logically (`start()` before
-  `stop()`).
-- **Don't rename or remove public classes, interfaces, log lines or comments** without a compatibility layer or a
-  reason in the PR.
-- **Tests**: prefer real fixture files over heavy mocking; keep timeouts realistic; don't make required parameters
-  optional just for test convenience.
-- **Dependencies carry a version** (`pkg>=x.y.z` like the rest of `requirements.txt`; exact pins only where
-  neuro-san/nsflow already are). Never unversioned, never a stale or retired API.
-- **Keep `__init__.py` empty**; import modules explicitly. A class not meant to be instantiated extends `ABC` with
-  `@abstractmethod`. Fixed value sets are an `Enum`. Keep variables in the narrowest scope (inside `main`, not at
-  module level).
-- **Never fail silently.** A missing or unreadable file, a malformed input or an unknown choice is reported with
-  the full exception, not swallowed. LLM-supplied args can be `None` or the wrong type — default them defensively
-  and comment why. Conversely, a disabled plugin or feature does *nothing*, not even log.
-- **Don't duplicate config.** A second HOCON that mostly matches another uses `include`; an overlay carries only the
-  differences. Use `${ENV_VAR}` substitution instead of parallel overlay entries.
+- Everything lives in a class. No standalone helpers, including in tests. `main()` is a static method, and no
+  nested `def`s without a comment stating why. Data-only classes carry no policy methods. One class per file,
+  named after it.
+- Use `async_invoke` in a `CodedTool`, since `invoke()` blocks the event loop, and wrap blocking I/O in
+  `asyncio.to_thread()`.
+- Use `snake_case` for functions, methods, variables, parameters and attributes, `PascalCase` for classes, and
+  `UPPER_CASE` for constants. Comment the reason if an external API forces `camelCase`.
+- Dictionary access uses `.get()`, never `dict[key]`.
+- Catch specific exceptions that can be handled at that level; never a generalized `Exception`.
+- Never fail silently. Report a missing or unreadable file, malformed input or an unknown choice with the full
+  exception, and log enough to act on.
+- Prefer logging over `print`, with lazy `%` formatting (`logger.info("Loaded %s", name)`) rather than f-strings.
+  Keep messages easy to interpret.
+- Use accessors, not internals. Do not read another class's attributes and do not `isinstance` against a concrete
+  class; check the interface, or add an interface method that answers the question.
+- Comment the non-obvious: which `_method`s are overrides, threading and lifecycle behavior, design decisions, and
+  a breadcrumb to related code or documentation. Order lifecycle methods logically, `start()` before `stop()`.
+- Use long-form flags (`--force`, not `-f`), and docstrings on functions, classes and modules.
+- Cover new behavior with a test: a unit test for a coded tool, an integration fixture for a network.
 
-## 3. Things that bite
+## 3. Framework behavior
 
-- In a manifest, `serve` loads the network, `public` lists it in `/list`, `mcp` exposes it as an MCP tool. Paths
-  resolve relative to `registries/`.
-- A subfolder prefixes the runtime name: `"generated/my_network.hocon"` is addressed as `generated/my_network`.
-  Use the prefixed name in `ns chat` and in test fixtures.
-- Short-form `class` resolves via `AGENT_TOOL_PATH` (default `coded_tools/`) plus the network's path, so
-  `basic/my_network.hocon` with `"class": "order_lookup.OrderLookup"` finds
-  `coded_tools/basic/my_network/order_lookup.py`. Fully-qualify anything under `neuro_san_studio/coded_tools/`.
 - The Front Man must be an LLM agent, never a coded or toolbox tool.
-- Network-level `tools` (agent *definitions*) is not an agent's `tools` (down-chain agents it may *call*).
-- `sly_data` does not reach external or other-network agents without an explicit `allow` policy; its schemas are
-  Front-Man-only.
-- `function.description` says *what* an agent does (so other agents know when to call it); `instructions` say
-  *how*. Don't mix them.
-- Paths in HOCON are relative to the repo root. Reference files in other repos (e.g. neuro-san) by HTTP link, not a
-  local path studio users won't have.
-- Review any internet-sourced agent skill before wiring it in — a `SKILL.md` can reference untrusted tools.
+- Network-level `tools` (agent definitions) is not an agent's `tools` (down-chain agents it may call).
+- `function.description` states what an agent does, so other agents know when to call it, while `instructions`
+  state how. Do not mix them.
+- `sly_data` reaches external or other-network agents only under an explicit `allow` policy, and its schemas are
+  Front-Man-only by default.
+- Short-form `class` resolves via `AGENT_TOOL_PATH` (default `coded_tools/`) plus the network's path, so
+  `basic/my_network.hocon` with `"class": "order_lookup.OrderLookup"` loads
+  `coded_tools/basic/my_network/order_lookup.py`. Fully qualify anything under `neuro_san_studio/coded_tools/`.
+- A subfolder prefixes the runtime name, so `"generated/my_network.hocon"` is addressed as
+  `generated/my_network`. Use the prefixed name in `ns chat` and in test fixtures.
+- In a manifest, `serve` loads the network, `public` lists it in `/list`, and `mcp` exposes it as an MCP tool.
+  Paths resolve relative to `registries/`.
+- Review any internet-sourced agent skill before use; a `SKILL.md` can reference untrusted tools.
 
 ## 4. Opening the PR
 
-The essentials are below; for more details go through [CONTRIBUTING.md](CONTRIBUTING.md).
+Details in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Branch as `feature/short-name`, `fix/short-name` or `docs/short-name` — never commit to `main`. Commits are a
-one-line summary, prefixed with the issue number when there is one:
-
-```text
-#123: Add retry handling to the order lookup coded tool
-```
-
-All four gates must pass first. CI runs the same checks (`.github/workflows/tests.yml`, `integration.yml`).
+Branch as `feature/short-name`, `fix/short-name` or `docs/short-name`, and never commit to `main`. A commit is a
+one-line summary, prefixed with the issue number like '#123: Add retry handling to the order lookup coded tool'.
 
 ```bash
 ns validate registries/<group>/<name>.hocon   # HOCON structure; no LLM calls, no keys needed
-make lint                                     # ruff format + ruff check + pylint + pymarkdown over docs/
-make test                                     # runs make lint, then pytest with coverage (no integration)
-make test-integration                         # sets AGENT_TOOL_PATH / AGENT_MANIFEST_FILE / PYTHONPATH for you
+make lint                                     # rewrites files (ruff format + import fix), then checks
+make test                                     # make lint, then pytest with coverage (no integration)
+make test-integration                         # installs into ./venv, then sets the required env vars
 ```
 
-Notes that save a round trip:
-
-- **Line length is 119** for Python (ruff and pylint enforce it), **120** for Markdown.
-- **`make lint` only scans `./docs` and `./README.md` for Markdown.** A `.md` anywhere else — this file included
-  — needs `pymarkdown --config ./.pymarkdownlint.yaml scan <path>` run by hand.
-- `ns validate` reports external-agent refs (`/industry/macys`) as errors unless you pass
-  `--external-agents "/industry/macys,…"`. Validator limitation, not a broken network.
+Notes:
+- Line length is 119 for Python and 120 for Markdown.
+- `make lint` scans only `./docs` and `./README.md` for Markdown. Any other `.md`, this file included, needs
+  `pymarkdown --config ./.pymarkdownlint.yaml scan <path>` run by hand.
+- `ns validate` reports external-agent references (`/industry/macys`) as errors unless you pass
+  `--external-agents "/industry/macys,…"`. That is a validator limitation, not a broken network.
 - Narrow integration runs with markers: `pytest -s -m "integration_basic"`.
-
-Then, before you push:
-
-- [ ] **One concern per PR.** Split anything that needs the word "and" to describe.
-- [ ] **Read your own diff** (`git diff main...HEAD`). Remove debug prints, commented-out code, stray `TODO`s, files you
-      touched by accident.
-- [ ] **Nothing unrelated committed** — no `.env`, no `logs/`, no `__pycache__`, no editor or OS files, and nothing pasted
-      from a terminal that carries a key or an internal URL.
-- [ ] **New behavior has a test** — unit test for a coded tool, integration fixture for a network.
-- [ ] **Links in any doc you touched still resolve** — relative depth included. If you moved or renamed a file, grep
-      the whole repo (docs, README, test READMEs, other `.hocon`) for the old path.
-- [ ] **Markdown is well-formed**: heading levels nest (`##` then `###`), TOC regenerated, no blank lines between
-      list items, links cleaned of tracking params.
-- [ ] **Backward compatible**, or the break is called out in the description with the migration path.
-- [ ] **Rebased on current `main`**, conflicts resolved locally rather than merged from the GitHub UI.
-
-Say what changed, why, and how you tested it — for a network, paste a real `ns chat` exchange.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,12 @@ Rules for coding agents in Neuro-san-studio. Follow them and the §4 gates pass 
 
 - Check the toolbox before writing Python. [toolbox_info.hocon](neuro_san_studio/toolbox/toolbox_info.hocon)
   already provides web search, RAG, code execution, Gmail, Jira and more.
-- Review any internet-sourced agent skill before use; a `SKILL.md` can reference untrusted tools.
 - Every network sets `max_steps` and `max_execution_seconds`; never leave them unbounded. Older networks that
   lack them are not precedent.
 - No secrets in HOCON: use the environment or `.env`. Never log or print `sly_data`.
 - Add optional dependencies in `coded_tools/<group>/<agent_network>/requirements.txt`, and keep the network disabled
   by default in the manifest.
+- Review any internet-sourced agent skill before use; a `SKILL.md` can reference untrusted tools.
 - Keep the diff focused: no unrequested refactors and no reformatting of untouched files. Review it before creating a
   PR and remove debug prints, commented-out code, stray `TODO`s and files touched by accident.
 - Documentation ships in the same PR. A curated example (`basic/`, `industry/`, `tools/`) requires `metadata`,
@@ -46,7 +46,7 @@ Rules for coding agents in Neuro-san-studio. Follow them and the §4 gates pass 
 - Use long-form flags (`--force`, not `-f`), and docstrings on functions, classes and modules.
 - Cover new behavior with a test: a unit test for a coded tool, an integration fixture for a network.
 
-## 3. Framework gotchas
+## 3. Framework behavior
 
 - The Front Man must be an LLM agent, never a coded or toolbox tool.
 - Network-level `tools` (agent definitions) is not an agent's `tools` (down-chain agents it may call).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,353 @@
+# CLAUDE.md
+
+Guidance for Claude working with **neuro-san-studio** — a playground for the
+[neuro-san](https://github.com/cognizant-ai-lab/neuro-san) framework. You build **multi-agent networks**
+declaratively in **HOCON** config files; add Python (a "coded tool") only when an agent needs deterministic logic
+(API calls, DB queries, math).
+
+Sections link the real docs — open them for detail instead of trusting this summary.
+**Start here:** [tutorial.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/tutorial.md)
+(build your first network) ·
+[examples.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples.md)
+(one example per feature — fastest way to find how to build something).
+
+---
+
+## 0. First-time setup
+
+**Inside this repo** (not installed yet; needs Python 3.12/3.13 + `make`, macOS/Linux — Windows steps in
+[CONTRIBUTING.md](CONTRIBUTING.md)):
+
+```bash
+make venv && make install       # venv/ + requirements.txt + requirements-build.txt
+source venv/bin/activate
+export PYTHONPATH=$(pwd)
+```
+
+**Fresh project instead** (just the framework, no clone):
+
+```bash
+pip install neuro-san-studio
+ns init             # scaffolds config/, mcp/, registries/ + shared aaosa*.hocon in the cwd
+```
+
+Either way: ask which LLM provider(s) the user wants, have them set the key in `.env`
+(`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`, §6), then verify with
+`ns check-llm-keys && ns check-config`. Full CLI:
+[cli.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cli.md).
+
+## 1. Repository layout
+
+| Path | Purpose |
+|------|---------|
+| `registries/` | HOCON networks + `manifest.hocon`, plus shared includes (`aaosa.hocon`, `llm_config.hocon`). Curated examples in `basic/`, `tools/`, `industry/`, `experimental/`; your networks go in `generated/`. |
+| `coded_tools/<agent_name>/` | Python `CodedTool` implementations (resolved via `AGENT_TOOL_PATH`, default `coded_tools/`). |
+| `neuro_san_studio/` | The framework: `ns` CLI, server runner, importer/exporter, toolbox, MCP, plugins. |
+| `middleware/` | Reusable `AgentMiddleware` implementations: Designer, skills, persistent memory, checklist. |
+| `config/` | LLM config (`llm_config.hocon`) + plugin config (`plugins.hocon`); created by `ns init`. |
+| `apps/` | Example apps built on networks (Flask UIs, Slack app) — §12. |
+| `servers/` | Standalone **example** a2a / mcp servers (e.g. a demo MCP server to test against) — not needed to use MCP. |
+| `skills/` | Example skill folders (each a `SKILL.md`) for `AgentSkillsMiddleware` (§10). |
+| `deploy/` | Container/deploy assets: `Dockerfile`, `build.sh`, `entrypoint.sh`, `run.sh`. |
+| `docs/` | Tutorials, examples, CLI docs, dev guide. |
+| `tests/fixtures/` | HOCON test cases; `tests/integration/` drives them. |
+
+## 2. Delegation between agents (AAOSA)
+
+Routing is driven by **AAOSA** (Adaptive Agent Oriented Software Architecture): each agent decides whether to
+answer itself or delegate to the down-chain agents in its `tools`, based on each down-chain agent's name and its
+`function.description`. `aaosa_instructions` and `aaosa_call` (from `registries/aaosa.hocon`, a substitution-only
+file) implement it — the Designer emits this for all agents:
+
+```hocon
+include "registries/aaosa.hocon",
+"function": ${aaosa_call}{ "description": "Controls the TV." },
+"instructions": ${instructions_prefix} """Your name is TV. ...""" ${aaosa_instructions},
+```
+
+Docs: [user_guide.md → AAOSA](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#aaosa).
+
+## 3. The build loop
+
+To build a new network:
+
+1. **Generate a baseline** with the Agent Network Designer (§4) from a plain-English use case.
+2. **Refine the HOCON by hand** (§5): improve instructions, add branch agents, and wire in
+   tools/mcp/middleware/apps as required.
+3. **Register and enable** it in `registries/generated/manifest.hocon` (§5) — the Designer usually does this, but
+   verify.
+4. **Lint and load it** to confirm the HOCON parses and runs correctly (`ns run` / `ns chat`, §13).
+5. **Add test fixtures** with ANTeGen to check the network behaves as required; if not, refine it (§14).
+6. **Documentation** is opt-in — ask the user first (§15).
+
+## 4. Agent Network Designer
+
+Write the use case (or the change you want) to a file, then run one-shot:
+
+```bash
+echo "Build a network for a coffee shop's order-status and loyalty-points lookup" > /tmp/prompt.txt
+ns chat agent_network_designer --one-shot --first_prompt_file /tmp/prompt.txt
+```
+
+Produces agents, links, instructions, toolbox/mcp wiring, and `sample_queries`; registers the manifest entry;
+saves under `registries/generated/`. To iterate on an existing generated network, pass it via `--sly_data`:
+
+```bash
+ns chat agent_network_designer --one-shot --first_prompt_file /tmp/prompt.txt \
+  --sly_data '{"agent_network_hocon_file": "registries/generated/coffee_shop.hocon"}'
+```
+
+The Designer gives a baseline only — refining the `.hocon` yourself (§5) is expected. Docs:
+[cli/chat.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cli/chat.md).
+
+## 5. Agent network HOCON
+
+A network is one `.hocon` file (JSON + comments, multi-line strings, `${}` substitutions). Docs:
+[agent HOCON reference](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md),
+[user_guide.md → Hocon files](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#hocon-files).
+
+### Agent types
+
+| Type | Marked by | Role |
+|------|-----------|------|
+| **Front Man** | first in `tools`, **no** `parameters` | entry point, talks to the user |
+| **Branch agent** | has `function.parameters` | LLM sub-agent, called by name |
+| **Coded tool** | has `class` | Python logic (§8); no LLM behavior |
+| **Toolbox tool** | has `toolbox` | runs directly (§7) |
+| **External agent** | name is `/path` or `http(s)://host:port/agent` | another network as a tool (§9) |
+| **MCP server** | URL starting `https://mcp` or ending `/mcp` | tools over MCP (§9) |
+
+### Fields
+
+- **Per-agent:** `name`, `function.description`, `instructions`, `function.parameters`, `tools`,
+  `class`/`toolbox`, `args`, `llm_config` (§6), `allow` (§8), `middleware` (§10).
+- **Front-Man only:** `function.sly_data_schema` / `sly_data_output_schema`, `max_message_history`,
+  `structure_formats`.
+- **Network-level:** `metadata` (`description`/`tags`/`sample_queries`), `llm_config` (§6), **`max_steps`**
+  (recursion budget — not `max_iterations`), **`max_execution_seconds`** (wall-clock). Rarer keys + full defaults
+  in the docs above.
+
+### Registering the network (manifest)
+
+`registries/manifest.hocon` includes per-group manifests. Add yours to `registries/generated/manifest.hocon` as
+`"my_network.hocon": true` (serve + list), or the detailed form
+`{ "serve": true, "public": false, "mcp": true }` — `serve` loads/runs it, `public` lists it in `/list` (set
+`false` to keep it reachable but unlisted, e.g. a support network), `mcp` exposes it as an MCP tool (§9).
+Docs:
+[manifest_hocon_reference.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/manifest_hocon_reference.md).
+
+## 6. LLM configuration
+
+All example/generated networks import a top-level `llm_config` file (§5) so model choice lives in one place. What it resolves to
+(provider, model, fallback order) is in [config/llm_config.hocon](config/llm_config.hocon) which in turn points to
+[developer_llm_config.hocon](config/developer_llm_config.hocon).
+Compatible providers include `openai`, `anthropic`, `azure-openai`, `gemini`, `nvidia`, `ollama`, `bedrock`, or a
+custom LangChain `class` (key setup in §0). The built-in model catalog is
+[default_llm_info.hocon](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon).
+End-users can also pass their own keys at request time via `sly_data.llm_config` (§8; see `byok_llm_config.hocon`).
+
+Docs:
+[agent HOCON reference → llm_config](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#llm_config).
+
+## 7. Toolbox: pre-built tools
+
+Before writing a coded tool, check the **toolbox** — ready-made tools (web search, RAG, code execution,
+Gmail/Jira, …). Reference by name; pass settings via `args` (merged over the tool's defaults):
+
+```hocon
+{ "name": "policy_web_search", "toolbox": "ddgs_search", "args": { "num_results": 3 } }
+```
+
+Catalog:
+[toolbox_info.hocon](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/neuro_san_studio/toolbox/toolbox_info.hocon)
+Defining/Customizing:
+[toolbox_info_hocon_reference.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/toolbox_info_hocon_reference.md).
+
+## 8. Coded tools, sly_data, external APIs
+
+When no toolbox tool fits, implement a `CodedTool` under `coded_tools/<agent_name>/`. No manifest entry — you wire
+it as an agent node in the network HOCON (an up-chain agent lists it in `tools`), giving the node a
+`function` (`description` + `parameters`) and `"class": "<module>.<ClassName>"` — the `.py` file name, then the
+class inside it (snake_case → PascalCase). So `order_lookup.py` with `class OrderLookup` →
+`"class": "order_lookup.OrderLookup"`. **Prefer `async_invoke`** — the synchronous `invoke()` blocks the event
+loop.
+
+```python
+class OrderLookup(CodedTool):
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Any:
+        return f"Order {args['order_id']} is shipped"
+```
+
+`args` comes from `function.parameters`; `sly_data` is the private dict below. No-args constructor, JSON-friendly
+return, wrap blocking I/O in `asyncio.to_thread(...)`. Docs:
+[user_guide.md → Coded tools](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#coded-tools).
+
+**sly_data** — network-wide private channel for secrets/inter-agent state: client passes it in, any coded tool
+reads/writes it, never reaches the LLM stream. Use a distinct key per purpose (any tool that reads sly_data reads
+all of it). Doesn't cross into external/other-network agents without an explicit `allow` policy; schemas are
+Front-Man-only. Also carries MCP auth headers (§9). `allow` schema:
+[agent HOCON reference → allow](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#allow).
+
+**Finding a new API** — reuse the toolbox (§7) and `registries/tools/` vendor adapters (§9) first. Else search
+[public-apis](https://github.com/public-apis/public-apis), [APIs.guru](https://apis.guru/),
+[RapidAPI Hub](https://rapidapi.com/hub), [Apify Store](https://apify.com/store), or the vendor's own docs. Before
+wiring one in, confirm base URL, **auth**, **rate limits**, pricing, and **terms**; prefer official/free tiers;
+keep keys out of HOCON (§15). If the choice is ambiguous or the API has cost/usage limits, ask which provider to
+use. If the user must act to get access (account, key, billing, terms), name the env var and link the pricing page.
+
+## 9. MCP and external agents
+
+An agent can consume/expose **MCP** tools, delegate to **other networks**, or bridge to **other frameworks**.
+
+1. **MCP** — reference a server by URL (starts `https://mcp` or ends `/mcp`); its tools become callable. Auth
+   headers travel via `sly_data.http_headers` (keyed by MCP URL) or server-side in
+   [mcp_info.hocon](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/neuro_san_studio/mcp/mcp_info.hocon)
+   (`MCP_SERVERS_INFO_FILE`). Expose your own network as MCP with `"mcp": true` in its manifest (§5). Docs:
+   [mcp_service.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/mcp_service.md).
+2. **Other neuro-san networks** — list one as a tool to hand off a query (compose "agent webs"). sly_data only
+   crosses under an explicit `allow` policy (§8):
+
+   ```hocon
+   "tools": ["/expedia"]                            # network on this server (expedia.hocon)
+   "tools": ["http://192.168.1.1:8080/expedia"]     # network on another neuro-san server
+   ```
+
+3. **Other frameworks** (A2A, CrewAI, LangGraph) — bridge with a coded tool acting as a client, e.g. the
+   [A2A research report](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/a2a_research_report.md).
+4. **SaaS adapters** in `registries/tools/` — copy one as a starting point: Salesforce
+   [Agentforce](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/agentforce.md)
+   (`agentforce.hocon`), Google
+   [Agentspace](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/agentspace_adapter.md)
+   (`agentspace_adapter.hocon`),
+   [ServiceNow](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/now_agents.md),
+   and others.
+
+## 10. Middleware (skills, memory, checklist)
+
+**Middleware** injects code at agent hook points (`abefore_agent`/`aafter_agent`, `abefore_model`/`aafter_model`,
+`awrap_model_call`, `awrap_tool_call` — async preferred). Attach per agent via `middleware` (order matters);
+class-based `AgentMiddleware` only. Docs:
+[user_guide.md → Middleware](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#middleware).
+Three commonly used middlewares ship with the repo:
+
+- **Skills** (`agent_skills_middleware.AgentSkillsMiddleware`, args `skill_sources`/`keep_skill_in_context`) — a
+  skill is a folder with a `SKILL.md`; metadata loads first, content pulls in on demand (progressive disclosure).
+  Example: [job_guessing_skill.hocon](registries/basic/job_guessing_skill.hocon). Docs:
+  [user_guide.md → Agent Skills](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#agent-skills).
+  **Security:** review any internet-sourced skill — it can reference untrusted tools/resources.
+- **Persistent memory** (`persistent_memory.persistent_memory_middleware.PersistentMemoryMiddleware`) — memory
+  across sessions (create/read/append/delete/search/list). Attach to **your own** agent, don't import the
+  reference network. Backends: `json_file`/`markdown_file` (local, per `(network, agent)`, **not** per user) or
+  `mem0` (cloud, per end user — for shared/production). Refs: `registries/tools/persistent_memory_local.hocon`,
+  `persistent_memory_mem0.hocon`; docs
+  [local](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/persistent_memory_local.md)
+  ·
+  [mem0](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/tools/persistent_memory_mem0.md).
+- **Checklist** (`agent_checklist_middleware.AgentChecklistMiddleware`, args `checklist_title`/
+  `keep_checklist_in_context`/`progress_reporter`) — `pending`/`in_progress`/`done`/`skipped` tracking for
+  multi-step tasks. Example:
+  [coding_assistant.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples/basic/coding_assistant.md).
+
+## 11. Plugins (observability, logging, authorization)
+
+**Plugins** extend the server for deployment use-cases; registered in `config/plugins.hocon`, toggled by env var,
+never required to run. All extend `BasePlugin` (`neuro_san_studio/interfaces/base_plugin.py`). Docs (with links to
+each tool's own docs): [plugins.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/plugins.md).
+
+- **Observability** — Langfuse / Arize Phoenix / LangSmith. Off by default (`LANGFUSE_ENABLED`, `PHOENIX_ENABLED`,
+  `LANGSMITH_TRACING`).
+- **Logging** — Log Bridge, Rich structured console logs. On by default (`LOGBRIDGE_ENABLED` to disable).
+- **Authorization** — Open FGA (ReBAC).
+
+## 12. Building an app on a network
+
+Wrap a network in your own app via the neuro-san **session client** — `DirectAgentSession` runs it in-process (no
+server; async variants exist). Docs:
+[clients.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/clients.md),
+[integration quick start](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/integration_quickstart.md).
+Examples in `apps/` (each with its own `requirements.txt`): `slack/` (Slack app), `conscious_assistant/` + `cruse/`
+(Flask UIs), `log_analyzer/`, `wwaw/`.
+
+**CRUSE** (Context-React User Experience) is a built-in dynamic UI that adapts to the network (AI-generated themes,
+form widgets, threads). Enable by importing the experimental `cruse_theme_agent` / `cruse_widget_agent`
+(`ns import`), then open the Cruse page. Docs:
+[cruse_interface.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cruse_interface.md).
+
+## 13. Running, linting, testing
+
+```bash
+ns run                     # server (localhost:8080) + nsflow UI (localhost:4173)
+ns chat my_network         # chat directly, no server
+ns chat --list             # list networks
+ns check-llm-keys          # validate provider keys
+ns check-config            # validate config/llm_config.hocon
+```
+
+`ns <command> --help` for flags. Logs under `logs/` (`server.log`, `nsflow.log`, `thinking_dir/`); verbose coded-
+tool logging via `export AGENT_SERVICE_LOG_JSON=logging.hocon`.
+
+Before finishing, everything must lint and pass (line length **119**):
+
+```bash
+make lint    # ruff format + ruff check + pylint, source and tests
+make test    # runs make lint, then pytest with coverage (excludes integration tests)
+```
+
+Integration tests (`tests/fixtures/`, §14) run via `make test-integration`, which sets the required env vars
+(`AGENT_TOOL_PATH=coded_tools/`, `AGENT_MANIFEST_FILE=registries/manifest.hocon`) for you — export those same
+values first if you call pytest directly (`pytest -s -m "integration_basic"` narrows to one group).
+
+Validate a network before running with the
+[HOCON validator CLI](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/hocon_validator_cli.md); docs
+are markdown-linted (`pymarkdown --config ./.pymarkdownlint.yaml scan ./docs ./README.md`).
+
+**Import/export:** `ns import` pulls example networks (by group/name, or from a file/`.zip`); `ns export
+my_network` bundles a network + all dependencies into one shareable file. Docs:
+[import](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cli/import.md),
+[export](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/cli/export.md).
+
+## 14. Test cases (fixtures + ANTeGen)
+
+Fixtures are HOCON under `tests/fixtures/<group>/<network>/*.hocon`, run by
+`tests/integration/test_integration_test_hocons.py`. A fixture names the `agent` and lists `interactions` (input
+`text` → expected `response`, e.g. `keywords` or a `structure`). Spec:
+[test_case_hocon_reference.md](https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/test_case_hocon_reference.md).
+
+Generate with **ANTeGen**: `ns chat agent_network_test_generator`, ask e.g. *"Generate test cases for
+basic/music_nerd_pro"*. Two follow-ups are on you: **review** the generated `keywords`/`gist`/`value`/`sly_data`
+(LLM-generated, not always right), and **register** the fixture in `test_integration_test_hocons.py` for CI. Docs:
+[agent_network_test_generator.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/agent_network_test_generator.md).
+
+## 15. Conventions, docs, pitfalls
+
+**Documentation is opt-in — ask first, don't write by default.** When asked:
+
+- Network in `generated/`: short doc at `docs/examples/generated/<network>.md` (intro, `## Prerequisites`,
+  `## File`, `## Description`, optional `## Example conversation`) + a line/TOC entry in
+  [examples.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/examples.md).
+- Curated example (`basic/`, `industry/`, `tools/`): heavier — follow the
+  [dev_guide.md checklist](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/dev_guide.md#checklist)
+  (metadata, per-network doc, `examples.md` entry, registered test fixture).
+- A feature, not a network (toolbox tool, plugin, middleware): update the matching reference doc
+  ([toolbox.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/toolbox.md),
+  [plugins.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/plugins.md),
+  [search_tools.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/search_tools.md),
+  [user_guide.md → Middleware](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#middleware)).
+
+**House rules:**
+
+- Every network sets `max_steps` and `max_execution_seconds` — never unbounded.
+- Long-form flags (`--force`, not `-f`); no secrets in HOCON (env/`.env`); `logging`, never `print`.
+- Keep changes minimal and focused — no unrequested refactors.
+- Moving a network between folders: follow the
+  [dev_guide.md](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/dev_guide.md) reorg checklist
+  (manifest, fixture, docs, cross-refs; tool refs become path-based like `/tools/ddgs_search`).
+- Branches `feature/…` `fix/…` `docs/…`; commits one line, issue number first (`#123: ...`). Full PR checklist:
+  [CONTRIBUTING.md](CONTRIBUTING.md).
+
+**Pitfalls:**
+
+- The Front Man must be an LLM agent, not a coded/toolbox tool.
+- Network-level `tools` (agent *definitions*) ≠ an agent's `tools` (down-chain agents it can *call*).
+- A `toolbox` agent can't have `tools` — it runs code, can't call sub-agents.
+- Don't assume the default model supports tool-calling; check `capabilities` in the LLM info config.


### PR DESCRIPTION
## Description

Adds a top-level `AGENTS.md` — a compact rule set that coding agents (Claude Code, Devin, Codex, Cursor…) read at
session start — plus a one-line `CLAUDE.md` containing `@AGENTS.md` so Claude Code imports it.

Note: **This is a basic starting point, not a final version.** Several of us already keep personal `CLAUDE.md` /
`SKILL.md` files for this repo; the intent is to merge everybody's into this one over time, so expect to add and
remove a lot of these rules once that happens.

The file is written so that an agent following it passes the §4 gates on the first run. It is rules, not a manual:
it states what reviewers in this repo actually flag and links to `CONTRIBUTING.md` and the reference docs for
everything else, so it does not become a second source of truth. Four sections:

1. **Rules** — check the toolbox before writing Python; every network sets `max_steps` / `max_execution_seconds`;
   no secrets in HOCON and never log `sly_data`; optional dependencies live in the tool's own `requirements.txt`
   with the network disabled by default; keep the diff focused; documentation ships in the same PR (curated
   example → `metadata`, `docs/examples/<group>/<agent_network>.md`, `examples.md` line + TOC, fixture; feature →
   its own reference doc).
2. **Python style** — everything in a class (`main()` static, no standalone helpers, one class per file);
   `async_invoke` over `invoke`; `snake_case` / `PascalCase` / `UPPER_CASE`; `.get()` over `dict[key]`; specific
   exceptions; never fail silently; `logging` with lazy `%` formatting; accessors over internals; comment the
   non-obvious; long-form flags and docstrings; new behavior has a test.
3. **Framework behavior** — Front Man must be an LLM agent; network-level vs agent `tools`; `function.description`
   (what) vs `instructions` (how); `sly_data` `allow` policy; `class` resolution via `AGENT_TOOL_PATH`; subfolder
   name prefixes; manifest `serve` / `public` / `mcp`; review internet-sourced skills.
4. **Opening the PR** — branch and commit conventions, the four gates (`ns validate`, `make lint`, `make test`,
   `make test-integration`), line lengths, the `pymarkdown` gotcha for `.md` files outside `docs/`, the
   `--external-agents` validator limitation, and integration markers.

## Impact

- No runtime effect: two new markdown files. Nothing imports or loads them; only agents that look for
  `AGENTS.md` / `CLAUDE.md` read them.
- `make lint` does not scan `AGENTS.md` (only `docs/` and `README.md`); it passes
  `pymarkdown --config ./.pymarkdownlint.yaml scan AGENTS.md` by hand.
- Sections 1 and 4 reference directories and Makefile targets and are the parts worth re-checking when those move.

## Type of Change

- [x] Documentation

## Checklist

- [x] Tested locally (`pymarkdown` scan passes; docs-only, no code paths affected)
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**