### PR TITLE
Cache subnetwork descriptions per process

### DIFF
--- a/coded_tools/agent_network_editor/constants.py
+++ b/coded_tools/agent_network_editor/constants.py
@@ -29,10 +29,6 @@ AGENT_NETWORK_NAME: str = "agent_network_name"
 # Cached list of MCP server URLs available to the designer.
 MCP_SERVERS: str = "mcp_servers"
 
-# Cached dict mapping external agent / subnetwork name to its front-man's description. Used when the editor needs to
-# surface available subnetworks (with descriptions) to the LLM.
-SUBNETWORKS: str = "subnetworks"
-
 # Cached ProgressHandler instance controls AGENT_PROGRESS reporting throttling
 PROGRESS_HANDLER: str = "progress_handler"
 

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -246,6 +246,8 @@ class GetSubnetwork(BranchActivation, CodedTool):
     # subnetwork's own hocon, which a manifest probe cannot see, and the
     # manifest-update-period bucket bounds that staleness at the same cadence
     # at which the server itself picks up registry changes.
+    # Not consulted at all when AGENT_AUTHORIZER is set — see
+    # _shared_descriptions_cache_enabled below.
     _shared_subnetwork_descriptions_cache: SharedProcessCache[dict[str, str]] = SharedProcessCache(
         fingerprint=_manifest_fingerprint
     )
@@ -258,6 +260,23 @@ class GetSubnetwork(BranchActivation, CodedTool):
         the same reasoning applies here.
         """
         GetSubnetwork._shared_subnetwork_descriptions_cache.clear_for_testing()
+
+    @staticmethod
+    def _shared_descriptions_cache_enabled() -> bool:
+        """
+        :return: True when descriptions may be shared process-wide. With an
+                AGENT_AUTHORIZER configured (non-empty env var; empty is the
+                server's allow-all default), the /function endpoint is
+                authorization-gated per caller identity — the metadata each
+                request forwards decides which networks answer and which
+                return 403 — so a mapping fetched under one user's identity
+                must not be served to other users: whichever user won the
+                cold race would blank out, or expose, networks according to
+                THEIR permissions for everyone. get_subnetworks() then skips
+                the shared cache and fetches once per invocation, the
+                pre-cache behavior.
+        """
+        return not os.getenv("AGENT_AUTHORIZER")
 
     @staticmethod
     async def get_subnetwork_names() -> list[str]:
@@ -297,30 +316,55 @@ class GetSubnetwork(BranchActivation, CodedTool):
         :return: dict mapping "/<network_name>" -> front-man's function.description.
                 Networks that fail to respond, return no front man, or have an empty
                 description are still included with an empty-string value so the LLM
-                at least sees the name. May be an empty dict if no names or no
-                run_context. The returned dict is a copy, so callers may mutate it
-                without corrupting the shared cache.
+                at least sees the name — unless EVERY description came back empty,
+                the signature of a fetch outage, in which case nothing is published
+                and this call returns an empty dict (the next call retries). Also an
+                empty dict if no names or no run_context. The returned dict is a
+                copy, so callers may mutate it without corrupting the shared cache.
         """
-        cached: dict[str, str] | None = GetSubnetwork._shared_subnetwork_descriptions_cache.peek()
-        if cached is not None:
-            return dict(cached)
+        use_shared_cache: bool = GetSubnetwork._shared_descriptions_cache_enabled()
+        if use_shared_cache:
+            # Besides skipping the factory resolution below on warm calls,
+            # this peek is what serves warm reads to callers WITHOUT a
+            # run_context (e.g. tests instantiating the tool directly): such
+            # callers degrade to an empty dict only when the cache is
+            # actually cold. aget_or_fill() peeks again on the miss path;
+            # that duplication is deliberate.
+            cached: dict[str, str] | None = GetSubnetwork._shared_subnetwork_descriptions_cache.peek()
+            if cached is not None:
+                return dict(cached)
 
         # Resolve the session factory BEFORE entering the shared fill.
         # `run_context` is injected by BranchActivation.__init__; if this CodedTool is
-        # ever instantiated outside that flow (e.g. tests bypassing __init__), the chain
-        # raises AttributeError and this call degrades to a per-call empty dict —
-        # crucially WITHOUT publishing that emptiness into the process-wide cache,
-        # where it would blank out every other conversation's view of the available
-        # subnetworks for up to a full refresh period.
-        try:
-            invocation_context = self.run_context.get_invocation_context()
-            factory = invocation_context.get_async_session_factory()
-        except AttributeError:
+        # ever instantiated outside that flow (e.g. tests bypassing __init__), this
+        # call degrades to a per-call empty dict — crucially WITHOUT publishing that
+        # emptiness into the process-wide cache, where it would blank out every other
+        # conversation's view of the available subnetworks. None-checks rather than a
+        # broad `except AttributeError`, which would also mask a genuine
+        # AttributeError raised INSIDE the neuro-san accessors (e.g. version skew).
+        run_context = getattr(self, "run_context", None)
+        invocation_context = run_context.get_invocation_context() if run_context is not None else None
+        factory = invocation_context.get_async_session_factory() if invocation_context is not None else None
+        if factory is None:
             logger.warning("No invocation context / session factory available; returning empty subnetworks.")
             return {}
 
         filler = partial(GetSubnetwork._fill_subnetwork_descriptions, factory, invocation_context)
-        subnetworks: dict[str, str] = await GetSubnetwork._shared_subnetwork_descriptions_cache.aget_or_fill(filler)
+        try:
+            if use_shared_cache:
+                subnetworks: dict[str, str] = await GetSubnetwork._shared_subnetwork_descriptions_cache.aget_or_fill(
+                    filler
+                )
+            else:
+                # An authorizer is configured: descriptions are caller-specific,
+                # so fetch under this invocation's own identity every time.
+                subnetworks = await filler()
+        except RuntimeError as error:
+            # The filler refused to build a publishable mapping (every fetch
+            # failed). Degrade to an empty dict for THIS call only — nothing
+            # was published, so the next call retries immediately.
+            logger.warning("Subnetwork description fetch failed; returning empty subnetworks for this call: %s", error)
+            return {}
         return dict(subnetworks)
 
     @staticmethod
@@ -338,15 +382,28 @@ class GetSubnetwork(BranchActivation, CodedTool):
         :param factory: The `AsyncAgentSessionFactory` of the filling invocation.
         :param invocation_context: That invocation's `InvocationContext`.
         :return: dict mapping "/<network_name>" -> description. An empty mapping
-                (no names in the manifest) IS returned, and therefore published:
-                like the names cache, this entry self-expires via the shared
-                fingerprint, so emptiness lasts at most one refresh period — and
-                publishing it prevents a per-call fetch storm within one.
+                from an empty manifest IS returned, and therefore published: like
+                the names cache, it heals when the fingerprint changes — and the
+                manifest fix that emptiness calls for is itself an mtime change
+                the fingerprint sees.
+        :raises RuntimeError: when names exist but EVERY description fetch came
+                back empty — the signature of a fetch outage, whose recovery
+                changes nothing the fingerprint observes. Publishing it would
+                blank every conversation's view, on a static server (manifest
+                update period <= 0, manifest never rewritten) until the process
+                restarts. Same failure shape, same remedy as the toolbox loader's
+                empty-mapping guard: raise so nothing is published and the next
+                call retries.
         """
         names: list[str] = await GetSubnetwork.get_subnetwork_names()
         if not names:
             return {}
-        return await GetSubnetwork._collect_via_sessions(names, factory, invocation_context)
+        descriptions: dict[str, str] = await GetSubnetwork._collect_via_sessions(names, factory, invocation_context)
+        if descriptions and not any(descriptions.values()):
+            raise RuntimeError(
+                f"all {len(descriptions)} subnetwork description fetches came back empty; treating as a failed load"
+            )
+        return descriptions
 
     @staticmethod
     async def _collect_via_sessions(
@@ -388,9 +445,11 @@ class GetSubnetwork(BranchActivation, CodedTool):
 
         # Keep every name in the result, even when the description came back empty —
         # the LLM at least gets visibility into the available subnetwork names and can
-        # still wire them if it knows what they do. Empty-description entries are
-        # cached too, so a broken network is not refetched on every call; it gets
-        # another chance when the shared entry expires at the next refresh period.
+        # still wire them if it knows what they do. A few empty entries ride along in
+        # the published mapping (a network may legitimately have no description) and
+        # refresh only when the fingerprint changes; the pathological case — EVERY
+        # description empty, the signature of a fetch outage — is rejected by the
+        # filler before anything is published.
         subnetworks: dict[str, str] = {}
         for name, desc in results:
             subnetworks[name] = desc

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -17,6 +17,7 @@
 import asyncio
 import logging
 import os
+from functools import partial
 from time import monotonic
 from typing import Any
 
@@ -31,9 +32,7 @@ from neuro_san.internals.graph.persistence.served_manifest_config_filter import 
 from pyparsing.exceptions import ParseException
 
 from coded_tools.agent_network_editor.and_logger import AndLogger
-from coded_tools.agent_network_editor.constants import SUBNETWORKS
 from coded_tools.agent_network_editor.shared_process_cache import SharedProcessCache
-from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 
 DEFAULT_MANIFEST_FILE = os.path.join("registries", "manifest_and.hocon")
 
@@ -51,7 +50,10 @@ class GetSubnetwork(BranchActivation, CodedTool):
     subnetwork — the same routing mechanism `CallAgent` uses to invoke other agents.
     The framework picks direct (in-process) or http (loopback) under the hood, so this
     works uniformly in both deployment modes without needing to reach the server's
-    internal `AgentNetworkStorage` directly.
+    internal `AgentNetworkStorage` directly. The fetched mapping is published to a
+    process-wide cache (see _shared_subnetwork_descriptions_cache below), so the
+    per-subnetwork fan-out runs once per refresh period rather than once per editor
+    invocation.
 
     The static helper `get_subnetwork_names()` is preserved for callers that do not
     have access to a run_context (e.g. middleware classes).
@@ -230,6 +232,33 @@ class GetSubnetwork(BranchActivation, CodedTool):
         """
         GetSubnetwork._shared_subnetwork_names_cache.clear_for_testing()
 
+    # Process-wide cache of the {/<network_name>: front-man description}
+    # mapping shown to the designer LLM. Previously cached per sly_data
+    # scope, which does not survive across editor invocations — so every
+    # user request re-fetched every description: one session.function({})
+    # call per subnetwork which, in http mode, is a loopback round trip
+    # processed by the same event loop that is serving the request.
+    # Constructed WITHOUT a loader: the fetch needs the framework session
+    # factory, which only a live run_context can reach, so get_subnetworks()
+    # fills the cache in-context via aget_or_fill(). Shares
+    # _manifest_fingerprint with the names cache above so names and
+    # descriptions go stale and refresh together — descriptions live in each
+    # subnetwork's own hocon, which a manifest probe cannot see, and the
+    # manifest-update-period bucket bounds that staleness at the same cadence
+    # at which the server itself picks up registry changes.
+    _shared_subnetwork_descriptions_cache: SharedProcessCache[dict[str, str]] = SharedProcessCache(
+        fingerprint=_manifest_fingerprint
+    )
+
+    @classmethod
+    def clear_shared_subnetwork_descriptions_for_testing(cls):
+        """
+        Reset the process-wide subnetwork-descriptions cache. For test
+        isolation only — see clear_shared_subnetwork_names_for_testing();
+        the same reasoning applies here.
+        """
+        GetSubnetwork._shared_subnetwork_descriptions_cache.clear_for_testing()
+
     @staticmethod
     async def get_subnetwork_names() -> list[str]:
         """
@@ -249,56 +278,75 @@ class GetSubnetwork(BranchActivation, CodedTool):
         """
         return list(await GetSubnetwork._shared_subnetwork_names_cache.aget())
 
-    async def get_subnetworks(self, sly_data: dict[str, Any]) -> dict[str, Any]:
+    async def get_subnetworks(self) -> dict[str, str]:
         """
         Return the {/<name>: front-man-description} mapping shown to the designer LLM.
 
-        For each name from the designer manifest, we open an `AsyncAgentSession` to that
-        agent and call its `function({})` endpoint to get the front-man's function spec
-        (the same JSON-schema-ish structure the LLM sees when wiring tools). The session
-        is created via `invocation_context.get_async_session_factory().create_session()`
-        — the same hook `CallAgent` uses, and the framework decides whether to dispatch
-        in-process (direct mode) or via loopback HTTP (server mode) based on the factory's
-        `use_direct` setting.
+        Served from the process-wide descriptions cache when warm. On a miss, this
+        invocation fills it: for each name from the designer manifest, we open an
+        `AsyncAgentSession` to that agent and call its `function({})` endpoint to get
+        the front-man's function spec (the same JSON-schema-ish structure the LLM sees
+        when wiring tools). The session is created via
+        `invocation_context.get_async_session_factory().create_session()` — the same
+        hook `CallAgent` uses, and the framework decides whether to dispatch
+        in-process (direct mode) or via loopback HTTP (server mode) based on the
+        factory's `use_direct` setting. Caching the result process-wide is what keeps
+        that fan-out — one `function` call per subnetwork, per editor invocation, i.e.
+        per user request — off the server's event loop in http mode.
 
-        :param sly_data: sly_data dict; result is cached at `sly_data[SUBNETWORKS]` and a
-                `SlyDataLock` named "subnetworks_lock" is held during the load.
         :return: dict mapping "/<network_name>" -> front-man's function.description.
                 Networks that fail to respond, return no front man, or have an empty
                 description are still included with an empty-string value so the LLM
                 at least sees the name. May be an empty dict if no names or no
-                run_context.
+                run_context. The returned dict is a copy, so callers may mutate it
+                without corrupting the shared cache.
         """
-        # Lock per-sly_data so two concurrent intra-session callers don't both do the work
-        # (e.g. when a parent tool fans out via asyncio.gather and several writers each
-        # transitively reach get_subnetwork).
-        async with await SlyDataLock.get_lock(sly_data, "subnetworks_lock"):
-            # Per-session cache hit (including an explicitly cached empty mapping).
-            if SUBNETWORKS in sly_data:
-                return sly_data[SUBNETWORKS]
+        cached: dict[str, str] | None = GetSubnetwork._shared_subnetwork_descriptions_cache.peek()
+        if cached is not None:
+            return dict(cached)
 
-            # Get the curated subset of names from the designer manifest.
-            # Cheap: served from the process-wide cache.
-            names: list[str] = await self.get_subnetwork_names()
-            if not names:
-                sly_data[SUBNETWORKS] = {}
-                return {}
+        # Resolve the session factory BEFORE entering the shared fill.
+        # `run_context` is injected by BranchActivation.__init__; if this CodedTool is
+        # ever instantiated outside that flow (e.g. tests bypassing __init__), the chain
+        # raises AttributeError and this call degrades to a per-call empty dict —
+        # crucially WITHOUT publishing that emptiness into the process-wide cache,
+        # where it would blank out every other conversation's view of the available
+        # subnetworks for up to a full refresh period.
+        try:
+            invocation_context = self.run_context.get_invocation_context()
+            factory = invocation_context.get_async_session_factory()
+        except AttributeError:
+            logger.warning("No invocation context / session factory available; returning empty subnetworks.")
+            return {}
 
-            # Reach the framework's session factory through run_context.
-            # `run_context` is injected by BranchActivation.__init__; if this CodedTool is
-            # ever instantiated outside that flow (e.g. tests bypassing __init__), the chain
-            # raises AttributeError and we return an empty dict rather than crashing.
-            try:
-                invocation_context = self.run_context.get_invocation_context()
-                factory = invocation_context.get_async_session_factory()
-            except AttributeError:
-                logger.warning("No invocation context / session factory available; returning empty subnetworks.")
-                sly_data[SUBNETWORKS] = {}
-                return {}
+        filler = partial(GetSubnetwork._fill_subnetwork_descriptions, factory, invocation_context)
+        subnetworks: dict[str, str] = await GetSubnetwork._shared_subnetwork_descriptions_cache.aget_or_fill(filler)
+        return dict(subnetworks)
 
-            subnetworks: dict[str, str] = await self._collect_via_sessions(names, factory, invocation_context)
-            sly_data[SUBNETWORKS] = subnetworks
-            return subnetworks
+    @staticmethod
+    async def _fill_subnetwork_descriptions(factory: Any, invocation_context: Any) -> dict[str, str]:
+        """
+        Filler for the shared descriptions cache: builds the complete mapping on
+        the event loop inside SharedProcessCache.aget_or_fill(), once per refresh
+        period, shared by every concurrent cold caller on the loop.
+
+        Whichever invocation reaches the cold cache first supplies the factory and
+        invocation_context the fill runs under; invocations are interchangeable for
+        this purpose because every factory routes `function({})` to the same server
+        state.
+
+        :param factory: The `AsyncAgentSessionFactory` of the filling invocation.
+        :param invocation_context: That invocation's `InvocationContext`.
+        :return: dict mapping "/<network_name>" -> description. An empty mapping
+                (no names in the manifest) IS returned, and therefore published:
+                like the names cache, this entry self-expires via the shared
+                fingerprint, so emptiness lasts at most one refresh period — and
+                publishing it prevents a per-call fetch storm within one.
+        """
+        names: list[str] = await GetSubnetwork.get_subnetwork_names()
+        if not names:
+            return {}
+        return await GetSubnetwork._collect_via_sessions(names, factory, invocation_context)
 
     @staticmethod
     async def _collect_via_sessions(
@@ -341,7 +389,8 @@ class GetSubnetwork(BranchActivation, CodedTool):
         # Keep every name in the result, even when the description came back empty —
         # the LLM at least gets visibility into the available subnetwork names and can
         # still wire them if it knows what they do. Empty-description entries are
-        # cached too, so we don't keep retrying within the session.
+        # cached too, so a broken network is not refetched on every call; it gets
+        # another chance when the shared entry expires at the next refresh period.
         subnetworks: dict[str, str] = {}
         for name, desc in results:
             subnetworks[name] = desc
@@ -427,4 +476,4 @@ class GetSubnetwork(BranchActivation, CodedTool):
             otherwise:
                 an empty dictionary.
         """
-        return await self.get_subnetworks(sly_data)
+        return await self.get_subnetworks()

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -94,7 +94,12 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #             no loader: descriptions can only be fetched through a live
     #             run_context's session factory, so the first
     #             get_subnetworks() call of each refresh period fills the
-    #             cache in-context (SharedProcessCache.aget_or_fill).
+    #             cache in-context (SharedProcessCache.aget_or_fill). A fill
+    #             whose fetches ALL failed raises instead of publishing —
+    #             that failure's recovery is invisible to the fingerprint —
+    #             and the cache is bypassed entirely when AGENT_AUTHORIZER
+    #             is set, because /function responses are then
+    #             caller-specific (see _shared_descriptions_cache_enabled).
     #    Used by: GetSubnetwork.get_subnetworks() (the coded tool path).
     # -----------------------------------------------------------------------
 

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -82,6 +82,20 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #             .AgentNetworkStructureValidationMiddleware.validate();
     #             agent_network_persistence_middleware.AgentNetworkPersistenceMiddleware
     #             ._assemble_and_persist().
+    #
+    # 4. Shared subnetwork descriptions
+    #    Holds:   the {/<network_name>: front-man description} mapping shown
+    #             to the designer LLM, fetched via one session.function({})
+    #             call per subnetwork.
+    #    Lives:   get_subnetwork.GetSubnetwork (async get_subnetworks)
+    #    Expiry:  the same fingerprint as the subnetwork names above (they
+    #             share _manifest_fingerprint), so names and descriptions go
+    #             stale and refresh together. Unlike the other caches it has
+    #             no loader: descriptions can only be fetched through a live
+    #             run_context's session factory, so the first
+    #             get_subnetworks() call of each refresh period fills the
+    #             cache in-context (SharedProcessCache.aget_or_fill).
+    #    Used by: GetSubnetwork.get_subnetworks() (the coded tool path).
     # -----------------------------------------------------------------------
 
     # Machine-readable registry of the entries above, as
@@ -102,6 +116,11 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
             "coded_tools.agent_network_editor.get_subnetwork",
             "GetSubnetwork",
             "clear_shared_subnetwork_names_for_testing",
+        ),
+        (
+            "coded_tools.agent_network_editor.get_subnetwork",
+            "GetSubnetwork",
+            "clear_shared_subnetwork_descriptions_for_testing",
         ),
     ]
 

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -31,6 +31,7 @@ from asyncio import shield
 from asyncio import to_thread
 from threading import Lock
 from typing import Any
+from typing import Awaitable
 from typing import Callable
 from typing import Generic
 from typing import TypeVar
@@ -44,13 +45,17 @@ class SharedProcessCache(Generic[CachedValue]):
     Process-wide cache of a single expensive value, safe across threads and
     event loops.
 
-    * loader: synchronous callable producing the value. It runs under the
-      cache lock — and in a worker thread when reached through aget() — so it
-      may do blocking file I/O and CPU-heavy parsing. It must either return a
-      complete, ready-to-share value or raise; on a raise nothing is
-      published, so the next call retries instead of serving a half-built or
-      failure value. Loaders must not return None (return an empty container
-      instead) — None is the cache's "not loaded" sentinel.
+    * loader: optional synchronous callable producing the value. It runs
+      under the cache lock — and in a worker thread when reached through
+      aget() — so it may do blocking file I/O and CPU-heavy parsing. It must
+      either return a complete, ready-to-share value or raise; on a raise
+      nothing is published, so the next call retries instead of serving a
+      half-built or failure value. Loaders must not return None (return an
+      empty container instead) — None is the cache's "not loaded" sentinel.
+      When the value can only be built from context that exists at the call
+      site (e.g. a request-scoped session factory that no standalone loader
+      could reach), construct the cache without a loader and fill it through
+      aget_or_fill() instead; get() and aget() then raise on a miss.
     * fingerprint: optional cheap callable identifying the version of the
       source the value was built from (e.g. a (path, mtime) tuple, which can
       also fold in a time bucket for TTL-style expiry). It is captured just
@@ -74,14 +79,25 @@ class SharedProcessCache(Generic[CachedValue]):
       burst cannot fill the loop's default executor with lock-waiters. The
       await is shield()-ed, so one cancelled caller cannot cancel the shared
       load out from under the others.
+    * aget_or_fill() applies the same discipline to values built by an async
+      callable ON the event loop: same once-gate, same capture-fingerprint-
+      before-building, same publish-only-on-success. Because a threading.Lock
+      cannot be held across an await, its miss double-check is lock-free and
+      only the publish takes the lock — so two loops can race to fill, which
+      is benign: each publishes a complete value under an equally current
+      fingerprint, and the race costs one duplicate build. Do not combine it
+      with a blocking loader on the same instance: get() holds the lock for
+      the whole load, and aget_or_fill()'s publish would then block its
+      event loop waiting for that lock.
     """
 
-    def __init__(self, loader: Callable[[], CachedValue], fingerprint: Callable[[], Any] | None = None):
+    def __init__(self, loader: Callable[[], CachedValue] | None = None, fingerprint: Callable[[], Any] | None = None):
         """
         Constructor
 
-        :param loader: Synchronous callable that builds the value. See the
-                class docstring for its contract.
+        :param loader: Optional synchronous callable that builds the value.
+                See the class docstring for its contract; omit it for caches
+                filled at the call site via aget_or_fill().
         :param fingerprint: Optional source-version probe. See the class
                 docstring for its contract.
         """
@@ -130,7 +146,9 @@ class SharedProcessCache(Generic[CachedValue]):
 
         :return: The cached or freshly loaded value. Loader exceptions
                 propagate without publishing anything, so the next call
-                retries.
+                retries. A miss on a cache constructed without a loader
+                raises RuntimeError — such a cache is filled at the call
+                site via aget_or_fill().
         """
         value: CachedValue | None = self.peek()
         if value is not None:
@@ -145,6 +163,12 @@ class SharedProcessCache(Generic[CachedValue]):
             entry: tuple[CachedValue, Any] | None = self._entry
             if entry is not None and (self._fingerprint is None or entry[1] == current_fingerprint):
                 return entry[0]
+
+            if self._loader is None:
+                raise RuntimeError(
+                    "SharedProcessCache miss on a cache with no loader; "
+                    "this cache can only be filled via aget_or_fill()."
+                )
 
             # The fingerprint was captured BEFORE loading: if the source
             # changes while the loader runs, the next read's probe mismatches
@@ -170,12 +194,55 @@ class SharedProcessCache(Generic[CachedValue]):
         if value is not None:
             return value
 
+        return await self._await_shared_load(lambda: to_thread(self.get))
+
+    async def aget_or_fill(self, filler: Callable[[], Awaitable[CachedValue]]) -> CachedValue:
+        """
+        aget() for caches whose value can only be built from context that
+        exists at the call site (e.g. a request-scoped session factory no
+        standalone loader could reach): warm reads resolve via the lock-free
+        peek without suspending the caller (the await completes immediately);
+        on a miss, ONE caller's filler runs on this event loop and every
+        concurrent cold caller on the loop awaits that shared fill.
+
+        Because whichever caller arrives first supplies the filler that
+        actually runs, all callers' fillers must build the same value —
+        differing only in the call-site context they carry. The filler
+        follows the loader contract: return a complete, ready-to-share value
+        or raise (nothing is published on a raise, so the next call
+        retries), and never return None. It runs ON the event loop, so it
+        should await network-style I/O; blocking file I/O or heavy parsing
+        belongs in a loader reached through aget() instead.
+
+        :param filler: Async callable that builds the value.
+        :return: The cached or freshly filled value. Filler exceptions
+                propagate to every caller awaiting that fill, and the next
+                call starts a fresh attempt.
+        """
+        value: CachedValue | None = self.peek()
+        if value is not None:
+            return value
+
+        return await self._await_shared_load(lambda: self._fill_and_publish(filler))
+
+    async def _await_shared_load(self, start_load: Callable[[], Awaitable[CachedValue]]) -> CachedValue:
+        """
+        The per-event-loop once-gate shared by aget() and aget_or_fill():
+        adopt this loop's in-flight load task if one is pending, otherwise
+        start a new one from start_load.
+
+        :param start_load: Zero-arg callable producing the awaitable that
+                performs the load; only invoked when a new task is needed,
+                so no coroutine is created (and left unawaited) on the
+                adopt path.
+        :return: The loaded value, once the shared task completes.
+        """
         loop = get_running_loop()
         task: Task | None = self._loads_in_flight.get(loop)
         if task is None or task.done():
             # A done task is a finished earlier attempt (possibly failed or
             # stale); start a new one. Awaiters of the old task are unaffected.
-            task = loop.create_task(to_thread(self.get))
+            task = loop.create_task(start_load())
             self._loads_in_flight[loop] = task
             task.add_done_callback(self._forget_in_flight_load)
         # shield() detaches awaiter cancellation from the shared task: a
@@ -184,6 +251,33 @@ class SharedProcessCache(Generic[CachedValue]):
         # here would let one cancelled caller cancel everyone else's load,
         # because Task.cancel() propagates into whatever the task is awaiting.
         return await shield(task)
+
+    async def _fill_and_publish(self, filler: Callable[[], Awaitable[CachedValue]]) -> CachedValue:
+        """
+        Body of an aget_or_fill() once-gate task: get()'s miss discipline,
+        restated for a build that happens on the event loop.
+
+        The fingerprint is probed once per miss — serving both as the
+        double-check against a fill that completed while this task was being
+        scheduled and as the freshness capture published with the value —
+        and it is captured BEFORE the filler runs, so a source change
+        mid-fill leaves the published entry already stale rather than a torn
+        read living forever. Unlike get(), the build runs outside the lock
+        (a threading.Lock cannot be held across an await), so the
+        double-check is advisory across loops/threads; see the class
+        docstring for why that race is benign.
+        """
+        current_fingerprint: Any = self._fingerprint() if self._fingerprint is not None else None
+        entry: tuple[CachedValue, Any] | None = self._entry
+        if entry is not None and (self._fingerprint is None or entry[1] == current_fingerprint):
+            return entry[0]
+
+        value: CachedValue = await filler()
+        # Publish only after the filler fully succeeded, under the lock so
+        # the swap serializes with get()'s publish and clear_for_testing().
+        with self._lock:
+            self._entry = (value, current_fingerprint)
+        return value
 
     def _forget_in_flight_load(self, task: Task):
         """

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -83,12 +83,21 @@ class SharedProcessCache(Generic[CachedValue]):
       callable ON the event loop: same once-gate, same capture-fingerprint-
       before-building, same publish-only-on-success. Because a threading.Lock
       cannot be held across an await, its miss double-check is lock-free and
-      only the publish takes the lock — so two loops can race to fill, which
-      is benign: each publishes a complete value under an equally current
-      fingerprint, and the race costs one duplicate build. Do not combine it
-      with a blocking loader on the same instance: get() holds the lock for
-      the whole load, and aget_or_fill()'s publish would then block its
-      event loop waiting for that lock.
+      only the publish takes the lock. The once-gate deduplicates per event
+      loop only, and the server hands each concurrent session its own loop —
+      so a cold burst can run one fill per session loop. (The loader path
+      does not duplicate work this way: get()'s lock makes cross-loop loser
+      threads wait and then serve the winner's published entry, while async
+      fills have no cross-loop serialization.) A publish-time fingerprint
+      re-probe in _fill_and_publish keeps a slower fill whose capture went
+      stale from clobbering a fresher racer's entry.
+    * A cache is either loader-backed (get()/aget()) or call-site-filled
+      (aget_or_fill()), never both; the wrong entry point raises RuntimeError
+      on a miss. Beyond keeping each instance's read surface predictable,
+      this guards two concrete hazards: an aget() task on a loaderless cache
+      would sit doomed in the once-gate slot for an aget_or_fill() caller to
+      adopt, and a fill's publish on the event loop would block behind get()
+      holding the lock across a whole blocking load in a worker thread.
     """
 
     def __init__(self, loader: Callable[[], CachedValue] | None = None, fingerprint: Callable[[], Any] | None = None):
@@ -135,6 +144,31 @@ class SharedProcessCache(Generic[CachedValue]):
             return None
         return value
 
+    def _probe_fresh(self) -> tuple[Any, CachedValue | None]:
+        """
+        The one copy of the per-miss freshness discipline shared by get()
+        and _fill_and_publish(): probe the fingerprint exactly once and
+        report whether the stored entry is still fresh under it. The single
+        probe serves both as the double-check against a load/fill that
+        completed in the meantime and as the freshness capture published
+        with a newly built value — so a stat-style probe runs once per
+        miss, not twice.
+
+        Takes no lock itself; each caller chooses its own locking (get()
+        calls this under the cache lock, _fill_and_publish() calls it
+        lock-free — its reads are one atomic reference read of _entry plus
+        the probe, exactly like peek()).
+
+        :return: (current fingerprint, the fresh cached value or None on a
+                miss). None-as-miss is unambiguous because loaders and
+                fillers must never return None.
+        """
+        current_fingerprint: Any = self._fingerprint() if self._fingerprint is not None else None
+        entry: tuple[CachedValue, Any] | None = self._entry
+        if entry is not None and (self._fingerprint is None or entry[1] == current_fingerprint):
+            return current_fingerprint, entry[0]
+        return current_fingerprint, None
+
     def get(self) -> CachedValue:
         """
         Get the value, running the loader on a miss (first call in the
@@ -155,14 +189,11 @@ class SharedProcessCache(Generic[CachedValue]):
             return value
 
         with self._lock:
-            # Probe the fingerprint once per miss: it serves both as the
-            # double-check against a load that finished while this thread
-            # waited for the lock, and as the freshness capture stored with
-            # the value below — so a stat-style probe runs once, not twice.
-            current_fingerprint: Any = self._fingerprint() if self._fingerprint is not None else None
-            entry: tuple[CachedValue, Any] | None = self._entry
-            if entry is not None and (self._fingerprint is None or entry[1] == current_fingerprint):
-                return entry[0]
+            # Under the lock, the shared probe doubles as the check against
+            # a load that finished while this thread waited for the lock.
+            current_fingerprint, fresh = self._probe_fresh()
+            if fresh is not None:
+                return fresh
 
             if self._loader is None:
                 raise RuntimeError(
@@ -188,11 +219,21 @@ class SharedProcessCache(Generic[CachedValue]):
 
         :return: The cached or freshly loaded value. Loader exceptions
                 propagate to every caller awaiting that load, and the next
-                aget() starts a fresh attempt.
+                aget() starts a fresh attempt. A miss on a cache constructed
+                without a loader raises RuntimeError — use aget_or_fill().
         """
         value: CachedValue | None = self.peek()
         if value is not None:
             return value
+
+        if self._loader is None:
+            # Reject before creating a task: a doomed to_thread(get) task
+            # sitting in the once-gate slot could otherwise be adopted by a
+            # concurrent aget_or_fill() caller holding a perfectly valid
+            # filler, failing it for no reason.
+            raise RuntimeError(
+                "SharedProcessCache miss on a cache with no loader; this cache can only be filled via aget_or_fill()."
+            )
 
         return await self._await_shared_load(lambda: to_thread(self.get))
 
@@ -217,11 +258,19 @@ class SharedProcessCache(Generic[CachedValue]):
         :param filler: Async callable that builds the value.
         :return: The cached or freshly filled value. Filler exceptions
                 propagate to every caller awaiting that fill, and the next
-                call starts a fresh attempt.
+                call starts a fresh attempt. A miss on a cache constructed
+                WITH a loader raises RuntimeError — use get()/aget().
         """
         value: CachedValue | None = self.peek()
         if value is not None:
             return value
+
+        if self._loader is not None:
+            # See the class docstring: mixing the modes on one instance is
+            # rejected because get() holds the cache lock across a whole
+            # blocking load, and the fill's publish would take that same
+            # lock on the event loop — stalling every coroutine on it.
+            raise RuntimeError("SharedProcessCache has a loader; read it via get()/aget() instead of aget_or_fill().")
 
         return await self._await_shared_load(lambda: self._fill_and_publish(filler))
 
@@ -257,26 +306,31 @@ class SharedProcessCache(Generic[CachedValue]):
         Body of an aget_or_fill() once-gate task: get()'s miss discipline,
         restated for a build that happens on the event loop.
 
-        The fingerprint is probed once per miss — serving both as the
-        double-check against a fill that completed while this task was being
-        scheduled and as the freshness capture published with the value —
-        and it is captured BEFORE the filler runs, so a source change
+        The fingerprint is probed once per miss (the shared _probe_fresh
+        discipline) and captured BEFORE the filler runs, so a source change
         mid-fill leaves the published entry already stale rather than a torn
         read living forever. Unlike get(), the build runs outside the lock
         (a threading.Lock cannot be held across an await), so the
-        double-check is advisory across loops/threads; see the class
-        docstring for why that race is benign.
+        double-check is advisory across loops/threads — concurrent loops can
+        each run a fill; see the class docstring.
         """
-        current_fingerprint: Any = self._fingerprint() if self._fingerprint is not None else None
-        entry: tuple[CachedValue, Any] | None = self._entry
-        if entry is not None and (self._fingerprint is None or entry[1] == current_fingerprint):
-            return entry[0]
+        current_fingerprint, fresh = self._probe_fresh()
+        if fresh is not None:
+            return fresh
 
         value: CachedValue = await filler()
         # Publish only after the filler fully succeeded, under the lock so
         # the swap serializes with get()'s publish and clear_for_testing().
         with self._lock:
-            self._entry = (value, current_fingerprint)
+            # Re-probe before publishing: a faster fill on another loop may
+            # have published under a newer fingerprint while this build ran.
+            # Overwriting that fresher entry with this one — already stale,
+            # since its capture no longer matches — would force yet another
+            # rebuild on the next read. Keep the fresher entry; this fill's
+            # own awaiters still receive `value` below.
+            latest_fingerprint, still_fresh = self._probe_fresh()
+            if still_fresh is None or current_fingerprint == latest_fingerprint:
+                self._entry = (value, current_fingerprint)
         return value
 
     def _forget_in_flight_load(self, task: Task):
@@ -314,9 +368,9 @@ class SharedProcessCache(Generic[CachedValue]):
         after the clear could adopt a still-pending pre-clear load and
         receive a value built under the previous test's env/file state. The
         lock serializes this reset with a load that is mid-publish; a
-        pre-clear load that was dispatched but never awaited can still
-        publish after the reset, which tests avoid by running loads
-        sequentially.
+        pre-clear load or fill that is still running (dispatched but never
+        awaited, or kept alive by shield()) can still publish after the
+        reset, which tests avoid by running loads sequentially.
         """
         # Taking the lock serializes the reset with a concurrent load, so
         # this can never unpublish an entry mid-initialization.

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -29,6 +29,7 @@ from asyncio import Task
 from asyncio import get_running_loop
 from asyncio import shield
 from asyncio import to_thread
+from functools import partial
 from threading import Lock
 from typing import Any
 from typing import Awaitable
@@ -235,7 +236,7 @@ class SharedProcessCache(Generic[CachedValue]):
                 "SharedProcessCache miss on a cache with no loader; this cache can only be filled via aget_or_fill()."
             )
 
-        return await self._await_shared_load(lambda: to_thread(self.get))
+        return await self._await_shared_load(partial(to_thread, self.get))
 
     async def aget_or_fill(self, filler: Callable[[], Awaitable[CachedValue]]) -> CachedValue:
         """
@@ -272,7 +273,7 @@ class SharedProcessCache(Generic[CachedValue]):
             # lock on the event loop — stalling every coroutine on it.
             raise RuntimeError("SharedProcessCache has a loader; read it via get()/aget() instead of aget_or_fill().")
 
-        return await self._await_shared_load(lambda: self._fill_and_publish(filler))
+        return await self._await_shared_load(partial(self._fill_and_publish, filler))
 
     async def _await_shared_load(self, start_load: Callable[[], Awaitable[CachedValue]]) -> CachedValue:
         """

--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -249,7 +249,7 @@ Operational notes:
                     ]
                 },
                 "from_downstream": {
-                    "sly_data": ["agent_network_definition", "agent_network_name", "agent_network_queries", "mcp_servers", "subnetworks"],
+                    "sly_data": ["agent_network_definition", "agent_network_name", "agent_network_queries", "mcp_servers"],
                     # Allow all messages sent from specific downstream agents to be reported
                     # as if they came back from this agent network
                     "messages": ["/agent_network_editor", "/agent_network_query_generator", "/agent_network_instructions_editor"]

--- a/registries/agent_network_editor.hocon
+++ b/registries/agent_network_editor.hocon
@@ -188,7 +188,7 @@ Always respond with "Successfully created/edited the structure of the agent netw
 """,
             "allow": {
                 "to_upstream": {
-                    "sly_data": ["agent_network_definition", "agent_network_name", "mcp_servers", "subnetworks"]
+                    "sly_data": ["agent_network_definition", "agent_network_name", "mcp_servers"]
                 }
             },
             "tools": [

--- a/tests/coded_tools/agent_network_editor/test_get_subnetwork.py
+++ b/tests/coded_tools/agent_network_editor/test_get_subnetwork.py
@@ -1,0 +1,191 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Policy tests for GetSubnetwork's process-wide descriptions cache: what gets
+published, what must never be published, and when the shared cache is
+bypassed. The generic cache mechanism itself is covered by
+test_shared_process_cache.py; these tests pin the policy layered on top of
+it, with the framework session layer stubbed out.
+
+Skipped (not failed) in environments whose neuro-san predates the imports
+get_subnetwork needs, so the suite still collects everywhere.
+"""
+
+import asyncio
+import os
+from unittest import TestCase
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("coded_tools.agent_network_editor.get_subnetwork")
+
+# The import must stay below importorskip so old environments skip cleanly.
+# pylint: disable-next=wrong-import-position
+from coded_tools.agent_network_editor.get_subnetwork import GetSubnetwork  # noqa: E402
+
+SUBNETWORK_NAMES: list[str] = ["/alpha", "/beta"]
+
+
+class TestGetSubnetwork(TestCase):
+    """Behavioral tests for the shared subnetwork-descriptions policy."""
+
+    def setUp(self):
+        # tests/conftest.py's autouse fixture also clears the shared caches
+        # around every test; clearing here as well keeps these tests correct
+        # when run directly through unittest.
+        GetSubnetwork.clear_shared_subnetwork_names_for_testing()
+        GetSubnetwork.clear_shared_subnetwork_descriptions_for_testing()
+        self.fetch_log: list[str] = []
+        self.descriptions: dict[str, str] = {"/alpha": "does alpha", "/beta": "does beta"}
+
+    def _make_tool(self) -> GetSubnetwork:
+        """
+        Build a GetSubnetwork (bypassing the framework-only __init__) whose
+        run_context chain yields a stub session factory serving
+        self.descriptions and recording each fetch in self.fetch_log.
+        """
+        fetch_log = self.fetch_log
+        descriptions = self.descriptions
+
+        def create_session(name: str, _invocation_context) -> mock.Mock:
+            async def function(_args) -> dict:
+                fetch_log.append(name)
+                return {"function": {"description": descriptions.get(name, "")}}
+
+            session = mock.Mock()
+            session.function = function
+            return session
+
+        factory = mock.Mock()
+        factory.create_session = create_session
+
+        tool: GetSubnetwork = GetSubnetwork.__new__(GetSubnetwork)
+        tool.run_context = mock.Mock()
+        tool.run_context.get_invocation_context.return_value.get_async_session_factory.return_value = factory
+        return tool
+
+    @staticmethod
+    def _patched_names():
+        """Pin the names half so these tests never parse the real manifest."""
+        return mock.patch.object(
+            GetSubnetwork, "get_subnetwork_names", new=mock.AsyncMock(return_value=list(SUBNETWORK_NAMES))
+        )
+
+    def test_concurrent_callers_share_one_fetch_and_warm_reads_are_free(self):
+        """A cold burst fans out once for the whole loop; warm reads fetch nothing."""
+
+        async def run() -> list[dict[str, str]]:
+            tools = [self._make_tool() for _ in range(10)]
+            burst = await asyncio.gather(*[tool.get_subnetworks() for tool in tools])
+            warm = await self._make_tool().get_subnetworks()
+            return burst + [warm]
+
+        with self._patched_names():
+            results = asyncio.run(run())
+
+        for result in results:
+            self.assertEqual(result, self.descriptions)
+        # One fetch per subnetwork for the whole burst, none for the warm read.
+        self.assertEqual(sorted(self.fetch_log), sorted(SUBNETWORK_NAMES))
+
+    def test_context_less_caller_degrades_without_publishing(self):
+        """A caller without run_context gets {} per-call, never poisoning the cache."""
+        bare: GetSubnetwork = GetSubnetwork.__new__(GetSubnetwork)
+
+        async def run() -> tuple[dict[str, str], dict[str, str]]:
+            empty = await bare.get_subnetworks()
+            filled = await self._make_tool().get_subnetworks()
+            return empty, filled
+
+        with self._patched_names():
+            empty, filled = asyncio.run(run())
+
+        self.assertEqual(empty, {})
+        # Had the {} been published, this caller would have been served it.
+        self.assertEqual(filled, self.descriptions)
+
+    def test_context_less_caller_is_served_warm_cache_hits(self):
+        """The pre-fill peek serves warm reads even to context-less callers."""
+
+        async def run() -> dict[str, str]:
+            await self._make_tool().get_subnetworks()
+            bare: GetSubnetwork = GetSubnetwork.__new__(GetSubnetwork)
+            return await bare.get_subnetworks()
+
+        with self._patched_names():
+            self.assertEqual(asyncio.run(run()), self.descriptions)
+
+    def test_all_empty_fetches_are_not_published_and_the_next_call_heals(self):
+        """A fill whose every fetch failed publishes nothing; recovery is immediate."""
+        # Every fetch degrades to "" — the signature of an outage.
+        self.descriptions.clear()
+
+        async def run() -> dict[str, str]:
+            return await self._make_tool().get_subnetworks()
+
+        with self._patched_names():
+            self.assertEqual(asyncio.run(run()), {})
+            # Nothing was published (no fingerprint change needed to heal):
+            # the moment fetches work again, callers get the full mapping.
+            self.descriptions.update({"/alpha": "does alpha", "/beta": "does beta"})
+            self.assertEqual(asyncio.run(run()), self.descriptions)
+
+    def test_partially_empty_descriptions_are_still_published(self):
+        """Some empty descriptions are legitimate; a partial mapping is cached."""
+        self.descriptions["/beta"] = ""
+
+        async def run() -> dict[str, str]:
+            return await self._make_tool().get_subnetworks()
+
+        with self._patched_names():
+            first = asyncio.run(run())
+            second = asyncio.run(run())
+
+        self.assertEqual(first, {"/alpha": "does alpha", "/beta": ""})
+        self.assertEqual(second, first)
+        # The second call was served warm — one fetch per subnetwork total.
+        self.assertEqual(sorted(self.fetch_log), sorted(SUBNETWORK_NAMES))
+
+    def test_returned_mapping_is_a_copy(self):
+        """Mutating a returned mapping must not corrupt the shared value."""
+
+        async def run() -> dict[str, str]:
+            first = await self._make_tool().get_subnetworks()
+            first["/tampered"] = "oops"
+            return await self._make_tool().get_subnetworks()
+
+        with self._patched_names():
+            second = asyncio.run(run())
+
+        self.assertNotIn("/tampered", second)
+
+    def test_authorizer_bypasses_the_shared_cache(self):
+        """With AGENT_AUTHORIZER set, every invocation fetches under its own identity."""
+
+        async def run() -> None:
+            await self._make_tool().get_subnetworks()
+            await self._make_tool().get_subnetworks()
+
+        with self._patched_names(), mock.patch.dict(os.environ, {"AGENT_AUTHORIZER": "some.authorizer.Class"}):
+            asyncio.run(run())
+
+        # Two invocations, two full fan-outs — /function responses are
+        # caller-specific under an authorizer, so nothing may be shared...
+        self.assertEqual(sorted(self.fetch_log), sorted(SUBNETWORK_NAMES * 2))
+        # ...and nothing was left behind in the shared cache.
+        cache = GetSubnetwork._shared_subnetwork_descriptions_cache  # pylint: disable=protected-access
+        self.assertIsNone(cache.peek())

--- a/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
+++ b/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
@@ -175,6 +175,120 @@ class TestSharedProcessCache(TestCase):
             self.assertEqual(asyncio.run(cache.aget()), "value")
         self.assertEqual(len(cache._loads_in_flight), 0)  # pylint: disable=protected-access
 
+    def test_get_raises_on_a_miss_without_a_loader(self):
+        """A loaderless cache raises on a get() miss but serves warm reads."""
+
+        async def filler() -> str:
+            return "filled"
+
+        cache: SharedProcessCache[str] = SharedProcessCache()
+        with self.assertRaises(RuntimeError):
+            cache.get()
+        self.assertEqual(asyncio.run(cache.aget_or_fill(filler)), "filled")
+        self.assertEqual(cache.get(), "filled")
+
+    def test_aget_or_fill_shares_one_fill_and_serves_warm_reads(self):
+        """Concurrent cold aget_or_fill() callers share a single filler run."""
+        calls = {"count": 0}
+
+        async def filler() -> str:
+            calls["count"] += 1
+            await asyncio.sleep(0.05)
+            return "filled"
+
+        cache: SharedProcessCache[str] = SharedProcessCache()
+
+        async def run() -> list[str]:
+            burst = await asyncio.gather(*[cache.aget_or_fill(filler) for _ in range(20)])
+            warm = await cache.aget_or_fill(filler)
+            return burst + [warm]
+
+        self.assertEqual(asyncio.run(run()), ["filled"] * 21)
+        self.assertEqual(calls["count"], 1)
+
+    def test_aget_or_fill_failure_is_shared_and_next_call_retries(self):
+        """A failing shared fill raises for all awaiters; the next call retries."""
+        attempts = {"count": 0}
+
+        async def filler() -> str:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("boom")
+            return "healed"
+
+        cache: SharedProcessCache[str] = SharedProcessCache()
+
+        async def run() -> str:
+            results = await asyncio.gather(*[cache.aget_or_fill(filler) for _ in range(3)], return_exceptions=True)
+            self.assertTrue(all(isinstance(result, RuntimeError) for result in results))
+            # Nothing was published, so the failure is not served warm.
+            self.assertIsNone(cache.peek())
+            return await cache.aget_or_fill(filler)
+
+        self.assertEqual(asyncio.run(run()), "healed")
+        self.assertEqual(attempts["count"], 2)
+
+    def test_aget_or_fill_respects_fingerprint_freshness(self):
+        """A fingerprint change turns warm aget_or_fill() reads into a refill."""
+        source = {"fingerprint": 1, "fills": 0}
+
+        async def filler() -> str:
+            source["fills"] += 1
+            return f"value-{source['fingerprint']}"
+
+        cache: SharedProcessCache[str] = SharedProcessCache(fingerprint=lambda: source["fingerprint"])
+
+        async def run() -> tuple[str, str, str]:
+            first = await cache.aget_or_fill(filler)
+            second = await cache.aget_or_fill(filler)
+            source["fingerprint"] = 2
+            third = await cache.aget_or_fill(filler)
+            return first, second, third
+
+        self.assertEqual(asyncio.run(run()), ("value-1", "value-1", "value-2"))
+        self.assertEqual(source["fills"], 2)
+
+    def test_aget_or_fill_captures_fingerprint_before_the_filler_runs(self):
+        """A mid-fill source change leaves the published entry stale."""
+        # The async twin of test_fingerprint_is_captured_before_the_loader_runs:
+        # if the source changes while the filler runs, the published entry must
+        # already be stale so the next read rebuilds it.
+        source = {"fingerprint": 1}
+
+        async def filler() -> str:
+            source["fingerprint"] = 2
+            return "torn"
+
+        cache: SharedProcessCache[str] = SharedProcessCache(fingerprint=lambda: source["fingerprint"])
+        self.assertEqual(asyncio.run(cache.aget_or_fill(filler)), "torn")
+        self.assertIsNone(cache.peek())
+
+    def test_aget_or_fill_survives_one_awaiter_being_cancelled(self):
+        """Cancelling one aget_or_fill() awaiter must not cancel the shared fill."""
+        calls = {"count": 0}
+
+        async def run() -> str:
+            release = asyncio.Event()
+
+            async def filler() -> str:
+                calls["count"] += 1
+                await release.wait()
+                return "survived"
+
+            cache: SharedProcessCache[str] = SharedProcessCache()
+            first = asyncio.create_task(cache.aget_or_fill(filler))
+            second = asyncio.create_task(cache.aget_or_fill(filler))
+            # One tick so both awaiters reach the shared fill task.
+            await asyncio.sleep(0)
+            first.cancel()
+            release.set()
+            with self.assertRaises(asyncio.CancelledError):
+                await first
+            return await second
+
+        self.assertEqual(asyncio.run(run()), "survived")
+        self.assertEqual(calls["count"], 1)
+
     def test_clear_for_testing_drops_entry_and_pending_loads(self):
         """clear_for_testing() drops the entry AND forgets pending loads."""
         calls = {"count": 0}

--- a/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
+++ b/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
@@ -187,6 +187,55 @@ class TestSharedProcessCache(TestCase):
         self.assertEqual(asyncio.run(cache.aget_or_fill(filler)), "filled")
         self.assertEqual(cache.get(), "filled")
 
+    def test_aget_raises_on_a_miss_without_a_loader(self):
+        """aget() rejects a loaderless miss without seeding the once-gate."""
+        cache: SharedProcessCache[str] = SharedProcessCache()
+
+        async def filler() -> str:
+            return "filled"
+
+        async def run() -> str:
+            with self.assertRaises(RuntimeError):
+                await cache.aget()
+            # The rejected aget() must not have left a doomed task behind
+            # for aget_or_fill() to adopt.
+            return await cache.aget_or_fill(filler)
+
+        self.assertEqual(asyncio.run(run()), "filled")
+
+    def test_aget_or_fill_raises_when_a_loader_is_configured(self):
+        """aget_or_fill() rejects a miss on a loader-backed cache."""
+        cache: SharedProcessCache[str] = SharedProcessCache(loader=lambda: "loaded")
+
+        async def filler() -> str:
+            return "filled"
+
+        async def run() -> None:
+            with self.assertRaises(RuntimeError):
+                await cache.aget_or_fill(filler)
+
+        asyncio.run(run())
+        # The loader path is unaffected by the rejected call.
+        self.assertEqual(cache.get(), "loaded")
+
+    def test_aget_or_fill_does_not_clobber_a_fresher_entry(self):
+        """A fill whose capture went stale must not overwrite a racer's fresher entry."""
+        source = {"fingerprint": 1}
+        cache: SharedProcessCache[str] = SharedProcessCache(fingerprint=lambda: source["fingerprint"])
+
+        async def slow_filler() -> str:
+            # Stand-in for a faster fill on ANOTHER event loop finishing
+            # first: the source rolls mid-build and the racer publishes a
+            # value that is current under the new fingerprint.
+            source["fingerprint"] = 2
+            cache._entry = ("fresh", 2)  # pylint: disable=protected-access
+            return "stale"
+
+        # This fill's own awaiter still receives its value...
+        self.assertEqual(asyncio.run(cache.aget_or_fill(slow_filler)), "stale")
+        # ...but the racer's fresher entry survives the publish.
+        self.assertEqual(cache.peek(), "fresh")
+
     def test_aget_or_fill_shares_one_fill_and_serves_warm_reads(self):
         """Concurrent cold aget_or_fill() callers share a single filler run."""
         calls = {"count": 0}


### PR DESCRIPTION
## Description

Follow-up to #1277 (issue #1267). That PR made the *names* half of `get_subnetwork` process-wide, but the expensive half — the `{"/name": description}` mapping — was still cached per sly_data scope, which does not survive across editor invocations. Since the designer instructs the editor to start every invocation with `get_subnetwork`, **every user request re-ran one `session.function({})` call per subnetwork** (~17 with the shipped manifest). In http mode each of those is a loopback round trip processed by the same event loop that is serving the requests, so the cost self-amplifies under concurrent load.

What this PR does:

1. **`SharedProcessCache` grows an async-filled path** — `aget_or_fill(filler)`, for values that can only be built from call-site context (here: the framework session factory, reachable only through a live `run_context`, so no standalone loader can fetch it). The loader becomes optional, the per-event-loop once-gate is factored into one `_await_shared_load()` helper shared with `aget()`, and the fill keeps the existing discipline: fingerprint captured before the build, publish only on success, shielded await. The loader/fill modes are mutually exclusive per instance and enforced at call time (`RuntimeError` from the wrong entry point), because mixing them has two concrete hazards documented in the class docstring.
2. **`GetSubnetwork` descriptions become process-wide** — filled in-context by whichever invocation reaches the cold cache first, keyed by the *same* manifest fingerprint as the names cache so names and descriptions go stale and refresh together. Callers receive copies.
3. **Failure containment**
   - A fill whose description fetches **all** came back empty raises instead of publishing — the signature of a fetch outage (e.g. loopback timeouts during startup), whose recovery changes nothing the fingerprint observes. On a static server a published blank map would otherwise be pinned until restart. Same failure shape, same remedy as `GetToolbox`'s empty-mapping guard.
   - With **`AGENT_AUTHORIZER` set, the shared cache is bypassed** and every invocation fetches under its own identity: the `/function` endpoint is authorization-gated per caller there, so a shared entry would serve whichever user won the cold race — their 403s blanked out, their visibility exposed — to everyone.
   - A **publish-time fingerprint re-probe** keeps a slow fill whose capture went stale mid-build from clobbering a fresher racer's entry.
   - A caller without a `run_context` degrades to a per-call empty dict **without** publishing that emptiness process-wide.
4. **Dead sly_data channel removed** — with descriptions no longer carried in sly_data, `"subnetworks"` became a write-only key: the constant, the stash + `SlyDataLock`, and the allowlist entries in both hocons are gone (see Impact for the allowlist disclosure).

## Impact

Freshness/behavior by configuration:

- **Server deployments** (`AGENT_MANIFEST_UPDATE_PERIOD_SECONDS=0` per `deploy/Dockerfile`): descriptions load once and live until a manifest path/mtime change — the same static-server assumption the names cache already documents.
- **Studio local runner** (period 5s): at most one fan-out per 5-second window, the same cadence at which the server itself picks up registry changes, so networks the designer just saved still appear promptly.
- **`AGENT_AUTHORIZER` configured**: shared cache bypassed; per-invocation fetch (identical to pre-PR behavior).

⚠️ **Hocon allowlist changes** (same disclosure style as #1276): `"subnetworks"` is removed from the editor front man's `to_upstream` sly_data and the designer front man's `from_downstream` sly_data. Nothing reads the key after this PR — it never flowed `to_downstream` nor to the client, so the designer-side copy was unread.

Note for reviewers: this branch touches the same two hocon allowlist lines, `constants.py`, and the `globals.py` inventory as the upcoming GetMcpTool caching branch (issue #1269); whichever merges second rebases trivially.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
