### PR TITLE
#1301: Replace LangChain Confluence loader

### DIFF
--- a/docs/examples/tools/confluence_rag.md
+++ b/docs/examples/tools/confluence_rag.md
@@ -14,14 +14,20 @@ The **Confluence RAG Assistant** answers user queries using Retrieval-Augmented 
 
 This agent is **disabled by default**. To enable and use it:
 
-1. Installing the required package:
+1. Install the required package:
 
    ```bash
-    pip install atlassian-python-api
-    ```
+   pip install atlassian-python-api
+   ```
 
-2. Install additional dependencies depending on the attachment types (e.g., PDFs, images, Office files). These may include
-both Python packages and system tools. See: [ConfluenceLoader documentation](https://python.langchain.com/api_reference/_modules/langchain_community/document_loaders/confluence.html#ConfluenceLoader)
+2. If attachments are enabled, install the dependencies for the file types you need:
+
+   ```bash
+   pip install docx2txt openpyxl pandas Pillow pytesseract reportlab svglib xlrd
+   ```
+
+   Image and SVG extraction also requires the Tesseract executable. PDF text extraction uses the project's existing
+   `pypdf` dependency.
 
 3. Set authentication credentials, either in the HOCON config file or via environment variables:
 
@@ -48,8 +54,8 @@ both Python packages and system tools. See: [ConfluenceLoader documentation](htt
 ##### Required
 
 - `url` (str): Base URL of your Confluence instance.
-- `page_ids` (list): List of `page_id` to load
-- `space_key` (str): Space to load all pages from
+- `page_ids` (list): List of `page_id` values to load.
+- `space_key` (str): Space from which to load all pages.
     > Note: If both `page_ids` and `space_key` are provided, the loader returns the union of pages from both lists.
 
 Both space_key and page_id can be found in the URL of a Confluence page:
@@ -64,10 +70,11 @@ Both space_key and page_id can be found in the URL of a Confluence page:
 
 ##### Optional
 
-- `include_attachments` (bool): If True, download and extract text content to add to the document.
-
-For a full list of options and supported file types, refer to the
-[LangChain ConfluenceLoader documentation](https://python.langchain.com/api_reference/_modules/langchain_community/document_loaders/confluence.html#ConfluenceLoader).
+- `include_attachments` (bool): If true, download supported attachments and append their extracted text to the page.
+  Supported file types are PDF, PNG, JPEG/JPG, SVG, DOCX, XLS, and XLSX.
+- `limit` (int): Maximum pages retrieved per request. Defaults to 50.
+- `max_pages` (int): Maximum pages retrieved from a space. Defaults to 1000.
+- `ocr_languages` (str): Optional Tesseract language selection for image and SVG attachments.
 
 - `save_vector_store` (bool): Save the vector store to a JSON file.
 - `vector_store_path`(str): Path to save/load the vector store (absolute or relative to `neuro-san-studio/neuro_san_studio/coded_tools/pdf_rag/`).

--- a/neuro_san_studio/coded_tools/confluence_rag.py
+++ b/neuro_san_studio/coded_tools/confluence_rag.py
@@ -14,28 +14,44 @@
 #
 # END COPYRIGHT
 
-"""Tool module for doing RAG from confluence pages"""
+"""Tool module for doing RAG from Confluence pages."""
 
-import inspect
+import asyncio
 import logging
 import os
+from io import BytesIO
+from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
 
-# pylint: disable=import-error
-from atlassian.errors import ApiPermissionError
-from langchain_community.document_loaders.confluence import ConfluenceLoader
+from bs4 import BeautifulSoup
 from langchain_core.documents import Document
+from leaf_common.resolution.resolver_util import ResolverUtil
 from neuro_san.interfaces.coded_tool import CodedTool
 from requests.exceptions import HTTPError
 
 from neuro_san_studio.coded_tools.base_rag import BaseRag
+from neuro_san_studio.coded_tools.utils.pdf_utils import PdfUtils
 
 INVALID_PATH_PATTERN = r"[<>:\"|?*\x00-\x1F]"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+PAGE_EXPANSIONS = "body.storage,version"
+DEFAULT_PAGE_LIMIT = 50
+DEFAULT_MAX_PAGES = 1000
+
+CONFLUENCE_TYPE = ResolverUtil.create_type("atlassian.Confluence", raise_if_not_found=False)
+API_PERMISSION_ERROR_TYPE = ResolverUtil.create_type("atlassian.errors.ApiPermissionError", raise_if_not_found=False)
+API_PERMISSION_ERRORS = (API_PERMISSION_ERROR_TYPE,) if API_PERMISSION_ERROR_TYPE is not None else ()
+IMAGE_OPEN = ResolverUtil.create_type("PIL.Image.open", raise_if_not_found=False)
+IMAGE_TO_STRING = ResolverUtil.create_type("pytesseract.image_to_string", raise_if_not_found=False)
+SVG_TO_DRAWING = ResolverUtil.create_type("svglib.svglib.svg2rlg", raise_if_not_found=False)
+DRAW_TO_FILE = ResolverUtil.create_type("reportlab.graphics.renderPM.drawToFile", raise_if_not_found=False)
+DOCX_PROCESS = ResolverUtil.create_type("docx2txt.process", raise_if_not_found=False)
+READ_EXCEL = ResolverUtil.create_type("pandas.read_excel", raise_if_not_found=False)
 
 
 class ConfluenceRag(CodedTool, BaseRag):
@@ -69,14 +85,22 @@ class ConfluenceRag(CodedTool, BaseRag):
         # Extract arguments from the input dictionary
         query: str = args.get("query", "")
 
-        # Create a list of parameters of ConfluenceLoader
-        # https://python.langchain.com/api_reference/community/document_loaders/langchain_community.document_loaders.confluence.ConfluenceLoader.html
-        confluence_loader_params = [
-            name for name in inspect.signature(ConfluenceLoader.__init__).parameters if name != "self"
-        ]
-
-        # Filter args from the above list
-        loader_args = {arg: arg_value for arg, arg_value in args.items() if arg in confluence_loader_params}
+        loader_args = {
+            name: args[name]
+            for name in (
+                "url",
+                "username",
+                "api_key",
+                "cloud",
+                "space_key",
+                "page_ids",
+                "include_attachments",
+                "limit",
+                "max_pages",
+                "ocr_languages",
+            )
+            if name in args
+        }
 
         # Check the env var for "username" and "api_key"
         loader_args.setdefault("username", os.getenv("JIRA_USERNAME"))
@@ -120,15 +144,203 @@ class ConfluenceRag(CodedTool, BaseRag):
         :return: List of loaded Confluence pages
         """
         url = loader_args.get("url")
-        docs: List[Document] = []
+
         try:
-            loader = ConfluenceLoader(**loader_args)
-            docs = await loader.aload()
+            docs = await asyncio.to_thread(self._load_documents_sync, loader_args)
             logger.info("Successfully loaded Confluence pages from %s", url)
         except HTTPError as http_error:
             logger.error("HTTP error while loading from %s: %s", url, http_error)
             return []
-        except ApiPermissionError as api_error:
+        except API_PERMISSION_ERRORS as api_error:
             logger.error("API Permission error while loading from %s: %s", url, api_error)
+            return []
 
         return docs
+
+    def _load_documents_sync(self, loader_args: Dict[str, Any]) -> List[Document]:
+        """Load and convert Confluence pages using the synchronous Atlassian client."""
+        if CONFLUENCE_TYPE is None:
+            logger.error("Confluence support requires the 'atlassian-python-api' package")
+            return []
+
+        url = loader_args["url"]
+        confluence = CONFLUENCE_TYPE(
+            url=url,
+            username=loader_args.get("username"),
+            password=loader_args.get("api_key"),
+            cloud=loader_args.get("cloud", True),
+        )
+        pages = self._get_pages(confluence, loader_args)
+        include_attachments = loader_args.get("include_attachments", False)
+        ocr_languages = loader_args.get("ocr_languages")
+
+        return [self._page_to_document(confluence, url, page, include_attachments, ocr_languages) for page in pages]
+
+    @staticmethod
+    def _get_pages(confluence: Any, loader_args: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Fetch configured pages, preserving order and removing duplicates."""
+        pages: List[Dict[str, Any]] = []
+        seen_page_ids = set()
+
+        space_key = loader_args.get("space_key")
+        if space_key:
+            limit = loader_args.get("limit", DEFAULT_PAGE_LIMIT)
+            max_pages = loader_args.get("max_pages", DEFAULT_MAX_PAGES)
+            start = 0
+            while len(pages) < max_pages:
+                batch = confluence.get_all_pages_from_space(
+                    space=space_key,
+                    start=start,
+                    limit=min(limit, max_pages - len(pages)),
+                    status="current",
+                    expand=PAGE_EXPANSIONS,
+                )
+                if not batch:
+                    break
+                for page in batch:
+                    page_id = str(page.get("id", ""))
+                    if not page_id:
+                        logger.warning("Skipping Confluence page without an id")
+                        continue
+                    if page_id not in seen_page_ids:
+                        seen_page_ids.add(page_id)
+                        pages.append(page)
+                if len(batch) < limit:
+                    break
+                start += len(batch)
+
+        for page_id in loader_args.get("page_ids") or []:
+            page_id = str(page_id)
+            if page_id in seen_page_ids:
+                continue
+            page = confluence.get_page_by_id(page_id=page_id, expand=PAGE_EXPANSIONS)
+            response_page_id = str(page.get("id", "")) if page else ""
+            if response_page_id:
+                seen_page_ids.add(response_page_id)
+                pages.append(page)
+            elif page:
+                logger.warning("Skipping Confluence page without an id")
+
+        return pages
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def _page_to_document(
+        self,
+        confluence: Any,
+        base_url: str,
+        page: Dict[str, Any],
+        include_attachments: bool,
+        ocr_languages: str | None,
+    ) -> Document:
+        """Convert one Confluence API page into a LangChain document."""
+        page_id = str(page.get("id", ""))
+        html = page.get("body", {}).get("storage", {}).get("value", "")
+        text = BeautifulSoup(html, "html.parser").get_text(" ", strip=True)
+        if include_attachments and page_id:
+            text += "".join(self._load_attachment_texts(confluence, base_url, page_id, ocr_languages))
+
+        metadata = {
+            "title": page.get("title", "Untitled"),
+            "id": page_id,
+            "source": base_url.rstrip("/") + page.get("_links", {}).get("webui", ""),
+        }
+        updated_at = page.get("version", {}).get("when")
+        if updated_at:
+            metadata["when"] = updated_at
+        return Document(page_content=text, metadata=metadata)
+
+    def _load_attachment_texts(
+        self, confluence: Any, base_url: str, page_id: str, ocr_languages: str | None
+    ) -> List[str]:
+        """Download and extract text from supported page attachments."""
+        attachments = confluence.get_attachments_from_content(page_id).get("results", [])
+        texts = []
+        for attachment in attachments:
+            media_type = attachment.get("metadata", {}).get("mediaType", "")
+            title = attachment.get("title", "")
+            download_path = attachment.get("_links", {}).get("download")
+            if not download_path:
+                continue
+            download_url = base_url.rstrip("/") + download_path
+            content = self._download_attachment(confluence, download_url)
+            if content is None:
+                continue
+
+            try:
+                extracted_text = self._extract_attachment_text(content, title, media_type, ocr_languages)
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.warning("Failed to extract text from attachment %s: %s", title, error)
+                continue
+            if extracted_text:
+                texts.append(f"\n{title}\n{extracted_text}")
+        return texts
+
+    @staticmethod
+    def _download_attachment(confluence: Any, download_url: str) -> bytes | None:
+        """Download one attachment, returning None when that attachment is unavailable."""
+        try:
+            response = confluence.request(path=download_url, absolute=True)
+            response.raise_for_status()
+            return response.content
+        except HTTPError as http_error:
+            logger.warning("HTTP error while loading attachment from %s: %s", download_url, http_error)
+        except API_PERMISSION_ERRORS as api_error:
+            logger.warning("Permission error while loading attachment from %s: %s", download_url, api_error)
+        return None
+
+    @staticmethod
+    def _extract_attachment_text(content: bytes, title: str, media_type: str, ocr_languages: str | None) -> str:
+        """Extract text from an attachment according to its media type."""
+        suffix = Path(title).suffix.lower()
+        if media_type == "application/pdf" or suffix == ".pdf":
+            return PdfUtils.parse_pdf_bytes(content)
+        if media_type in {"image/png", "image/jpeg", "image/jpg"} or suffix in {".png", ".jpg", ".jpeg"}:
+            return ConfluenceRag._extract_image_text(content, ocr_languages)
+        if media_type == "image/svg+xml" or suffix == ".svg":
+            return ConfluenceRag._extract_svg_text(content, ocr_languages)
+        if suffix == ".docx":
+            return ConfluenceRag._extract_docx_text(content)
+        if suffix in {".xls", ".xlsx"}:
+            return ConfluenceRag._extract_excel_text(content)
+
+        logger.info("Skipping unsupported Confluence attachment type %s (%s)", media_type, title)
+        return ""
+
+    @staticmethod
+    def _extract_image_text(content: bytes, ocr_languages: str | None) -> str:
+        """Extract text from a raster image attachment."""
+        if IMAGE_OPEN is None or IMAGE_TO_STRING is None:
+            logger.error("Image attachments require the 'Pillow' and 'pytesseract' packages and Tesseract")
+            return ""
+        return IMAGE_TO_STRING(IMAGE_OPEN(BytesIO(content)), lang=ocr_languages)
+
+    @staticmethod
+    def _extract_svg_text(content: bytes, ocr_languages: str | None) -> str:
+        """Extract text from an SVG attachment."""
+        if any(processor is None for processor in (IMAGE_OPEN, IMAGE_TO_STRING, SVG_TO_DRAWING, DRAW_TO_FILE)):
+            logger.error(
+                "SVG attachments require the 'Pillow', 'pytesseract', 'reportlab', and 'svglib' packages and Tesseract"
+            )
+            return ""
+
+        image_bytes = BytesIO()
+        DRAW_TO_FILE(SVG_TO_DRAWING(BytesIO(content)), image_bytes, fmt="PNG")
+        image_bytes.seek(0)
+        return IMAGE_TO_STRING(IMAGE_OPEN(image_bytes), lang=ocr_languages)
+
+    @staticmethod
+    def _extract_docx_text(content: bytes) -> str:
+        """Extract text from a DOCX attachment."""
+        if DOCX_PROCESS is None:
+            logger.error("DOCX attachments require the 'docx2txt' package")
+            return ""
+        return DOCX_PROCESS(BytesIO(content))
+
+    @staticmethod
+    def _extract_excel_text(content: bytes) -> str:
+        """Extract text from an Excel attachment."""
+        if READ_EXCEL is None:
+            logger.error("Excel attachments require the 'pandas', 'openpyxl', and 'xlrd' packages")
+            return ""
+        sheets = READ_EXCEL(BytesIO(content), sheet_name=None, header=None)
+        return "\n\n".join(f"{name}:\n{sheet.to_string(index=False, header=False)}" for name, sheet in sheets.items())

--- a/neuro_san_studio/toolbox/toolbox_info.hocon
+++ b/neuro_san_studio/toolbox/toolbox_info.hocon
@@ -350,8 +350,8 @@
     # To use this tool, start by installing the required package:
     #     pip install atlassian-python-api
     #
-    # Additional installations may be required depending on the attachment types used.
-    # For details, see https://python.langchain.com/api_reference/_modules/langchain_community/document_loaders/confluence.html#ConfluenceLoader
+    # Additional Python packages and system tools may be required depending on the attachment types used.
+    # See docs/examples/tools/confluence_rag.md for details.
     # Set "username" and "api_key" in the agent network hocon or 
     # as environment variable "JIRA_USERNAME" and "JIRA_API_TOKEN", respectively.
     "confluence_rag": {

--- a/registries/tools/confluence_rag.hocon
+++ b/registries/tools/confluence_rag.hocon
@@ -116,15 +116,13 @@
                 # PNG (.png)
                 # JPEG/JPG (.jpeg, .jpg)
                 # SVG (.svg)
-                # Word (.doc, .docx)
+                # Word (.docx)
                 # Excel (.xls, .xlsx)
                 #
-                # Note: Some file types require additional Python packages (e.g., pytesseract, pdf2image, Pillow)
-                # and external system dependencies (e.g., Poppler for PDFs, Tesseract for OCR).
+                # Note: Some file types require additional Python packages (e.g., pytesseract, Pillow, pandas)
+                # and external system dependencies (e.g., Tesseract for OCR).
                 #
-                # For full details on supported arguments and required dependencies for loading Confluence pages,
-                # refer to the official LangChain documentation:
-                # https://python.langchain.com/api_reference/_modules/langchain_community/document_loaders/confluence.html#ConfluenceLoader
+                # See docs/examples/tools/confluence_rag.md for attachment dependencies.
 
                 # Vector Store
                 #

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -56,8 +56,8 @@
     # To use this confluence agent network, start by installing the required package:
     #     pip install atlassian-python-api
     #
-    # Additional installations may be required depending on the attachment types used.
-    # For details, see https://python.langchain.com/api_reference/_modules/langchain_community/document_loaders/confluence.html#ConfluenceLoader
+    # Additional Python packages and system tools may be required depending on the attachment types used.
+    # See docs/examples/tools/confluence_rag.md for details.
     # Set "username" and "api_key" in the agent network hocon or
     # as environment variable "JIRA_USERNAME" and "JIRA_API_TOKEN", respectively.
     "tools/confluence_rag.hocon": false,

--- a/tests/neuro_san_studio/coded_tools/test_confluence_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_confluence_rag.py
@@ -1,0 +1,210 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for the Confluence RAG coded tool."""
+
+# pylint: disable=protected-access
+
+import asyncio
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from requests.exceptions import HTTPError
+
+from neuro_san_studio.coded_tools import confluence_rag
+from neuro_san_studio.coded_tools.confluence_rag import ConfluenceRag
+
+BASE_URL = "https://your-domain.atlassian.net/wiki"
+
+
+def _page(page_id: str, title: str = "Page") -> dict:
+    """Create a representative Confluence API page."""
+    return {
+        "id": page_id,
+        "title": title,
+        "body": {"storage": {"value": "<h1>Heading</h1><p>Page text</p>"}},
+        "version": {"when": "2026-08-01T12:00:00Z"},
+        "_links": {"webui": f"/spaces/TEST/pages/{page_id}"},
+    }
+
+
+def test_get_pages_paginates_and_deduplicates_explicit_page_ids():
+    """Space pages are paginated and duplicate explicit IDs are not fetched twice."""
+    confluence = MagicMock()
+    confluence.get_all_pages_from_space.side_effect = [[_page("1"), _page("2")], [_page("3")]]
+    confluence.get_page_by_id.return_value = _page("4")
+
+    pages = ConfluenceRag._get_pages(
+        confluence,
+        {"space_key": "TEST", "page_ids": ["2", "4"], "limit": 2, "max_pages": 10},
+    )
+
+    assert [page["id"] for page in pages] == ["1", "2", "3", "4"]
+    assert confluence.get_all_pages_from_space.call_count == 2
+    confluence.get_page_by_id.assert_called_once_with(page_id="4", expand="body.storage,version")
+
+
+def test_page_to_document_converts_html_and_preserves_metadata():
+    """Page content and metadata retain the previous loader's output shape."""
+    document = object.__new__(ConfluenceRag)._page_to_document(
+        MagicMock(), f"{BASE_URL}/", _page("42", "Runbook"), False, None
+    )
+
+    assert document.page_content == "Heading Page text"
+    assert document.metadata == {
+        "title": "Runbook",
+        "id": "42",
+        "source": f"{BASE_URL}/spaces/TEST/pages/42",
+        "when": "2026-08-01T12:00:00Z",
+    }
+
+
+def test_page_to_document_appends_attachment_text():
+    """Attachment text is retained when include_attachments is enabled."""
+    tool = object.__new__(ConfluenceRag)
+    with patch.object(tool, "_load_attachment_texts", return_value=["\nnotes.pdf\nAttachment text"]):
+        document = tool._page_to_document(MagicMock(), BASE_URL, _page("42"), True, None)
+
+    assert document.page_content == "Heading Page text\nnotes.pdf\nAttachment text"
+
+
+def test_load_attachment_texts_skips_missing_attachment():
+    """A missing attachment is logged and skipped without hiding other HTTP failures."""
+    confluence = MagicMock()
+    confluence.get_attachments_from_content.return_value = {
+        "results": [
+            {
+                "title": "missing.pdf",
+                "metadata": {"mediaType": "application/pdf"},
+                "_links": {"download": "/download/missing.pdf"},
+            }
+        ]
+    }
+    response = MagicMock()
+    error = HTTPError(response=MagicMock(status_code=404))
+    response.raise_for_status.side_effect = error
+    confluence.request.return_value = response
+
+    texts = object.__new__(ConfluenceRag)._load_attachment_texts(confluence, BASE_URL, "42", None)
+
+    assert not texts
+
+
+def test_load_attachment_texts_skips_non_404_http_error():
+    """One forbidden attachment does not discard the loaded page corpus."""
+    confluence = MagicMock()
+    confluence.get_attachments_from_content.return_value = {
+        "results": [
+            {
+                "title": "forbidden.pdf",
+                "metadata": {"mediaType": "application/pdf"},
+                "_links": {"download": "/download/forbidden.pdf"},
+            }
+        ]
+    }
+    response = MagicMock()
+    response.raise_for_status.side_effect = HTTPError(response=MagicMock(status_code=403))
+    confluence.request.return_value = response
+
+    texts = object.__new__(ConfluenceRag)._load_attachment_texts(confluence, BASE_URL, "42", None)
+
+    assert not texts
+
+
+def test_extract_attachment_text_uses_shared_pdf_util():
+    """PDF attachment extraction delegates to the shared PDF utility."""
+    with patch.object(confluence_rag.PdfUtils, "parse_pdf_bytes", return_value="PDF text") as parse_pdf:
+        text = ConfluenceRag._extract_attachment_text(b"pdf bytes", "notes.pdf", "application/pdf", None)
+
+    assert text == "PDF text"
+    parse_pdf.assert_called_once_with(b"pdf bytes")
+
+
+def test_load_attachment_texts_downloads_and_extracts_supported_attachment():
+    """Enabled attachments are downloaded through the authenticated client and included."""
+    confluence = MagicMock()
+    confluence.get_attachments_from_content.return_value = {
+        "results": [
+            {
+                "title": "notes.pdf",
+                "metadata": {"mediaType": "application/pdf"},
+                "_links": {"download": "/download/notes.pdf"},
+            }
+        ]
+    }
+    confluence.request.return_value.content = b"pdf bytes"
+    tool = object.__new__(ConfluenceRag)
+
+    with patch.object(tool, "_extract_attachment_text", return_value="Attachment text") as extract:
+        texts = tool._load_attachment_texts(confluence, BASE_URL, "42", None)
+
+    assert texts == ["\nnotes.pdf\nAttachment text"]
+    confluence.request.assert_called_once_with(path=f"{BASE_URL}/download/notes.pdf", absolute=True)
+    extract.assert_called_once_with(b"pdf bytes", "notes.pdf", "application/pdf", None)
+
+
+def test_load_attachment_texts_skips_extraction_failure(caplog):
+    """One unreadable attachment does not prevent later attachments from being extracted."""
+    confluence = MagicMock()
+    confluence.get_attachments_from_content.return_value = {
+        "results": [
+            {
+                "title": "corrupt.pdf",
+                "metadata": {"mediaType": "application/pdf"},
+                "_links": {"download": "/download/corrupt.pdf"},
+            },
+            {
+                "title": "notes.pdf",
+                "metadata": {"mediaType": "application/pdf"},
+                "_links": {"download": "/download/notes.pdf"},
+            },
+        ]
+    }
+    confluence.request.return_value.content = b"pdf bytes"
+    tool = object.__new__(ConfluenceRag)
+
+    with patch.object(tool, "_extract_attachment_text", side_effect=[ValueError("invalid PDF"), "Notes"]):
+        texts = tool._load_attachment_texts(confluence, BASE_URL, "42", None)
+
+    assert texts == ["\nnotes.pdf\nNotes"]
+    assert "Failed to extract text from attachment corrupt.pdf: invalid PDF" in caplog.text
+
+
+def test_load_documents_handles_permission_error():
+    """Atlassian permission failures return no documents."""
+
+    class ApiPermissionError(Exception):
+        """Test replacement for the optional dependency exception."""
+
+    tool = object.__new__(ConfluenceRag)
+
+    with (
+        patch.object(confluence_rag, "API_PERMISSION_ERRORS", (ApiPermissionError,)),
+        patch.object(tool, "_load_documents_sync", side_effect=ApiPermissionError("denied")),
+    ):
+        documents = asyncio.run(tool.load_documents({"url": BASE_URL}))
+
+    assert documents == []
+
+
+def test_get_pages_skips_page_without_id():
+    """Partial API responses without page IDs are skipped."""
+    confluence = MagicMock()
+    confluence.get_all_pages_from_space.return_value = [{"title": "Incomplete"}]
+
+    pages = ConfluenceRag._get_pages(confluence, {"space_key": "TEST", "limit": 50, "max_pages": 100})
+
+    assert not pages


### PR DESCRIPTION
## Description

Replaces the deprecated LangChain `ConfluenceLoader` integration with direct usage of `atlassian-python-api`.

The replacement preserves:

- Loading pages by page ID or space key
- Paginated space loading
- Deduplication when page IDs and a space overlap
- Confluence page metadata
- Optional attachment extraction
- Specific HTTP and permission-error handling

The Confluence documentation and configuration comments have also been updated to remove obsolete LangChain references and describe the attachment dependencies.

Fixes #1301

## Impact

Confluence RAG no longer depends on `langchain-community` for loading Confluence content.

Existing configurations using `url`, `username`, `api_key`, `space_key`, `page_ids`, and `include_attachments` remain supported. Optional dependencies are imported only when the corresponding Confluence or attachment functionality is used.

## Screenshots / Logs / Examples (optional)

Focused unit-test result:

```
6 passed
```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [x] Updated relevant documentation
- [x] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->
No new core dependencies were added. Confluence and attachment-processing packages remain optional and are documented in the Confluence RAG example.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
