### PR TITLE
docs: add Legacy Business-Rule Extractor to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,10 @@ surfacing content most relevant to the user's industry and seniority level.
 * [Tochiro File Organizer](https://github.com/ofrancon/tochiro):
 a macOS file organization assistant with a dedicated UI to analyze a folder,
 create a plan for moving the files, ask for approval and execute the moves.
+* [Legacy Business-Rule Extractor](https://github.com/Sivakumarraj/neuro-san-legacy-analyzer):
+a 6-agent network that extracts business rules from legacy COBOL, Java, and PL/SQL code,
+pairing deterministic CodedTool parsers with LLM agents to produce a modernization-ready
+specification document.
 
 ### Utilities
 


### PR DESCRIPTION
## Description

Adds [Legacy Business-Rule Extractor](https://github.com/Sivakumarraj/neuro-san-legacy-analyzer) to
the Community Projects → Applications list.

Context: my earlier entry was merged in
[#1134](https://github.com/cognizant-ai-lab/neuro-san-studio/pull/1134) and then removed in
[#1138](https://github.com/cognizant-ai-lab/neuro-san-studio/pull/1138), because the referenced
project was a standalone application wrapping an LLM rather than a Neuro SAN network. This is a
different project, built on the framework from the start:

* 6-agent network declared in `registries/legacy_business_rules.hocon`, registered through
  `manifest.hocon`, served directly by `ns run`.
* Front-man orchestrator routes work; 2 CodedTools implement
  `neuro_san.interfaces.coded_tool.CodedTool` with `async_invoke()`; 3 LLM agents handle
  interpretation.
* The CodedTool/LLM split is deliberate per agent. Parsing COBOL paragraphs and tracing
  `CALL`/`IMPORT` edges are exact pattern matches, so they are regex and cannot hallucinate.
  Business-rule interpretation, migration-risk assessment and spec generation need judgment, so they
  are LLM agents. The README carries the per-agent justification table.

It covers legacy modernization — extracting business rules from COBOL, Java and PL/SQL for migration
planning — which no current entry in the list addresses.

**Scope of testing.** The 84 tests cover the two deterministic CodedTools only: paragraph and method
extraction, business-calculation detection, external-call tracing, file I/O mapping, and error paths
for the bundled COBOL and Java samples. The LLM agents are not unit-tested, since their output is not
deterministic; they are exercised manually against the sample programs.

@ofrancon — tagging you as you maintain this list. Happy to adjust the wording or placement, or to
narrow the entry if it runs long against the existing format.Pleasure to get feedback for my contribution

## Impact

Documentation-only: one entry under Community Projects → Applications, matching the existing format.
No code paths affected.

## Screenshots / Logs / Examples (optional)

`ns check-config` in the project repo:

```
All LLM configurations are working.
```

`uv run pytest`:

```
84 passed in 0.79s
```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests <!-- N/A: documentation-only change -->
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` <!-- N/A: no dependencies added -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**