### PR TITLE
Rename mtime to modification_time in the cache fingerprint helpers

### DIFF
--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -99,22 +99,22 @@ class GetMcpTool(CodedTool):
 
         * the resolved path — an env-var change or the cwd-scaffolded file
           appearing takes effect on the next read;
-        * the file's mtime — a direct edit invalidates immediately, and a
-          missing file (mtime None) self-heals the moment it appears.
+        * the file's modification_time — a direct edit invalidates immediately, and a
+          missing file (modification_time None) self-heals the moment it appears.
 
         Two changes are invisible to this probe: HOCON `${...}` references
         inside the file resolve against the environment at parse time, so
         changing THOSE env vars alters the parse result without touching
-        path or mtime; and LangChainMcpAdapter keeps its own copy of the
+        path or modification_time; and LangChainMcpAdapter keeps its own copy of the
         servers info, frozen at its first load — a file edit refreshes
         which URLs this class serves, but not the connection details the
         adapter already latched. Both heal on process restart (or on the
-        mtime change of the next file edit, for the first).
+        modification_time change of the next file edit, for the first).
 
-        :return: (path, mtime_ns or None) tuple.
+        :return: (path, modification_time_ns or None) tuple.
         """
         mcp_info_file: str = GetMcpTool.get_mcp_info_file()
-        return (mcp_info_file, SharedProcessCache.stat_mtime_ns(mcp_info_file))
+        return (mcp_info_file, SharedProcessCache.stat_modification_time_ns(mcp_info_file))
 
     @staticmethod
     def _load_mcp_servers() -> list[str]:
@@ -125,8 +125,8 @@ class GetMcpTool(CodedTool):
         :return: List of MCP server URLs from mcp_info.hocon. A missing,
                 unreadable, or unparseable file returns an empty list, which
                 IS published: the fingerprint self-heals it — a missing file
-                flips the mtime component when it appears, and fixing a
-                broken file changes its mtime — so nothing can pin an empty
+                flips the modification_time component when it appears, and fixing a
+                broken file changes its modification_time — so nothing can pin an empty
                 list past the next change to the file itself (env-var
                 references INSIDE the file are the one exception; see
                 _mcp_info_fingerprint).
@@ -155,7 +155,7 @@ class GetMcpTool(CodedTool):
     # Process-wide cache of the MCP server URLs parsed from mcp_info.hocon.
     # Previously cached per sly_data scope, so a server handling N concurrent
     # conversations re-parsed the same HOCON N times, on the event loop.
-    # The (path, mtime) fingerprint picks up env-var changes and file edits
+    # The (path, modification_time) fingerprint picks up env-var changes and file edits
     # immediately; there is no time bucket because nothing changes this file
     # at runtime. Locking, publish ordering, and the async once-gate live in
     # SharedProcessCache; access goes through the class by name (not cls) so
@@ -236,11 +236,11 @@ class GetMcpTool(CodedTool):
         one and revive a stale entry; carrying the TTL makes any change to
         it an immediate miss instead.
 
-        :return: (path, mtime_ns or None, ttl, time bucket) tuple.
+        :return: (path, modification_time_ns or None, ttl, time bucket) tuple.
         """
-        mcp_info_file, mtime_ns = GetMcpTool._mcp_info_fingerprint()
+        mcp_info_file, modification_time_ns = GetMcpTool._mcp_info_fingerprint()
         ttl: float = GetMcpTool._mcp_tools_ttl_seconds()
-        return (mcp_info_file, mtime_ns, ttl, SharedProcessCache.time_bucket(ttl))
+        return (mcp_info_file, modification_time_ns, ttl, SharedProcessCache.time_bucket(ttl))
 
     @staticmethod
     async def _fetch_tool_descriptions(server: str, fetch_timeout: float | None) -> tuple[str, str | None]:
@@ -343,7 +343,7 @@ class GetMcpTool(CodedTool):
     # scope, so every conversation paid the full network round-trip to every
     # server (sequentially). The sources are external servers with no local
     # change signal, so freshness is time-based: the fingerprint reuses the
-    # mcp_info.hocon (path, mtime) probe — a config edit refreshes
+    # mcp_info.hocon (path, modification_time) probe — a config edit refreshes
     # immediately — plus a TTL bucket (default 300s, see
     # _mcp_tools_ttl_seconds) that bounds both staleness and how long a
     # failed fetch's empty/partial result can be served. (With time-based

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -85,7 +85,7 @@ class GetSubnetwork(BranchActivation, CodedTool):
                 the server never picks up new manifest entries, a fresher
                 name list would only advertise networks that are not
                 reachable yet — so on a static server the cached list goes
-                static too (a manifest path or mtime change still refreshes
+                static too (a manifest path or modification_time change still refreshes
                 it). When updates are enabled, one manifest parse per period
                 (~15-20ms, off the event loop, and only if a caller actually
                 reads in that period) is the whole steady-state refresh cost.
@@ -104,8 +104,8 @@ class GetSubnetwork(BranchActivation, CodedTool):
         go stale:
 
         * the resolved path — an env-var change takes effect on the next read;
-        * the manifest file's mtime — a direct edit invalidates immediately, and
-          a missing manifest (mtime None) self-heals the moment the file appears;
+        * the manifest file's modification_time — a direct edit invalidates immediately, and
+          a missing manifest (modification_time None) self-heals the moment the file appears;
         * a time bucket that rolls once per manifest-update period (see
           _manifest_update_period_seconds) — the manifest composes other
           manifests via `include` (notably registries/generated/manifest.hocon,
@@ -114,14 +114,14 @@ class GetSubnetwork(BranchActivation, CodedTool):
           cannot see those included files, so the rolling bucket bounds that
           staleness instead. With updates disabled (period <= 0, the
           static-server default) the bucket is constant, so only a path or
-          mtime change invalidates.
+          modification_time change invalidates.
 
-        :return: (path, mtime_ns or None, time bucket) tuple.
+        :return: (path, modification_time_ns or None, time bucket) tuple.
         """
         manifest_file: str = GetSubnetwork._resolve_manifest_file()
-        mtime_ns: int | None = SharedProcessCache.stat_mtime_ns(manifest_file)
+        modification_time_ns: int | None = SharedProcessCache.stat_modification_time_ns(manifest_file)
         period: float = GetSubnetwork._manifest_update_period_seconds()
-        return (manifest_file, mtime_ns, SharedProcessCache.time_bucket(period))
+        return (manifest_file, modification_time_ns, SharedProcessCache.time_bucket(period))
 
     @staticmethod
     def _load_subnetwork_names() -> list[str]:
@@ -136,11 +136,11 @@ class GetSubnetwork(BranchActivation, CodedTool):
         :return: List of subnetwork name strings (in "/<network_name>" form).
                 A missing or unparseable manifest returns an empty list, which IS
                 published: unlike an immortal cache this entry expires on its own
-                (mtime change or manifest-update-period roll, whichever comes
+                (modification_time change or manifest-update-period roll, whichever comes
                 first), so a bad manifest cannot poison the process beyond one
                 refresh period — and publishing the empty result prevents a
                 per-call parse storm within it. (On a static server with
-                updates disabled, healing relies on the mtime/path change that
+                updates disabled, healing relies on the modification_time/path change that
                 fixing the manifest entails.)
         """
         manifest_file: str = GetSubnetwork._resolve_manifest_file()
@@ -203,7 +203,7 @@ class GetSubnetwork(BranchActivation, CodedTool):
     # caches, this source legitimately changes at runtime on local runs —
     # the designer saves every generated network into a manifest the top
     # file `include`s; server deployments persist elsewhere and never write
-    # it — so the fingerprint (path + mtime + a manifest-update-period
+    # it — so the fingerprint (path + modification_time + a manifest-update-period
     # bucket, see _manifest_fingerprint) keeps the list at most one
     # AGENT_MANIFEST_UPDATE_PERIOD_SECONDS period stale, the same cadence at
     # which the server itself picks up new manifest entries.
@@ -379,7 +379,7 @@ class GetSubnetwork(BranchActivation, CodedTool):
         :return: dict mapping "/<network_name>" -> description. An empty mapping
                 from an empty manifest IS returned, and therefore published: like
                 the names cache, it heals when the fingerprint changes — and the
-                manifest fix that emptiness calls for is itself an mtime change
+                manifest fix that emptiness calls for is itself a modification_time change
                 the fingerprint sees.
         :raises RuntimeError: when names exist but EVERY description fetch came
                 back empty — the signature of a fetch outage, whose recovery

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -68,7 +68,7 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #    Holds:   the "/<network_name>" list parsed from the designer manifest
     #             (AGENT_NETWORK_DESIGNER_MANIFEST_FILE).
     #    Lives:   get_subnetwork.GetSubnetwork (async get_subnetwork_names)
-    #    Expiry:  manifest path/mtime change, or one
+    #    Expiry:  manifest path/modification_time change, or one
     #             AGENT_MANIFEST_UPDATE_PERIOD_SECONDS period when manifest
     #             updates are enabled — the same setting that drives the
     #             server's own manifest refresh; <= 0 (static server) means no
@@ -107,7 +107,7 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #             (MCP_SERVERS_INFO_FILE, the cwd scaffold, or the bundled
     #             copy — see GetMcpTool.get_mcp_info_file).
     #    Lives:   get_mcp_tool.GetMcpTool (async get_mcp_servers)
-    #    Expiry:  resolved path or mtime change — no time bucket, since
+    #    Expiry:  resolved path or modification_time change — no time bucket, since
     #             nothing writes the file at runtime.
     #    Used by: GetMcpTool (input to the tool-descriptions cache below);
     #             agent_network_structure_validation_middleware
@@ -119,7 +119,7 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #    Holds:   the {server URL: tool descriptions} mapping fetched from
     #             the MCP servers themselves (network calls).
     #    Lives:   get_mcp_tool.GetMcpTool (async get_mcp_tool_descriptions)
-    #    Expiry:  mcp_info.hocon path/mtime change, or one
+    #    Expiry:  mcp_info.hocon path/modification_time change, or one
     #             AGENT_NETWORK_DESIGNER_MCP_TOOLS_TTL_SECONDS window
     #             (default 300s, clamped to at least twice the per-server
     #             fetch cap; <= 0 disables time-based refresh) — the

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -61,13 +61,13 @@ class SharedProcessCache(Generic[CachedValue]):
       could reach), construct the cache without a loader and fill it through
       aget_or_fill() instead; get() and aget() then raise on a miss.
     * fingerprint: optional cheap callable identifying the version of the
-      source the value was built from (e.g. a (path, mtime) tuple, which can
+      source the value was built from (e.g. a (path, modification_time) tuple, which can
       also fold in a time bucket for TTL-style expiry). It is captured just
       BEFORE the loader runs and re-checked on every read; when the current
       fingerprint no longer matches the stored one, the entry is treated as a
       miss and reloaded. It must be lock-free-safe and must not raise. When
       None, the value is loaded once and lives for the life of the process.
-      stat_mtime_ns() and time_bucket() below are the standard building
+      stat_modification_time_ns() and time_bucket() below are the standard building
       blocks for composing such fingerprints.
 
     Concurrency notes (the reasoning previously duplicated per cache):
@@ -132,16 +132,16 @@ class SharedProcessCache(Generic[CachedValue]):
         self._loads_in_flight: WeakKeyDictionary = WeakKeyDictionary()
 
     @staticmethod
-    def stat_mtime_ns(path: str) -> int | None:
+    def stat_modification_time_ns(path: str) -> int | None:
         """
         Fingerprint building block: a file's modification time.
 
         :param path: The file to probe.
-        :return: The file's st_mtime_ns, or None when it cannot be stat-ed
-                (missing file, permission problem, ...). Never raises, per
-                the fingerprint contract — and None compares like any other
-                component value, so "file missing" is itself a version that
-                goes stale the moment the file appears.
+        :return: The file's st_mtime_ns (the stat field's real name), or None
+                when it cannot be stat-ed (missing file, permission problem,
+                ...). Never raises, per the fingerprint contract — and None
+                compares like any other component value, so "file missing" is
+                itself a version that goes stale the moment the file appears.
         """
         try:
             return stat(path).st_mtime_ns

--- a/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
+++ b/tests/coded_tools/agent_network_editor/test_shared_process_cache.py
@@ -365,11 +365,11 @@ class TestSharedProcessCache(TestCase):
 
         self.assertEqual(asyncio.run(run()), "load-2")
 
-    def test_stat_mtime_ns_probes_without_raising(self):
-        """The mtime building block reports a bad path as None, per the fingerprint contract."""
-        self.assertIsNone(SharedProcessCache.stat_mtime_ns("/nonexistent/definitely/not/here"))
+    def test_stat_modification_time_ns_probes_without_raising(self):
+        """The modification_time building block reports a bad path as None, per the fingerprint contract."""
+        self.assertIsNone(SharedProcessCache.stat_modification_time_ns("/nonexistent/definitely/not/here"))
         with tempfile.NamedTemporaryFile() as probe:
-            self.assertIsInstance(SharedProcessCache.stat_mtime_ns(probe.name), int)
+            self.assertIsInstance(SharedProcessCache.stat_modification_time_ns(probe.name), int)
 
     def test_time_bucket_rolls_with_the_period_and_freezes_otherwise(self):
         """Positive periods roll once per period; zero, negative, and non-finite pin bucket 0."""


### PR DESCRIPTION
## Description

Follow-up to #1282, addressing @d1donlydfink  feedback there: `mtime` doesn't immediately impart its meaning when reading client code, so it is renamed to the human-friendly `modification_time` everywhere the name is ours to choose:

- `SharedProcessCache.stat_mtime_ns()` → `stat_modification_time_ns()` (and its test)
- the `mtime_ns` locals and tuple components in `GetSubnetwork._manifest_fingerprint()` and `GetMcpTool._mcp_info_fingerprint()` / `_mcp_tools_fingerprint()` → `modification_time_ns`
- every "(path, mtime)" fingerprint mention in the docstrings/comments of the four cache modules and the `globals.py` inventory

One `st_mtime_ns` mention deliberately survives, inside `stat_modification_time_ns()` itself: that is the real name of the `os.stat_result` field the helper wraps, so the stat call must keep it — and the docstring now flags it as "the stat field's real name" so a future rename sweep doesn't reach into the API reference.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
