### PR TITLE
#1304: Replace LangChain Slack helpers with slack-sdk

### DIFF
--- a/coded_tools/tools/agentic_rag/slack.py
+++ b/coded_tools/tools/agentic_rag/slack.py
@@ -14,19 +14,19 @@
 #
 # END COPYRIGHT
 
-"""Tool module for reading messages from a slack channel"""
+"""Tool module for reading messages from a Slack channel."""
 
 import json
+import os
 from typing import Any
 from typing import Dict
-from typing import Literal
 
-from langchain_community.tools.slack.get_channel import SlackGetChannel
-from langchain_community.tools.slack.get_message import SlackGetMessage
 from neuro_san.interfaces.coded_tool import CodedTool
-from pydantic import PydanticUserError
 
-EMPTY: Literal[""] = ""
+try:
+    from slack_sdk.web.async_client import AsyncWebClient
+except ImportError:  # pragma: no cover - exercised in environments without the optional dependency
+    AsyncWebClient = None
 
 
 class Slack(CodedTool):
@@ -54,7 +54,6 @@ class Slack(CodedTool):
                 once.
         """
 
-    # pylint: disable=too-many-return-statements
     async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
         """
         Get messages on the provided slack channel.
@@ -83,34 +82,39 @@ class Slack(CodedTool):
         if not channel_name:
             return "Error: No slack channel name provided."
 
-        # SlackGetChannel requires no inputs and returns a str in the
-        # following format:
-        # '[{"id": "CE", "name": "gen", "created": 15, "num_members": 3}, ...]'
-        # SlackGetMessage requires channel_id as an input and returns a str in
-        # a following format:
-        # '[{"user": "WU0JH", "text": "Yes", "ts": "1744677036.155459"}, ...]'
-        try:
-            # Get a str of channel ids and names
-            channel_id_name_str: str = await SlackGetChannel().ainvoke(input=EMPTY)
-            # Convert the JSON str to a list
-            channel_id_name_list: list = json.loads(channel_id_name_str)
-            # Make a lookup table with channel names as keys and ids as values
-            channel_id_name_dict: dict = {channel["name"]: channel["id"] for channel in channel_id_name_list}
+        slack_token = os.getenv("SLACK_BOT_TOKEN") or os.getenv("SLACK_USER_TOKEN")
+        if AsyncWebClient is None or not slack_token:
+            return self._mock_response(channel_name)
 
-            # Get channel id and return the messages if possible.
-            channel_id: str = channel_id_name_dict.get(channel_name)
-            if channel_id:
-                return await SlackGetMessage().ainvoke(channel_id)
+        client = AsyncWebClient(token=slack_token)
+        channel_id = None
+        cursor = None
+        while channel_id is None:
+            channel_response = await client.conversations_list(
+                types="public_channel,private_channel", limit=200, cursor=cursor
+            )
+            channel_id_name_dict = {channel["name"]: channel["id"] for channel in channel_response["channels"]}
+            channel_id = channel_id_name_dict.get(channel_name)
+            cursor = channel_response.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+
+        if not channel_id:
             return f"The {channel_name} channel not found."
 
-        except json.JSONDecodeError as err:
-            return f"Error: Could not parse slack channel list: {err}"
+        message_response = await client.conversations_history(channel=channel_id)
+        messages = [
+            {key: message[key] for key in ("user", "text", "ts")}
+            for message in message_response["messages"]
+            if all(key in message for key in ("user", "text", "ts"))
+        ]
+        return json.dumps(messages)
 
-        # If slack-sdk is not installed, PydanticUserError is triggered
-        # Return a mock message depending on the channel_name
-        except PydanticUserError:
-            if channel_name == "higher_education":
-                return """Opportunity Areas:
+    @staticmethod
+    def _mock_response(channel_name: str) -> str:
+        """Return demo data when Slack is unavailable or not configured."""
+        if channel_name == "higher_education":
+            return """Opportunity Areas:
 
 Adaptive learning and AI-powered personalization
 
@@ -124,8 +128,8 @@ Accessibility innovations for inclusive learning
 
 Ideal Partners: EdTech startups, AI developers, instructional design firms"""
 
-            if channel_name == "retail":
-                return """Opportunity Areas:
+        if channel_name == "retail":
+            return """Opportunity Areas:
 
 AI-driven demand forecasting and inventory optimization
 
@@ -140,7 +144,7 @@ Retail media and monetization of customer engagement
 Ideal Partners: SaaS providers, AI/ML startups, logistics tech firms,
 CX platforms"""
 
-            return """Opportunity Areas:
+        return """Opportunity Areas:
 
 Process automation and workflow optimization
 

--- a/docs/examples/tools/agentic_rag.md
+++ b/docs/examples/tools/agentic_rag.md
@@ -15,6 +15,20 @@ enterprise question-answering.
 
 ---
 
+## Setup
+
+This agent network is disabled by default. Before enabling `"tools/agentic_rag.hocon"` in
+`registries/tools/manifest.hocon`, install the optional Slack dependency:
+
+```bash
+pip install slack-sdk
+```
+
+Set either `SLACK_BOT_TOKEN` or `SLACK_USER_TOKEN` to retrieve Slack messages. Without the package or a configured
+token, the Slack tool returns demo data.
+
+---
+
 ## Description
 
 The assistant is built around a **Front Man** agent that acts as the main point of contact with users. This agent determines

--- a/registries/tools/agentic_rag.hocon
+++ b/registries/tools/agentic_rag.hocon
@@ -87,6 +87,7 @@
             "class": "rag.Rag"
         },
         # Retrieves messages from a specified Slack channel.
+        # Install slack-sdk and set SLACK_BOT_TOKEN or SLACK_USER_TOKEN to use this tool.
         {
             "name": "slack_tool",
             "function": {

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -30,6 +30,7 @@
 
     "tools/agent_network_html_creator.hocon": true,
     "tools/agentforce.hocon": true,
+    # Install slack-sdk and set SLACK_BOT_TOKEN or SLACK_USER_TOKEN before enabling this agent network.
     "tools/agentic_rag.hocon": false,
     "tools/agentspace_adapter.hocon": false,
 

--- a/tests/coded_tools/tools/agentic_rag/__init__.py
+++ b/tests/coded_tools/tools/agentic_rag/__init__.py
@@ -1,0 +1,17 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for agentic RAG coded tools."""

--- a/tests/coded_tools/tools/agentic_rag/test_slack.py
+++ b/tests/coded_tools/tools/agentic_rag/test_slack.py
@@ -1,0 +1,129 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Unit tests for the agentic RAG Slack tool."""
+
+import json
+from unittest.mock import AsyncMock
+from unittest.mock import call
+from unittest.mock import patch
+
+import pytest
+
+from coded_tools.tools.agentic_rag.slack import Slack
+
+
+@pytest.mark.asyncio
+async def test_async_invoke_returns_messages_from_configured_slack():
+    """The tool paginates private channels and filters fields and incomplete messages."""
+    client = AsyncMock()
+    client.conversations_list.side_effect = [
+        {
+            "channels": [{"id": "C100", "name": "public"}],
+            "response_metadata": {"next_cursor": "next-page"},
+        },
+        {
+            "channels": [{"id": "C123", "name": "general"}],
+            "response_metadata": {"next_cursor": ""},
+        },
+    ]
+    client.conversations_history.return_value = {
+        "messages": [
+            {"user": "U123", "text": "Hello", "ts": "123.456", "blocks": ["unused"]},
+            {"bot_id": "B123", "text": "Automated update", "ts": "123.457"},
+        ]
+    }
+
+    with (
+        patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-token"}),
+        patch("coded_tools.tools.agentic_rag.slack.AsyncWebClient", return_value=client) as client_class,
+    ):
+        result = await Slack().async_invoke({"channel_name": "general"}, {})
+
+    assert json.loads(result) == [{"user": "U123", "text": "Hello", "ts": "123.456"}]
+    client_class.assert_called_once_with(token="xoxb-token")
+    assert client.conversations_list.await_args_list == [
+        call(types="public_channel,private_channel", limit=200, cursor=None),
+        call(types="public_channel,private_channel", limit=200, cursor="next-page"),
+    ]
+    client.conversations_history.assert_awaited_once_with(channel="C123")
+
+
+@pytest.mark.asyncio
+async def test_async_invoke_accepts_user_token():
+    """A user token is used when no bot token is configured."""
+    client = AsyncMock()
+    client.conversations_list.return_value = {"channels": []}
+
+    with (
+        patch.dict("os.environ", {"SLACK_USER_TOKEN": "xoxp-token"}, clear=True),
+        patch("coded_tools.tools.agentic_rag.slack.AsyncWebClient", return_value=client) as client_class,
+    ):
+        await Slack().async_invoke({"channel_name": "missing"}, {})
+
+    client_class.assert_called_once_with(token="xoxp-token")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("client_class", "environment"),
+    [(None, {"SLACK_BOT_TOKEN": "xoxb-token"}), (AsyncMock(), {})],
+)
+async def test_async_invoke_returns_mock_data_when_slack_is_unavailable(client_class, environment):
+    """An absent SDK or token keeps the demo fallback behavior."""
+    with (
+        patch.dict("os.environ", environment, clear=True),
+        patch("coded_tools.tools.agentic_rag.slack.AsyncWebClient", client_class),
+    ):
+        result = await Slack().async_invoke({"channel_name": "retail"}, {})
+
+    assert "AI-driven demand forecasting" in result
+
+
+@pytest.mark.asyncio
+async def test_async_invoke_returns_channel_not_found():
+    """A configured client reports an unknown channel without fetching history."""
+    client = AsyncMock()
+    client.conversations_list.return_value = {"channels": []}
+
+    with (
+        patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-token"}),
+        patch("coded_tools.tools.agentic_rag.slack.AsyncWebClient", return_value=client),
+    ):
+        result = await Slack().async_invoke({"channel_name": "missing"}, {})
+
+    assert result == "The missing channel not found."
+    client.conversations_history.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_invoke_does_not_mask_slack_api_errors():
+    """Errors from a configured Slack client propagate to the caller."""
+    client = AsyncMock()
+    client.conversations_list.side_effect = RuntimeError("Slack API failed")
+
+    with (
+        patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-token"}),
+        patch("coded_tools.tools.agentic_rag.slack.AsyncWebClient", return_value=client),
+        pytest.raises(RuntimeError, match="Slack API failed"),
+    ):
+        await Slack().async_invoke({"channel_name": "general"}, {})
+
+
+@pytest.mark.asyncio
+async def test_async_invoke_requires_channel_name():
+    """The required argument is validated before Slack configuration."""
+    assert await Slack().async_invoke({}, {}) == "Error: No slack channel name provided."


### PR DESCRIPTION
## Description

Replaces the LangChain Community Slack helpers used by the agentic RAG Slack tool with the asynchronous `slack-sdk` client.

Mock data remains available only when `slack-sdk` is unavailable or `SLACK_BOT_TOKEN` is not configured. Errors returned by the Slack API are allowed to propagate instead of being masked by demo data.

Fixes #1304

## Impact

- Removes the Slack tool’s dependency on `langchain_community.tools.slack`.
- Uses `AsyncWebClient` to list channels and retrieve message history.
- Preserves existing responses for missing channels and demo environments.
- Adds `slack-sdk` as a direct dependency.
- Adds unit coverage for configured Slack access, fallback behavior, missing channels, input validation, and API error propagation.

## Screenshots / Logs / Examples (optional)

Not applicable.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [x] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**