### PR TITLE
Support OAuth-authenticated MCP servers in the agent network designer

### DIFF
--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -214,10 +214,10 @@ class GetMcpTool(CodedTool):
 
         :return: The UNION of mcp_info.hocon entries and nsflow token-store
                 entries holding an access token, as
-                {server URL: {"has_file_headers": bool, "access_token": str | None}}.
-                has_file_headers records whether mcp_info.hocon configures
-                http_headers for the URL (i.e. the server is authenticated
-                file-side and needs no client-supplied token); access_token
+                {server URL: {"in_info_file": bool, "access_token": str | None}}.
+                in_info_file records whether the URL is configured in
+                mcp_info.hocon (its auth — if any — is a server-side
+                concern: file/env headers, or none needed); access_token
                 is the nsflow OAuth bearer token when one is stored. A
                 missing, unreadable, or unparseable mcp_info.hocon degrades
                 to the token-store half alone, which IS published: the
@@ -240,12 +240,8 @@ class GetMcpTool(CodedTool):
             if info is None:
                 logger.warning("MCP servers info file not found at %s. No MCP Servers will be used.", mcp_info_file)
                 info = {}
-            for server_url, spec in info.items():
-                headers: Any = spec.get("http_headers") if isinstance(spec, dict) else None
-                infos[server_url] = {
-                    "has_file_headers": isinstance(headers, dict) and bool(headers),
-                    "access_token": None,
-                }
+            for server_url in info:
+                infos[server_url] = {"in_info_file": True, "access_token": None}
         except (OSError, ValueError) as error:
             # neuro-san re-wraps HOCON parse errors as ValueError; OSError
             # covers a file that exists but cannot be read (permissions, I/O
@@ -255,11 +251,11 @@ class GetMcpTool(CodedTool):
             logger.warning("Failed to read MCP servers info file %s: %s", mcp_info_file, error)
 
         # Overlay nsflow's OAuth connections. A URL present in both sources
-        # keeps has_file_headers=True and gains the token: the token wins at
-        # fetch time (mirroring runtime sly_data-over-file precedence), while
-        # has_file_headers still marks the server as usable without one.
+        # keeps in_info_file=True and gains the token: the token wins at
+        # fetch time, while in_info_file still marks the server as a
+        # server-side auth concern (not declared in generated schemas).
         for server_url, access_token in GetMcpTool._load_storage_access_tokens().items():
-            entry: dict[str, Any] = infos.setdefault(server_url, {"has_file_headers": False, "access_token": None})
+            entry: dict[str, Any] = infos.setdefault(server_url, {"in_info_file": False, "access_token": None})
             entry["access_token"] = access_token
         return infos
 
@@ -535,11 +531,14 @@ class GetMcpTool(CodedTool):
     async def get_mcp_servers_auth_info() -> dict[str, bool]:
         """
         Get, for every known MCP server URL, whether it needs a
-        client-supplied token: True iff mcp_info.hocon configures no
-        http_headers for it (servers known only from nsflow's OAuth token
-        store are therefore always True). Used to build the data-driven
-        `required` list of the sly_data_schema emitted into generated
-        agent networks.
+        client-supplied token: True iff the server is known only from
+        nsflow's OAuth token store — the user connected it via OAuth, so
+        its auth is client-side and generated networks must declare it in
+        their sly_data_schema. Servers listed in mcp_info.hocon are False:
+        their auth (if any) is configured server-side, or they need none,
+        so clients have nothing to supply and generated schemas omit them
+        entirely. (Consequently a client-token OAuth server belongs in the
+        token store, not headerless in the info file.)
 
         Same cache and fingerprint as get_mcp_servers(), so the two views
         are always consistent. Values are bools only — no token material
@@ -549,10 +548,7 @@ class GetMcpTool(CodedTool):
                 may mutate it without corrupting the shared cache.
         """
         infos: dict[str, dict[str, Any]] = await GetMcpTool._shared_mcp_servers_cache.aget()
-        return {
-            server_url: not (isinstance(entry, dict) and entry.get("has_file_headers"))
-            for server_url, entry in infos.items()
-        }
+        return {server_url: not entry["in_info_file"] for server_url, entry in infos.items()}
 
     @staticmethod
     async def get_mcp_tool_descriptions() -> dict[str, str]:

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -510,9 +510,15 @@ class GetMcpTool(CodedTool):
         an OAuth-capable client injects (nsflow injects one for every
         connected server when chatting with the Agent Network Designer; the
         designer's allow.to_downstream forwards the key to this network).
-        Tolerant of malformed shapes: a missing/non-dict http_headers reads
-        as no URLs, and non-string keys or non-dict header values are
-        skipped rather than raising — chat clients control this input.
+
+        Only http(s) URLs that carry at least one usable header (a string
+        name with a non-blank string value — see _has_usable_header) are
+        returned; everything else is skipped rather than raising, since chat
+        clients control this input. That covers a missing/non-dict
+        http_headers, a non-string or non-http(s) key (which must never
+        reach URL validation as an accepted reference), a non-dict header
+        value, and a header-less or blank-valued entry (which supplies no
+        credential to fetch with, declare, or gate on).
 
         :param sly_data: The conversation's sly_data (may be None).
         :return: URLs in first-appearance order. Values are URLs only — no
@@ -521,7 +527,37 @@ class GetMcpTool(CodedTool):
         http_headers: Any = sly_data.get("http_headers") if isinstance(sly_data, dict) else None
         if not isinstance(http_headers, dict):
             return []
-        return [url for url, headers in http_headers.items() if isinstance(url, str) and isinstance(headers, dict)]
+        return [
+            url
+            for url, headers in http_headers.items()
+            if isinstance(url, str)
+            and url.startswith(("http://", "https://"))
+            and isinstance(headers, dict)
+            and GetMcpTool._has_usable_header(headers)
+        ]
+
+    @staticmethod
+    def _has_usable_header(headers: dict[Any, Any]) -> bool:
+        """
+        Whether a per-URL header dict carries at least one usable credential:
+        a string name that is not blank with a string value that is not
+        blank after stripping.
+
+        This is the classification counterpart to _sanitized_headers (which
+        cleans the values actually sent): a server counts as client-token
+        only when it has such a header, so an empty dict, non-string
+        names/values, and blank values never make the fetch, the generated
+        schema, or URL validation treat a credential-less entry as a real
+        server.
+
+        :param headers: A per-URL header dict from sly_data["http_headers"].
+        :return: True if any header is usable. Reads names/values only for
+                the check — no header material leaves this function.
+        """
+        return any(
+            isinstance(name, str) and name.strip() and isinstance(value, str) and value.strip()
+            for name, value in headers.items()
+        )
 
     @staticmethod
     def _sanitized_headers(server: str, headers: dict[str, Any]) -> dict[str, str]:

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -280,8 +280,12 @@ class GetMcpTool(CodedTool):
         stale or revoked token), which is the one hint an operator needs to
         pick the right remedy (re-auth in the client vs. a server outage).
         Unwrap the group and append the leaf exceptions. Leaf messages from
-        this stack (httpx/mcp) carry the URL and status line, never request
-        headers, so no token material can reach the log.
+        this stack usually carry only the URL and status line, but a header
+        VALIDATION failure (e.g. h11's LocalProtocolError) can embed the raw
+        header value, so the caller validates the values it sends up front
+        (see _sanitized_headers) and redacts them from this string before
+        logging (see _redact_values) — this renderer itself makes no such
+        guarantee.
 
         :param error: The exception caught by the fetch.
         :return: str(error), plus "[Type: message; ...]" for group leaves.
@@ -297,6 +301,34 @@ class GetMcpTool(CodedTool):
             else:
                 leaves.append(f"{type(sub).__name__}: {sub}")
         return f"{error} [{'; '.join(leaves)}]"
+
+    @staticmethod
+    def _redact_values(text: str, headers: dict[str, str] | None) -> str:
+        """
+        Mask any header value we sent out of a log-bound string.
+
+        Defense in depth for the drop-path warning. _sanitized_headers
+        already blocks the values that make the HTTP stack raise a
+        value-bearing error, but no exception renderer should be trusted
+        with token material: an illegal header value surfaces as its bytes
+        repr (h11 formats it b'...'), so each value is masked in the plain,
+        str-repr, and bytes-repr forms an error might use — longest first so
+        a shorter form cannot leave a fragment behind.
+
+        :param text: The rendered error summary bound for the log.
+        :param headers: The header dict handed to this fetch, or None (the
+                file-configured path, whose values live in the adapter and
+                are operator-controlled, not client-supplied).
+        :return: text with every non-empty header value we sent masked.
+        """
+        if not headers:
+            return text
+        for value in headers.values():
+            if not isinstance(value, str) or not value:
+                continue
+            for form in (repr(value.encode()), repr(value), value):
+                text = text.replace(form, "***")
+        return text
 
     @staticmethod
     async def _fetch_tool_descriptions(
@@ -343,7 +375,10 @@ class GetMcpTool(CodedTool):
             # conversation's listing of the healthy servers. This warning is
             # the only trace of a dropped server, so surface group leaves
             # (see _error_summary).
-            logger.warning("Error: Failed to load tools from %s. %s", server, GetMcpTool._error_summary(error))
+            # Redact the values we sent (sly_data path): a header
+            # validation error echoes the raw value, which may be a token.
+            summary: str = GetMcpTool._redact_values(GetMcpTool._error_summary(error), headers)
+            logger.warning("Error: Failed to load tools from %s. %s", server, summary)
             return server, None
         return server, description
 
@@ -489,6 +524,40 @@ class GetMcpTool(CodedTool):
         return [url for url, headers in http_headers.items() if isinstance(url, str) and isinstance(headers, dict)]
 
     @staticmethod
+    def _sanitized_headers(server: str, headers: dict[str, Any]) -> dict[str, str]:
+        """
+        Clean a conversation's per-URL header dict before it reaches the
+        HTTP stack.
+
+        A value with control characters — most often a token read with a
+        trailing newline — makes the streamable-http client raise before
+        the request, and that exception embeds the raw value, so an
+        unvalidated header could put token material on the drop path. Outer
+        whitespace is stripped (the common, recoverable case, so a
+        newline-tailed token still authenticates); a value still holding a
+        control character is genuinely malformed and dropped, logging the
+        header NAME only. Non-string names/values are skipped. A value is
+        never logged.
+
+        :param server: The MCP server URL, for the drop warning.
+        :param headers: The conversation's per-URL header dict (from
+                sly_data["http_headers"][server]).
+        :return: The cleaned headers to hand to the adapter; may be empty,
+                in which case the fetch runs unauthenticated and a private
+                server simply drops out of the listing (attempt-and-drop).
+        """
+        cleaned: dict[str, str] = {}
+        for name, value in headers.items():
+            if not isinstance(name, str) or not isinstance(value, str):
+                continue
+            stripped: str = value.strip()
+            if any((ord(char) < 0x20 and char != "\t") or ord(char) == 0x7F for char in stripped):
+                logger.warning("Dropping malformed MCP header %r for %s (illegal value characters).", name, server)
+                continue
+            cleaned[name] = stripped
+        return cleaned
+
+    @staticmethod
     async def _fetch_sly_data_tool_descriptions(sly_data: dict[str, Any], exclude: set[str]) -> dict[str, str]:
         """
         Fetch tool listings for the conversation's sly_data http_headers
@@ -517,9 +586,16 @@ class GetMcpTool(CodedTool):
         http_headers: dict[str, Any] = sly_data["http_headers"]
         fetch_timeout: float | None = GetMcpTool._mcp_tools_fetch_timeout_seconds()
         # return_exceptions=False is safe here because
-        # _fetch_tool_descriptions swallows its own errors.
+        # _fetch_tool_descriptions swallows its own errors. Values are
+        # sanitized per URL first (see _sanitized_headers) so a malformed
+        # header can neither raise a value-bearing error nor reach a log.
         results = await asyncio.gather(
-            *[GetMcpTool._fetch_tool_descriptions(url, fetch_timeout, http_headers[url]) for url in urls]
+            *[
+                GetMcpTool._fetch_tool_descriptions(
+                    url, fetch_timeout, GetMcpTool._sanitized_headers(url, http_headers[url])
+                )
+                for url in urls
+            ]
         )
         return {server: description for server, description in results if description is not None}
 

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -335,12 +335,17 @@ class GetMcpTool(CodedTool):
                 descriptions; servers that failed are absent.
         """
         fetch_timeout: float | None = GetMcpTool._mcp_tools_fetch_timeout_seconds()
+        fetches: list[Any] = []
+        for server in servers:
+            fetches.append(GetMcpTool._fetch_tool_descriptions(server, fetch_timeout))
         # return_exceptions=False is safe here because
         # _fetch_tool_descriptions swallows its own errors.
-        results = await asyncio.gather(
-            *[GetMcpTool._fetch_tool_descriptions(server, fetch_timeout) for server in servers]
-        )
-        return {server: description for server, description in results if description is not None}
+        results = await asyncio.gather(*fetches)
+        descriptions: dict[str, str] = {}
+        for server, description in results:
+            if description is not None:
+                descriptions[server] = description
+        return descriptions
 
     @staticmethod
     def _load_mcp_tool_descriptions() -> dict[str, str]:
@@ -493,14 +498,14 @@ class GetMcpTool(CodedTool):
         http_headers: Any = sly_data.get("http_headers") if isinstance(sly_data, dict) else None
         if not isinstance(http_headers, dict):
             return []
-        return [
-            url
-            for url, headers in http_headers.items()
-            if isinstance(url, str)
-            and url.startswith(("http://", "https://"))
-            and isinstance(headers, dict)
-            and McpHeaderHygiene.usable_header_names(headers)
-        ]
+        urls: list[str] = []
+        for url, headers in http_headers.items():
+            if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+                continue
+            if not isinstance(headers, dict) or not McpHeaderHygiene.usable_header_names(headers):
+                continue
+            urls.append(url)
+        return urls
 
     @staticmethod
     async def _fetch_sly_data_tool_descriptions(sly_data: dict[str, Any], exclude: set[str]) -> dict[str, str]:
@@ -525,25 +530,32 @@ class GetMcpTool(CodedTool):
                 descriptions; servers that failed are absent
                 (attempt-and-drop, same as the shared path).
         """
-        urls: list[str] = [url for url in GetMcpTool.sly_data_http_header_urls(sly_data) if url not in exclude]
+        urls: list[str] = []
+        for url in GetMcpTool.sly_data_http_header_urls(sly_data):
+            if url not in exclude:
+                urls.append(url)
         if not urls:
             return {}
         http_headers: dict[str, Any] = sly_data["http_headers"]
         fetch_timeout: float | None = GetMcpTool._mcp_tools_fetch_timeout_seconds()
-        # return_exceptions=False is safe here because
-        # _fetch_tool_descriptions swallows its own errors. Headers are
-        # sanitized per URL first (see McpHeaderHygiene.sanitized_headers)
-        # so a malformed header can neither raise a value-bearing error nor
-        # reach a log.
-        results = await asyncio.gather(
-            *[
+        # Headers are sanitized per URL first (see
+        # McpHeaderHygiene.sanitized_headers) so a malformed header can
+        # neither raise a value-bearing error nor reach a log.
+        fetches: list[Any] = []
+        for url in urls:
+            fetches.append(
                 GetMcpTool._fetch_tool_descriptions(
                     url, fetch_timeout, McpHeaderHygiene.sanitized_headers(url, http_headers[url])
                 )
-                for url in urls
-            ]
-        )
-        return {server: description for server, description in results if description is not None}
+            )
+        # return_exceptions=False is safe here because
+        # _fetch_tool_descriptions swallows its own errors.
+        results = await asyncio.gather(*fetches)
+        descriptions: dict[str, str] = {}
+        for server, description in results:
+            if description is not None:
+                descriptions[server] = description
+        return descriptions
 
     @staticmethod
     async def get_mcp_tool_descriptions() -> dict[str, str]:

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -481,15 +481,17 @@ class GetMcpTool(CodedTool):
         connected server when chatting with the Agent Network Designer; the
         designer's allow.to_downstream forwards the key to this network).
 
-        Only http(s) URLs that carry at least one usable header (a legal
-        header name with a non-blank string value — see
-        McpHeaderHygiene.usable_header_names) are returned; everything else
-        is skipped rather than raising, since chat clients control this
-        input. That covers a missing/non-dict http_headers, a non-string or
-        non-http(s) key (which must never reach URL validation as an
-        accepted reference), a non-dict header value, and a header-less or
-        blank-valued entry (which supplies no credential to fetch with,
-        declare, or gate on).
+        Only well-formed http(s) URLs (see McpHeaderHygiene.usable_server_url)
+        that carry at least one usable header (a legal header name with a
+        non-blank string value — see McpHeaderHygiene.usable_header_names)
+        are returned; everything else is skipped rather than raising, since
+        chat clients control this input. That covers a missing/non-dict
+        http_headers; a key that is not a string, not http(s), or not a
+        well-formed URL — control characters that would forge log lines,
+        userinfo, a missing host — which must never become a fetch target,
+        a log line, or an accepted URL-validation reference; a non-dict
+        header value; and a header-less or blank-valued entry (which
+        supplies no credential to fetch with, declare, or gate on).
 
         :param sly_data: The conversation's sly_data (may be None).
         :return: URLs in first-appearance order. Values are URLs only — no
@@ -500,7 +502,7 @@ class GetMcpTool(CodedTool):
             return []
         urls: list[str] = []
         for url, headers in http_headers.items():
-            if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+            if not McpHeaderHygiene.usable_server_url(url):
                 continue
             if not isinstance(headers, dict) or not McpHeaderHygiene.usable_header_names(headers):
                 continue

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -419,10 +419,15 @@ class GetMcpTool(CodedTool):
         fetch_timeout: float | None = GetMcpTool._mcp_tools_fetch_timeout_seconds()
         coroutines: list[Any] = []
         for server, entry in server_infos.items():
-            access_token: Any = entry.get("access_token") if isinstance(entry, dict) else None
-            # A stored nsflow OAuth token is sent as the Authorization
-            # header and takes precedence over any file-configured headers
-            # (headers=None falls back to those inside the adapter).
+            # A stored nsflow OAuth token authenticates only servers known
+            # solely from the token store. Servers configured in
+            # mcp_info.hocon keep headers=None so the adapter falls back to
+            # their file-configured headers (or none, for public servers):
+            # the file side is the working, refreshable credential there,
+            # while a leftover stored token can be stale — this path cannot
+            # refresh it — and sending it instead would replace working
+            # auth and hide the server on a 401 (attempt-and-drop).
+            access_token: Any = None if entry["in_info_file"] else entry["access_token"]
             headers: dict[str, str] | None = {"Authorization": f"Bearer {access_token}"} if access_token else None
             coroutines.append(GetMcpTool._fetch_tool_descriptions(server, fetch_timeout, headers))
         # return_exceptions=False is safe here because

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -15,9 +15,9 @@
 # END COPYRIGHT
 
 import asyncio
-import json
 import logging
 import os
+import sys
 from math import isfinite
 from pathlib import Path
 from typing import Any
@@ -36,15 +36,6 @@ from neuro_san_studio import mcp as _mcp_pkg
 # after `pip install` on every platform. Mirrors run.py.
 BUNDLED_MCP_INFO_FILE: Path = Path(_mcp_pkg.__file__).parent / "mcp_info.hocon"
 
-# Where nsflow persists its MCP OAuth credentials (see nsflow's
-# mcp_token_storage.py): a tokens.json keyed by MCP server URL, written
-# atomically, in NSFLOW_MCP_STORAGE_DIR or the same default nsflow uses.
-# Reading it lets the designer list tools from OAuth-protected MCP servers
-# whose bearer tokens were obtained by the nsflow client on this machine.
-NSFLOW_MCP_STORAGE_DIR_ENV: str = "NSFLOW_MCP_STORAGE_DIR"
-DEFAULT_NSFLOW_MCP_STORAGE_DIR: str = "~/.nsflow/mcp_oauth"
-NSFLOW_MCP_TOKENS_FILE_NAME: str = "tokens.json"
-
 # Default cap on how long one MCP server may take to answer a tool listing
 # (see _mcp_tools_fetch_timeout_seconds for the env-var override). The
 # listings are fetched by a process-wide shared load, so without a cap a
@@ -62,12 +53,31 @@ DEFAULT_MCP_TOOLS_FETCH_TIMEOUT_SECONDS: float = 30.0
 # re-fetched (see _mcp_tools_ttl_seconds for the env-var override).
 DEFAULT_MCP_TOOLS_TTL_SECONDS: float = 300.0
 
+# ExceptionGroup is a builtin from Python 3.11 (the repo minimum is 3.10).
+# On 3.10 the conditional's true branch never evaluates, and isinstance
+# against the empty tuple is simply always False — those interpreters keep
+# the plain str(error) rendering.
+_EXCEPTION_GROUP_TYPES: tuple[type[BaseException], ...] = (BaseExceptionGroup,) if sys.version_info >= (3, 11) else ()
+
 logger = AndLogger(logging.getLogger(__name__))
 
 
 class GetMcpTool(CodedTool):
     """
-    CodedTool implementation which provides a way to get tool definition from given MCP servers
+    CodedTool implementation which provides a way to get tool definition from given MCP servers.
+
+    Two sources of servers:
+
+    * mcp_info.hocon — file-configured servers whose auth (if any) lives
+      server-side. Their listings are fetched with the adapter's own
+      file-configured headers and cached process-wide.
+    * sly_data["http_headers"] — per-conversation auth headers injected by
+      an OAuth-capable client. nsflow injects a fresh Authorization header
+      for EVERY connected MCP server when the chat target is the Agent
+      Network Designer (its NSFLOW_WAND_NAME), and the designer network
+      forwards http_headers downstream to this tool's network. These
+      listings are fetched per call and never cached process-wide, because
+      the headers belong to one conversation.
     """
 
     # TODO: This duplicates NeuroSanRunner._resolve_mcp_info_file in
@@ -98,150 +108,66 @@ class GetMcpTool(CodedTool):
         return str(BUNDLED_MCP_INFO_FILE)
 
     @staticmethod
-    def get_nsflow_tokens_file() -> str:
-        """Resolve the path of nsflow's MCP OAuth token store at call time.
-
-        NSFLOW_MCP_STORAGE_DIR (expanduser'd, mirroring nsflow's
-        _default_storage_dir) when non-empty, else ~/.nsflow/mcp_oauth;
-        the file inside it is tokens.json.
-
-        :return: The tokens.json path. Never raises — this resolver runs
-                inside fingerprint probes; when no home directory can be
-                resolved the unexpanded path is returned, which simply
-                stats to None ("no token store").
-        """
-        base: str = os.getenv(NSFLOW_MCP_STORAGE_DIR_ENV) or DEFAULT_NSFLOW_MCP_STORAGE_DIR
-        try:
-            return str(Path(base).expanduser() / NSFLOW_MCP_TOKENS_FILE_NAME)
-        except (OSError, RuntimeError):
-            # expanduser raises when the home directory cannot be resolved.
-            return str(Path(base) / NSFLOW_MCP_TOKENS_FILE_NAME)
-
-    @staticmethod
-    def _load_storage_access_tokens() -> dict[str, str]:
-        """
-        Read nsflow's MCP OAuth token store into {server URL: access token}.
-
-        An entry is included iff it is a dict whose "tokens" value is a dict
-        holding a non-empty string "access_token" — the minimum needed to
-        attempt an authenticated tool listing. Entries marked needs_reauth
-        or past their expires_at are deliberately NOT filtered out here:
-        the policy is attempt-and-drop — a stale token fails its listing
-        fetch downstream and that server is simply omitted from the result,
-        exactly like any other unreachable server. (A cheap expires_at
-        pre-skip would save one doomed round trip, but it is intentionally
-        not implemented so attempt-and-drop stays the single behavior.)
-
-        A missing file just means nsflow has no stored connections — not
-        worth a warning. Unreadable or unparsable files degrade to {} with
-        a warning; nsflow writes the file atomically (os.replace), so torn
-        reads are impossible and no locking is needed for a read.
-
-        Token values must never be logged, and they never leave this class
-        except as Authorization headers on MCP requests.
-
-        :return: {server URL: access token}; {} when there is no usable store.
-        """
-        tokens_file: str = GetMcpTool.get_nsflow_tokens_file()
-        try:
-            with open(tokens_file, "r", encoding="utf-8") as handle:
-                blob: Any = json.load(handle)
-        except FileNotFoundError:
-            return {}
-        except (OSError, ValueError) as error:
-            logger.warning("Could not read nsflow MCP token store at %s: %s", tokens_file, error)
-            return {}
-        if not isinstance(blob, dict):
-            logger.warning("Ignoring nsflow MCP token store at %s: top level is not an object", tokens_file)
-            return {}
-
-        access_tokens: dict[str, str] = {}
-        for server_url, entry in blob.items():
-            if not isinstance(entry, dict):
-                continue
-            tokens: Any = entry.get("tokens")
-            if not isinstance(tokens, dict):
-                continue
-            access_token: Any = tokens.get("access_token")
-            if isinstance(access_token, str) and access_token:
-                access_tokens[server_url] = access_token
-        return access_tokens
-
-    @staticmethod
-    def _mcp_sources_fingerprint() -> tuple[str, int | None, str, int | None]:
+    def _mcp_info_fingerprint() -> tuple[str, int | None]:
         """
         Freshness probe for the shared MCP-servers cache (see
-        SharedProcessCache): the cached value is served only while this
-        value is unchanged. It covers both sources of the union the cache
-        holds — mcp_info.hocon and nsflow's tokens.json. Unlike the
-        designer manifest there is no time bucket: both are plain files
-        whose every relevant change touches path or modification time —
+        SharedProcessCache): the cached list is served only while this value
+        is unchanged. Unlike the designer manifest there is no time bucket:
+        mcp_info.hocon is a plain config file with no `include`s and nothing
+        writes it at runtime, so the two components cover everything the
+        probe can see —
 
-        * the resolved paths — an env-var change or the cwd-scaffolded file
+        * the resolved path — an env-var change or the cwd-scaffolded file
           appearing takes effect on the next read;
-        * each file's modification_time — a direct edit invalidates
-          immediately, and a missing file (modification_time None)
-          self-heals the moment it appears. nsflow rewrites tokens.json on
-          every connect/refresh/disconnect, so a new OAuth connection is
-          picked up promptly.
+        * the file's modification_time — a direct edit invalidates immediately, and a
+          missing file (modification_time None) self-heals the moment it appears.
 
         Two changes are invisible to this probe: HOCON `${...}` references
-        inside mcp_info.hocon resolve against the environment at parse time,
-        so changing THOSE env vars alters the parse result without touching
+        inside the file resolve against the environment at parse time, so
+        changing THOSE env vars alters the parse result without touching
         path or modification_time; and LangChainMcpAdapter keeps its own copy of the
         servers info, frozen at its first load — a file edit refreshes
         which URLs this class serves, but not the connection details the
         adapter already latched. Both heal on process restart (or on the
         modification_time change of the next file edit, for the first).
 
-        :return: (mcp_info path, its modification_time_ns or None,
-                tokens.json path, its modification_time_ns or None) tuple.
+        :return: (path, modification_time_ns or None) tuple.
         """
         mcp_info_file: str = GetMcpTool.get_mcp_info_file()
-        tokens_file: str = GetMcpTool.get_nsflow_tokens_file()
-        return (
-            mcp_info_file,
-            SharedProcessCache.stat_modification_time_ns(mcp_info_file),
-            tokens_file,
-            SharedProcessCache.stat_modification_time_ns(tokens_file),
-        )
+        return (mcp_info_file, SharedProcessCache.stat_modification_time_ns(mcp_info_file))
 
     @staticmethod
-    def _load_mcp_server_infos() -> dict[str, dict[str, Any]]:
+    def _load_mcp_servers() -> list[str]:
         """
-        Loader for the shared MCP-servers cache (runs inside
+        Loader for the shared MCP-servers list (runs inside
         SharedProcessCache, off the event loop when reached via aget()).
 
-        :return: The UNION of mcp_info.hocon entries and nsflow token-store
-                entries holding an access token, as
-                {server URL: {"in_info_file": bool, "access_token": str | None}}.
-                in_info_file records whether the URL is configured in
-                mcp_info.hocon (its auth — if any — is a server-side
-                concern: file/env headers, or none needed); access_token
-                is the nsflow OAuth bearer token when one is stored. A
-                missing, unreadable, or unparseable mcp_info.hocon degrades
-                to the token-store half alone, which IS published: the
-                fingerprint self-heals it — a missing file flips the
-                modification_time component when it appears, and fixing a
-                broken file changes its modification_time — so nothing can pin a degraded
-                value past the next change to the files themselves (env-var
-                references INSIDE mcp_info.hocon are the one exception; see
-                _mcp_sources_fingerprint). NOTE: values hold token material —
-                never log this mapping.
+        :return: List of MCP server URLs from mcp_info.hocon. A missing,
+                unreadable, or unparseable file returns an empty list, which
+                IS published: the fingerprint self-heals it — a missing file
+                flips the modification_time component when it appears, and fixing a
+                broken file changes its modification_time — so nothing can pin an empty
+                list past the next change to the file itself (env-var
+                references INSIDE the file are the one exception; see
+                _mcp_info_fingerprint).
         """
         mcp_info_file: str = GetMcpTool.get_mcp_info_file()
         logger.info("MCP servers info file: %s", mcp_info_file)
 
-        infos: dict[str, dict[str, Any]] = {}
+        servers: list[str] = []
         try:
             # McpServersInfoRestorer is constructed with must_exist=False, so
             # a missing file comes back as None rather than an exception.
             info: dict[str, Any] = McpServersInfoRestorer().restore(file_reference=mcp_info_file)
             if info is None:
-                logger.warning("MCP servers info file not found at %s. No MCP Servers will be used.", mcp_info_file)
+                # Servers supplied per-conversation via sly_data http_headers
+                # (if any) are unaffected — only the file half is empty.
+                logger.warning(
+                    "MCP servers info file not found at %s. No file-configured MCP servers will be used.",
+                    mcp_info_file,
+                )
                 info = {}
-            for server_url in info:
-                infos[server_url] = {"in_info_file": True, "access_token": None}
+            servers = list(info.keys())
         except (OSError, ValueError) as error:
             # neuro-san re-wraps HOCON parse errors as ValueError; OSError
             # covers a file that exists but cannot be read (permissions, I/O
@@ -249,31 +175,20 @@ class GetMcpTool(CodedTool):
             # every caller sharing this load, when the healthy answer is
             # simply "no file-configured MCP servers right now".
             logger.warning("Failed to read MCP servers info file %s: %s", mcp_info_file, error)
+        return servers
 
-        # Overlay nsflow's OAuth connections. A URL present in both sources
-        # keeps in_info_file=True and gains the token: the token wins at
-        # fetch time, while in_info_file still marks the server as a
-        # server-side auth concern (not declared in generated schemas).
-        for server_url, access_token in GetMcpTool._load_storage_access_tokens().items():
-            entry: dict[str, Any] = infos.setdefault(server_url, {"in_info_file": False, "access_token": None})
-            entry["access_token"] = access_token
-        return infos
-
-    # Process-wide cache of MCP server info: the union of the URLs parsed
-    # from mcp_info.hocon and the OAuth connections in nsflow's token store,
-    # with per-URL auth metadata (see _load_mcp_server_infos; the values
-    # hold token material — never log them). Previously cached per sly_data
-    # scope, so a server handling N concurrent conversations re-parsed the
-    # same HOCON N times, on the event loop.
-    # The (paths, modification_times) fingerprint picks up env-var changes
-    # and edits to either file immediately; there is no time bucket because
-    # nothing changes mcp_info.hocon at runtime and every nsflow token write
-    # touches tokens.json's modification time. Locking, publish ordering,
-    # and the async once-gate live in SharedProcessCache; access goes
-    # through the class by name (not cls) so a hypothetical subclass shares
-    # the one cache instead of splitting it.
-    _shared_mcp_servers_cache: SharedProcessCache[dict[str, dict[str, Any]]] = SharedProcessCache(
-        loader=_load_mcp_server_infos, fingerprint=_mcp_sources_fingerprint
+    # Process-wide cache of the MCP server URLs parsed from mcp_info.hocon.
+    # Previously cached per sly_data scope, so a server handling N concurrent
+    # conversations re-parsed the same HOCON N times, on the event loop.
+    # The (path, modification_time) fingerprint picks up env-var changes and file edits
+    # immediately; there is no time bucket because nothing changes this file
+    # at runtime. Per-conversation servers from sly_data http_headers are
+    # deliberately NOT part of this cache — they belong to one conversation.
+    # Locking, publish ordering, and the async once-gate live in
+    # SharedProcessCache; access goes through the class by name (not cls) so
+    # a hypothetical subclass shares the one cache instead of splitting it.
+    _shared_mcp_servers_cache: SharedProcessCache[list[str]] = SharedProcessCache(
+        loader=_load_mcp_servers, fingerprint=_mcp_info_fingerprint
     )
 
     @staticmethod
@@ -336,23 +251,52 @@ class GetMcpTool(CodedTool):
         return max(ttl, 2 * fetch_cap)
 
     @staticmethod
-    def _mcp_tools_fingerprint() -> tuple[str, int | None, str, int | None, float, int]:
+    def _mcp_tools_fingerprint() -> tuple[str, int | None, float, int]:
         """
         Freshness probe for the shared tool-descriptions cache: the
-        MCP-sources fingerprint (so an mcp_info.hocon edit or an nsflow
-        OAuth connect/refresh refreshes the listings immediately) plus the
-        TTL and a time bucket that rolls once per TTL window (see
-        _mcp_tools_ttl_seconds; frozen when TTL <= 0).
+        MCP-servers-list fingerprint (so an mcp_info.hocon edit refreshes the
+        listings immediately) plus the TTL and a time bucket that rolls once
+        per TTL window (see _mcp_tools_ttl_seconds; frozen when TTL <= 0).
         The TTL value itself rides along because bucket numbers from
         different TTL regimes are not comparable — after an env-var change,
         bucket N under the new TTL can collide with bucket N under the old
         one and revive a stale entry; carrying the TTL makes any change to
         it an immediate miss instead.
 
-        :return: (*_mcp_sources_fingerprint(), ttl, time bucket) tuple.
+        :return: (path, modification_time_ns or None, ttl, time bucket) tuple.
         """
+        mcp_info_file, modification_time_ns = GetMcpTool._mcp_info_fingerprint()
         ttl: float = GetMcpTool._mcp_tools_ttl_seconds()
-        return (*GetMcpTool._mcp_sources_fingerprint(), ttl, SharedProcessCache.time_bucket(ttl))
+        return (mcp_info_file, modification_time_ns, ttl, SharedProcessCache.time_bucket(ttl))
+
+    @staticmethod
+    def _error_summary(error: BaseException) -> str:
+        """
+        Render an exception for the drop-path warning below.
+
+        The MCP streamable-http client surfaces failures as an anyio
+        ExceptionGroup whose str() is just "unhandled errors in a TaskGroup
+        (1 sub-exception)" — hiding the actual cause (e.g. a 401 from a
+        stale or revoked token), which is the one hint an operator needs to
+        pick the right remedy (re-auth in the client vs. a server outage).
+        Unwrap the group and append the leaf exceptions. Leaf messages from
+        this stack (httpx/mcp) carry the URL and status line, never request
+        headers, so no token material can reach the log.
+
+        :param error: The exception caught by the fetch.
+        :return: str(error), plus "[Type: message; ...]" for group leaves.
+        """
+        if not isinstance(error, _EXCEPTION_GROUP_TYPES):
+            return str(error)
+        leaves: list[str] = []
+        stack: list[BaseException] = list(error.exceptions)
+        while stack:
+            sub: BaseException = stack.pop(0)
+            if isinstance(sub, _EXCEPTION_GROUP_TYPES):
+                stack.extend(sub.exceptions)
+            else:
+                leaves.append(f"{type(sub).__name__}: {sub}")
+        return f"{error} [{'; '.join(leaves)}]"
 
     @staticmethod
     async def _fetch_tool_descriptions(
@@ -360,15 +304,13 @@ class GetMcpTool(CodedTool):
     ) -> tuple[str, str | None]:
         """
         Fetch one MCP server's tool listing and flatten it into a
-        description string, on the private event loop that
-        _load_mcp_tool_descriptions runs. With headers=None,
-        LangChainMcpAdapter resolves the server's connection details from
-        its own copy of the servers info (loaded once per process — see
-        _mcp_sources_fingerprint), opens a session, and lists the tools.
-        Passing headers overrides the adapter's file-configured
-        http_headers for this request — used to send an nsflow OAuth bearer
-        token, mirroring the runtime precedence of sly_data headers over
-        the servers-info file.
+        description string. Runs both on the private event loop of the
+        shared loader (file-configured servers, headers=None — the adapter
+        resolves connection details from its own copy of the servers info,
+        loaded once per process; see _mcp_info_fingerprint) and on the
+        server's event loop for the per-conversation sly_data path
+        (headers=the conversation's per-URL header dict, which overrides
+        any file-configured headers, mirroring runtime precedence).
 
         :param server: The MCP server URL.
         :param fetch_timeout: Per-server cap in seconds, or None for no cap
@@ -398,41 +340,30 @@ class GetMcpTool(CodedTool):
             # Broad on purpose: this is a shared load, so one bad server
             # (ExceptionGroup out of the MCP client, TimeoutError from the
             # cap above, connection errors, ...) must not take out every
-            # conversation's listing of the healthy servers.
-            logger.warning("Error: Failed to load tools from %s. %s", server, error)
+            # conversation's listing of the healthy servers. This warning is
+            # the only trace of a dropped server, so surface group leaves
+            # (see _error_summary).
+            logger.warning("Error: Failed to load tools from %s. %s", server, GetMcpTool._error_summary(error))
             return server, None
         return server, description
 
     @staticmethod
-    async def _fetch_all_tool_descriptions(server_infos: dict[str, dict[str, Any]]) -> dict[str, str]:
+    async def _fetch_all_tool_descriptions(servers: list[str]) -> dict[str, str]:
         """
-        Fetch every known server's tool listing concurrently; the
+        Fetch every file-configured server's tool listing concurrently; the
         entry point of the private event loop that
         _load_mcp_tool_descriptions runs.
 
-        :param server_infos: The {server URL: auth info} union from the
-                shared servers cache (see _load_mcp_server_infos). Holds
-                token material — never log it.
+        :param servers: The MCP server URLs from the shared servers cache.
         :return: dict mapping each server URL that answered to its tools'
                 descriptions; servers that failed are absent.
         """
         fetch_timeout: float | None = GetMcpTool._mcp_tools_fetch_timeout_seconds()
-        coroutines: list[Any] = []
-        for server, entry in server_infos.items():
-            # A stored nsflow OAuth token authenticates only servers known
-            # solely from the token store. Servers configured in
-            # mcp_info.hocon keep headers=None so the adapter falls back to
-            # their file-configured headers (or none, for public servers):
-            # the file side is the working, refreshable credential there,
-            # while a leftover stored token can be stale — this path cannot
-            # refresh it — and sending it instead would replace working
-            # auth and hide the server on a 401 (attempt-and-drop).
-            access_token: Any = None if entry["in_info_file"] else entry["access_token"]
-            headers: dict[str, str] | None = {"Authorization": f"Bearer {access_token}"} if access_token else None
-            coroutines.append(GetMcpTool._fetch_tool_descriptions(server, fetch_timeout, headers))
         # return_exceptions=False is safe here because
         # _fetch_tool_descriptions swallows its own errors.
-        results = await asyncio.gather(*coroutines)
+        results = await asyncio.gather(
+            *[GetMcpTool._fetch_tool_descriptions(server, fetch_timeout) for server in servers]
+        )
         return {server: description for server, description in results if description is not None}
 
     @staticmethod
@@ -464,30 +395,33 @@ class GetMcpTool(CodedTool):
                 descriptions filler's all-empty guard.
         """
         # Already in a worker thread here, so the blocking get() is fine.
-        server_infos: dict[str, dict[str, Any]] = GetMcpTool._shared_mcp_servers_cache.get()
-        descriptions: dict[str, str] = asyncio.run(GetMcpTool._fetch_all_tool_descriptions(server_infos))
-        if server_infos and not descriptions and GetMcpTool._mcp_tools_ttl_seconds() <= 0:
+        servers: list[str] = GetMcpTool._shared_mcp_servers_cache.get()
+        descriptions: dict[str, str] = asyncio.run(GetMcpTool._fetch_all_tool_descriptions(servers))
+        if servers and not descriptions and GetMcpTool._mcp_tools_ttl_seconds() <= 0:
             raise RuntimeError(
-                f"all {len(server_infos)} MCP tool-listing fetches failed and time-based refresh is disabled; "
+                f"all {len(servers)} MCP tool-listing fetches failed and time-based refresh is disabled; "
                 "treating as a failed load"
             )
         return descriptions
 
     # Process-wide cache of the {server URL: tool descriptions} mapping
-    # fetched from the MCP servers themselves. Previously cached per sly_data
-    # scope, so every conversation paid the full network round-trip to every
-    # server (sequentially). The sources are external servers with no local
-    # change signal, so freshness is time-based: the fingerprint reuses the
-    # MCP-sources (paths, modification_times) probe — a config edit or an
-    # nsflow OAuth token write refreshes immediately — plus a TTL bucket
-    # (default 300s, see
-    # _mcp_tools_ttl_seconds) that bounds both staleness and how long a
-    # failed fetch's empty/partial result can be served. (With time-based
-    # refresh disabled, an all-failed fetch raises instead of publishing —
-    # see the loader.) Locking, publish
-    # ordering, and the async once-gate live in SharedProcessCache; access
-    # goes through the class by name (not cls) so a hypothetical subclass
-    # shares the one cache instead of splitting it.
+    # fetched from the file-configured MCP servers themselves. Previously
+    # cached per sly_data scope, so every conversation paid the full network
+    # round-trip to every server (sequentially). The sources are external
+    # servers with no local change signal, so freshness is time-based: the
+    # fingerprint reuses the mcp_info.hocon (path, modification_time) probe
+    # — a config edit refreshes immediately — plus a TTL bucket (default
+    # 300s, see _mcp_tools_ttl_seconds) that bounds both staleness and how
+    # long a failed fetch's empty/partial result can be served. (With
+    # time-based refresh disabled, an all-failed fetch raises instead of
+    # publishing — see the loader.) Listings for per-conversation sly_data
+    # servers are deliberately NOT cached here: their auth headers belong to
+    # one conversation, and a process-wide entry would serve one user's
+    # authenticated listing to every other (see
+    # _fetch_sly_data_tool_descriptions). Locking, publish ordering, and the
+    # async once-gate live in SharedProcessCache; access goes through the
+    # class by name (not cls) so a hypothetical subclass shares the one
+    # cache instead of splitting it.
     _shared_mcp_tool_descriptions_cache: SharedProcessCache[dict[str, str]] = SharedProcessCache(
         loader=_load_mcp_tool_descriptions, fingerprint=_mcp_tools_fingerprint
     )
@@ -516,51 +450,86 @@ class GetMcpTool(CodedTool):
     @staticmethod
     async def get_mcp_servers() -> list[str]:
         """
-        Get the list of known MCP server URLs: the union of mcp_info.hocon
-        entries and the OAuth connections stored by nsflow (see
-        _load_mcp_server_infos).
+        Get the list of MCP server URLs from mcp_info.hocon.
 
         Used by callers (e.g. middleware) that need to validate MCP
-        references. Reads only local files, not the servers — and at
-        most once per process per source-file change, off the event loop,
-        shared by concurrent cold callers.
+        references. Reads only the config file, not the servers — and at
+        most once per process per config change, off the event loop, shared
+        by concurrent cold callers. Per-conversation servers supplied via
+        sly_data http_headers are not included: callers that need those too
+        union this list with sly_data_http_header_urls(sly_data).
 
-        :return: List of MCP server URLs, or an empty list if neither
-                source yields any (see the loader for the self-healing
-                semantics). The returned list is a copy, so callers may
-                mutate it without corrupting the shared cache.
+        :return: List of MCP server URLs, or an empty list if the file is
+                missing or fails to parse (see the loader for the
+                self-healing semantics). The returned list is a copy, so
+                callers may mutate it without corrupting the shared cache.
         """
         return list(await GetMcpTool._shared_mcp_servers_cache.aget())
 
     @staticmethod
-    async def get_mcp_servers_auth_info() -> dict[str, bool]:
+    def sly_data_http_header_urls(sly_data: dict[str, Any] | None) -> list[str]:
         """
-        Get, for every known MCP server URL, whether it needs a
-        client-supplied token: True iff the server is known only from
-        nsflow's OAuth token store — the user connected it via OAuth, so
-        its auth is client-side and generated networks must declare it in
-        their sly_data_schema. Servers listed in mcp_info.hocon are False:
-        their auth (if any) is configured server-side, or they need none,
-        so clients have nothing to supply and generated schemas omit them
-        entirely. (Consequently a client-token OAuth server belongs in the
-        token store, not headerless in the info file.)
+        Get the MCP server URLs a conversation supplies auth headers for.
 
-        Same cache and fingerprint as get_mcp_servers(), so the two views
-        are always consistent. Values are bools only — no token material
-        leaves this class.
+        These come from sly_data["http_headers"], the per-URL header dicts
+        an OAuth-capable client injects (nsflow injects one for every
+        connected server when chatting with the Agent Network Designer; the
+        designer's allow.to_downstream forwards the key to this network).
+        Tolerant of malformed shapes: a missing/non-dict http_headers reads
+        as no URLs, and non-string keys or non-dict header values are
+        skipped rather than raising — chat clients control this input.
 
-        :return: {server URL: needs_client_token}. A fresh dict, so callers
-                may mutate it without corrupting the shared cache.
+        :param sly_data: The conversation's sly_data (may be None).
+        :return: URLs in first-appearance order. Values are URLs only — no
+                header material leaves this function.
         """
-        infos: dict[str, dict[str, Any]] = await GetMcpTool._shared_mcp_servers_cache.aget()
-        return {server_url: not entry["in_info_file"] for server_url, entry in infos.items()}
+        http_headers: Any = sly_data.get("http_headers") if isinstance(sly_data, dict) else None
+        if not isinstance(http_headers, dict):
+            return []
+        return [url for url, headers in http_headers.items() if isinstance(url, str) and isinstance(headers, dict)]
+
+    @staticmethod
+    async def _fetch_sly_data_tool_descriptions(sly_data: dict[str, Any], exclude: set[str]) -> dict[str, str]:
+        """
+        Fetch tool listings for the conversation's sly_data http_headers
+        servers, concurrently, on the caller's event loop.
+
+        Deliberately NOT cached process-wide: the headers are one
+        conversation's credentials (nsflow refreshes them every message),
+        and a shared cache entry would serve one user's authenticated
+        listing to every other conversation. The editor LLM calls
+        get_mcp_tool once per conversation, so the per-call cost is one
+        bounded concurrent fetch round.
+
+        :param sly_data: The conversation's sly_data; http_headers holds
+                token material — never log it.
+        :param exclude: URLs to skip — the file-configured servers, whose
+                auth is a server-side concern and whose listings the shared
+                cache already provides. Skipping them also keeps a stale
+                client header from displacing working file-side auth.
+        :return: dict mapping each answering server URL to its tools'
+                descriptions; servers that failed are absent
+                (attempt-and-drop, same as the shared path).
+        """
+        urls: list[str] = [url for url in GetMcpTool.sly_data_http_header_urls(sly_data) if url not in exclude]
+        if not urls:
+            return {}
+        http_headers: dict[str, Any] = sly_data["http_headers"]
+        fetch_timeout: float | None = GetMcpTool._mcp_tools_fetch_timeout_seconds()
+        # return_exceptions=False is safe here because
+        # _fetch_tool_descriptions swallows its own errors.
+        results = await asyncio.gather(
+            *[GetMcpTool._fetch_tool_descriptions(url, fetch_timeout, http_headers[url]) for url in urls]
+        )
+        return {server: description for server, description in results if description is not None}
 
     @staticmethod
     async def get_mcp_tool_descriptions() -> dict[str, str]:
         """
-        Get the {server URL: tool descriptions} mapping, fetching from the
-        MCP servers at most once per process per TTL window (or config
-        change), off the event loop, shared by concurrent cold callers.
+        Get the {server URL: tool descriptions} mapping for the
+        file-configured servers, fetching from the MCP servers at most once
+        per process per TTL window (or config change), off the event loop,
+        shared by concurrent cold callers.
 
         :return: dict mapping each server URL to a newline-joined string of
                 its tools' descriptions; servers that failed this round are
@@ -600,12 +569,18 @@ class GetMcpTool(CodedTool):
                 adding the data is not invoke()-ed more than once.
 
                 Keys expected for this implementation are:
-                    None
+                    "http_headers" (optional): {MCP server URL: {header: value}}
+                    per-conversation auth headers injected by an OAuth-capable
+                    client (see sly_data_http_header_urls). Absent for clients
+                    that inject nothing — the listing then covers only the
+                    file-configured servers.
 
         :return:
             In case of successful execution:
                 a string rendering of the dictionary that maps each MCP
-                server URL to the descriptions of the tools it provides.
+                server URL to the descriptions of the tools it provides —
+                the union of the file-configured servers (shared, cached)
+                and the conversation's sly_data servers (fetched per call).
             otherwise:
                 servers that failed to respond are omitted from that
                 dictionary; "{}" if none responded or none are configured.
@@ -614,4 +589,13 @@ class GetMcpTool(CodedTool):
         # Get tool list from MCP servers
         logger.info(">>>>>>>>>>>>>>>>>>>Getting Tool Definition from MCP Servers>>>>>>>>>>>>>>>>>>>")
 
-        return str(await self.get_mcp_tool_descriptions())
+        file_descriptions: dict[str, str] = await self.get_mcp_tool_descriptions()
+        # Exclude by the configured server list, not by which servers
+        # answered: a file server whose shared fetch failed stays a
+        # server-side concern — retrying it with a client header would let
+        # a stale token mask (or briefly "fix") a config problem.
+        file_servers: set[str] = set(await self.get_mcp_servers())
+        client_descriptions: dict[str, str] = await self._fetch_sly_data_tool_descriptions(
+            sly_data, exclude=file_servers
+        )
+        return str({**file_descriptions, **client_descriptions})

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -17,6 +17,7 @@
 import asyncio
 import logging
 import os
+import re
 import sys
 from math import isfinite
 from pathlib import Path
@@ -59,6 +60,14 @@ DEFAULT_MCP_TOOLS_TTL_SECONDS: float = 300.0
 # against the empty tuple is simply always False — those interpreters keep
 # the plain str(error) rendering.
 _EXCEPTION_GROUP_TYPES: tuple[type[BaseException], ...] = (BaseExceptionGroup,) if sys.version_info >= (3, 11) else ()
+
+# Legal HTTP field-name charset (RFC 9110 "token"), for validating
+# conversation-supplied header NAMES. The HTTP stack validates outgoing
+# names just like values and raises on the first illegal one — failing the
+# whole request, not just the one header — so names outside this set are
+# dropped before the fetch (see _usable_header_name). Matched with
+# fullmatch(); the + quantifier also rejects an empty (blank) name.
+_HEADER_NAME_RE: re.Pattern[str] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 
 logger = AndLogger(logging.getLogger(__name__))
 
@@ -558,10 +567,10 @@ class GetMcpTool(CodedTool):
         connected server when chatting with the Agent Network Designer; the
         designer's allow.to_downstream forwards the key to this network).
 
-        Only http(s) URLs that carry at least one usable header (a string
-        name with a non-blank string value — see _has_usable_header) are
-        returned; everything else is skipped rather than raising, since chat
-        clients control this input. That covers a missing/non-dict
+        Only http(s) URLs that carry at least one usable header (a legal
+        header name with a non-blank string value — see usable_header_names)
+        are returned; everything else is skipped rather than raising, since
+        chat clients control this input. That covers a missing/non-dict
         http_headers, a non-string or non-http(s) key (which must never
         reach URL validation as an accepted reference), a non-dict header
         value, and a header-less or blank-valued entry (which supplies no
@@ -580,31 +589,59 @@ class GetMcpTool(CodedTool):
             if isinstance(url, str)
             and url.startswith(("http://", "https://"))
             and isinstance(headers, dict)
-            and GetMcpTool._has_usable_header(headers)
+            and GetMcpTool.usable_header_names(headers)
         ]
 
     @staticmethod
-    def _has_usable_header(headers: dict[Any, Any]) -> bool:
+    def usable_header_names(headers: dict[Any, Any]) -> list[str]:
         """
-        Whether a per-URL header dict carries at least one usable credential:
-        a string name that is not blank with a string value that is not
-        blank after stripping.
+        Get the header names in a per-URL header dict that supply a usable
+        credential: a legal HTTP header name (see _usable_header_name)
+        whose value is a string that is not blank after stripping.
 
-        This is the classification counterpart to _sanitized_headers (which
-        cleans the values actually sent): a server counts as client-token
-        only when it has such a header, so an empty dict, non-string
-        names/values, and blank values never make the fetch, the generated
-        schema, or URL validation treat a credential-less entry as a real
-        server.
+        Single owner of what counts as a usable client-supplied header.
+        Three call sites keep the story consistent: URL classification
+        (sly_data_http_header_urls treats a server as client-token only
+        when this is non-empty), the fetch path (_sanitized_headers sends
+        exactly these names, values cleaned), and the persisted contract
+        (AgentNetworkPersistenceMiddleware declares these names in the
+        generated sly_data_schema) — so a network never requires a header
+        that would not actually be sent.
 
         :param headers: A per-URL header dict from sly_data["http_headers"].
-        :return: True if any header is usable. Reads names/values only for
-                the check — no header material leaves this function.
+        :return: The stripped names in first-appearance order, deduped (two
+                raw spellings of one name collapse into the first). Names
+                only — no header value leaves this function.
         """
-        return any(
-            isinstance(name, str) and name.strip() and isinstance(value, str) and value.strip()
-            for name, value in headers.items()
-        )
+        names: dict[str, None] = {}
+        for name, value in headers.items():
+            usable_name: str | None = GetMcpTool._usable_header_name(name)
+            if usable_name is not None and isinstance(value, str) and value.strip():
+                names[usable_name] = None
+        return list(names)
+
+    @staticmethod
+    def _usable_header_name(name: Any) -> str | None:
+        """
+        Validate and normalize one conversation-supplied header name.
+
+        Outer whitespace is stripped (recoverable, the same treatment
+        values get). What remains must be a legal HTTP field name (RFC
+        9110 token — see _HEADER_NAME_RE): the HTTP stack validates names
+        on send exactly like values, so a blank name or one holding a
+        colon, space, control, or non-ASCII character would fail the whole
+        request rather than just this header.
+
+        :param name: One key from a per-URL header dict.
+        :return: The stripped name, or None when the name is not a string
+                or not a legal field name.
+        """
+        if not isinstance(name, str):
+            return None
+        stripped: str = name.strip()
+        if not _HEADER_NAME_RE.fullmatch(stripped):
+            return None
+        return stripped
 
     @staticmethod
     def _sanitized_headers(server: str, headers: dict[str, Any]) -> dict[str, str]:
@@ -612,14 +649,22 @@ class GetMcpTool(CodedTool):
         Clean a conversation's per-URL header dict before it reaches the
         HTTP stack.
 
-        A value with control characters — most often a token read with a
-        trailing newline — makes the streamable-http client raise before
-        the request, and that exception embeds the raw value, so an
-        unvalidated header could put token material on the drop path. Outer
+        The HTTP client validates outgoing names AND values and raises on
+        the first illegal one — failing the whole listing for this server,
+        and, for values, embedding the raw value (most often a token read
+        with a trailing newline) in the exception, which would put token
+        material on the drop path. So both halves are cleaned here.
+
+        Names: outer whitespace is stripped; what remains must be a legal
+        field name (see _usable_header_name) or the header is dropped with
+        a warning that does NOT echo the name — an arbitrary junk name
+        could hold anything, including a misplaced secret. Values: outer
         whitespace is stripped (the common, recoverable case, so a
-        newline-tailed token still authenticates); a value still holding a
-        control character is genuinely malformed and dropped, logging the
-        header NAME only. Non-string names/values are skipped. A value is
+        newline-tailed token still authenticates); a blank value supplies
+        no credential and is skipped silently, matching
+        usable_header_names; a value still holding a control character is
+        genuinely malformed and dropped, logging the (already validated)
+        header name only. Non-string names/values are skipped. A value is
         never logged.
 
         :param server: The MCP server URL, for the drop warning.
@@ -633,11 +678,19 @@ class GetMcpTool(CodedTool):
         for name, value in headers.items():
             if not isinstance(name, str) or not isinstance(value, str):
                 continue
-            stripped: str = value.strip()
-            if any((ord(char) < 0x20 and char != "\t") or ord(char) == 0x7F for char in stripped):
-                logger.warning("Dropping malformed MCP header %r for %s (illegal value characters).", name, server)
+            usable_name: str | None = GetMcpTool._usable_header_name(name)
+            if usable_name is None:
+                logger.warning("Dropping malformed MCP header for %s (illegal name characters).", server)
                 continue
-            cleaned[name] = stripped
+            stripped: str = value.strip()
+            if not stripped:
+                continue
+            if any((ord(char) < 0x20 and char != "\t") or ord(char) == 0x7F for char in stripped):
+                logger.warning(
+                    "Dropping malformed MCP header %r for %s (illegal value characters).", usable_name, server
+                )
+                continue
+            cleaned[usable_name] = stripped
         return cleaned
 
     @staticmethod

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -17,12 +17,9 @@
 import asyncio
 import logging
 import os
-import re
-import sys
 from math import isfinite
 from pathlib import Path
 from typing import Any
-from typing import NamedTuple
 
 from langchain_core.tools import BaseTool
 from neuro_san.interfaces.coded_tool import CodedTool
@@ -30,6 +27,8 @@ from neuro_san.internals.run_context.langchain.mcp.langchain_mcp_adapter import 
 from neuro_san.internals.run_context.langchain.mcp.mcp_servers_info_restorer import McpServersInfoRestorer
 
 from coded_tools.agent_network_editor.and_logger import AndLogger
+from coded_tools.agent_network_editor.mcp_header_hygiene import McpHeaderHygiene
+from coded_tools.agent_network_editor.mcp_servers_load import McpServersLoad
 from coded_tools.agent_network_editor.shared_process_cache import SharedProcessCache
 from neuro_san_studio import mcp as _mcp_pkg
 
@@ -55,37 +54,7 @@ DEFAULT_MCP_TOOLS_FETCH_TIMEOUT_SECONDS: float = 30.0
 # re-fetched (see _mcp_tools_ttl_seconds for the env-var override).
 DEFAULT_MCP_TOOLS_TTL_SECONDS: float = 300.0
 
-# ExceptionGroup is a builtin from Python 3.11 (the repo minimum is 3.10).
-# On 3.10 the conditional's true branch never evaluates, and isinstance
-# against the empty tuple is simply always False — those interpreters keep
-# the plain str(error) rendering.
-_EXCEPTION_GROUP_TYPES: tuple[type[BaseException], ...] = (BaseExceptionGroup,) if sys.version_info >= (3, 11) else ()
-
-# Legal HTTP field-name charset (RFC 9110 "token"), for validating
-# conversation-supplied header NAMES. The HTTP stack validates outgoing
-# names just like values and raises on the first illegal one — failing the
-# whole request, not just the one header — so names outside this set are
-# dropped before the fetch (see _usable_header_name). Matched with
-# fullmatch(); the + quantifier also rejects an empty (blank) name.
-_HEADER_NAME_RE: re.Pattern[str] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
-
 logger = AndLogger(logging.getLogger(__name__))
-
-
-class _McpServersLoad(NamedTuple):
-    """
-    Result of loading mcp_info.hocon: the file-configured server URLs plus
-    whether the file was read successfully.
-
-    loaded_ok separates an authoritatively empty result (a missing or empty
-    file — there really are no file-configured servers) from a degraded one
-    (the file exists but could not be read or parsed — the set is UNKNOWN).
-    Only the former makes it safe to treat a connected server as
-    client-token; see get_mcp_servers_or_none.
-    """
-
-    urls: list[str]
-    loaded_ok: bool
 
 
 class GetMcpTool(CodedTool):
@@ -163,12 +132,12 @@ class GetMcpTool(CodedTool):
         return (mcp_info_file, SharedProcessCache.stat_modification_time_ns(mcp_info_file))
 
     @staticmethod
-    def _load_mcp_servers() -> "_McpServersLoad":
+    def _load_mcp_servers() -> McpServersLoad:
         """
         Loader for the shared MCP-servers list (runs inside
         SharedProcessCache, off the event loop when reached via aget()).
 
-        :return: A _McpServersLoad. A missing, unreadable, or unparseable
+        :return: A McpServersLoad. A missing, unreadable, or unparseable
                 file returns an empty URL list, which IS published: the
                 fingerprint self-heals it — a missing file flips the
                 modification_time component when it appears, and fixing a
@@ -205,10 +174,10 @@ class GetMcpTool(CodedTool):
             # simply "no file-configured MCP servers right now". But flag the
             # load as FAILED (not an authoritative empty) so a caller that
             # persists a network can tell "no file servers" from "the set is
-            # unknown" and avoid baking a wrong schema (get_mcp_servers_or_none).
+            # unknown" and avoid baking a wrong schema (get_mcp_servers_load).
             logger.warning("Failed to read MCP servers info file %s: %s", mcp_info_file, error)
             loaded_ok = False
-        return _McpServersLoad(servers, loaded_ok)
+        return McpServersLoad(servers, loaded_ok)
 
     # Process-wide cache of the MCP server URLs parsed from mcp_info.hocon.
     # Previously cached per sly_data scope, so a server handling N concurrent
@@ -220,7 +189,7 @@ class GetMcpTool(CodedTool):
     # Locking, publish ordering, and the async once-gate live in
     # SharedProcessCache; access goes through the class by name (not cls) so
     # a hypothetical subclass shares the one cache instead of splitting it.
-    _shared_mcp_servers_cache: SharedProcessCache[_McpServersLoad] = SharedProcessCache(
+    _shared_mcp_servers_cache: SharedProcessCache[McpServersLoad] = SharedProcessCache(
         loader=_load_mcp_servers, fingerprint=_mcp_info_fingerprint
     )
 
@@ -303,67 +272,6 @@ class GetMcpTool(CodedTool):
         return (mcp_info_file, modification_time_ns, ttl, SharedProcessCache.time_bucket(ttl))
 
     @staticmethod
-    def _error_summary(error: BaseException) -> str:
-        """
-        Render an exception for the drop-path warning below.
-
-        The MCP streamable-http client surfaces failures as an anyio
-        ExceptionGroup whose str() is just "unhandled errors in a TaskGroup
-        (1 sub-exception)" — hiding the actual cause (e.g. a 401 from a
-        stale or revoked token), which is the one hint an operator needs to
-        pick the right remedy (re-auth in the client vs. a server outage).
-        Unwrap the group and append the leaf exceptions. Leaf messages from
-        this stack usually carry only the URL and status line, but a header
-        VALIDATION failure (e.g. h11's LocalProtocolError) can embed the raw
-        header value, so the caller validates the values it sends up front
-        (see _sanitized_headers) and redacts them from this string before
-        logging (see _redact_values) — this renderer itself makes no such
-        guarantee.
-
-        :param error: The exception caught by the fetch.
-        :return: str(error), plus "[Type: message; ...]" for group leaves.
-        """
-        if not isinstance(error, _EXCEPTION_GROUP_TYPES):
-            return str(error)
-        leaves: list[str] = []
-        stack: list[BaseException] = list(error.exceptions)
-        while stack:
-            sub: BaseException = stack.pop(0)
-            if isinstance(sub, _EXCEPTION_GROUP_TYPES):
-                stack.extend(sub.exceptions)
-            else:
-                leaves.append(f"{type(sub).__name__}: {sub}")
-        return f"{error} [{'; '.join(leaves)}]"
-
-    @staticmethod
-    def _redact_values(text: str, headers: dict[str, str] | None) -> str:
-        """
-        Mask any header value we sent out of a log-bound string.
-
-        Defense in depth for the drop-path warning. _sanitized_headers
-        already blocks the values that make the HTTP stack raise a
-        value-bearing error, but no exception renderer should be trusted
-        with token material: an illegal header value surfaces as its bytes
-        repr (h11 formats it b'...'), so each value is masked in the plain,
-        str-repr, and bytes-repr forms an error might use — longest first so
-        a shorter form cannot leave a fragment behind.
-
-        :param text: The rendered error summary bound for the log.
-        :param headers: The header dict handed to this fetch, or None (the
-                file-configured path, whose values live in the adapter and
-                are operator-controlled, not client-supplied).
-        :return: text with every non-empty header value we sent masked.
-        """
-        if not headers:
-            return text
-        for value in headers.values():
-            if not isinstance(value, str) or not value:
-                continue
-            for form in (repr(value.encode()), repr(value), value):
-                text = text.replace(form, "***")
-        return text
-
-    @staticmethod
     async def _fetch_tool_descriptions(
         server: str, fetch_timeout: float | None, headers: dict[str, str] | None = None
     ) -> tuple[str, str | None]:
@@ -407,10 +315,10 @@ class GetMcpTool(CodedTool):
             # cap above, connection errors, ...) must not take out every
             # conversation's listing of the healthy servers. This warning is
             # the only trace of a dropped server, so surface group leaves
-            # (see _error_summary).
+            # (see McpHeaderHygiene.error_summary).
             # Redact the values we sent (sly_data path): a header
             # validation error echoes the raw value, which may be a token.
-            summary: str = GetMcpTool._redact_values(GetMcpTool._error_summary(error), headers)
+            summary: str = McpHeaderHygiene.redact_values(McpHeaderHygiene.error_summary(error), headers)
             logger.warning("Error: Failed to load tools from %s. %s", server, summary)
             return server, None
         return server, description
@@ -531,31 +439,32 @@ class GetMcpTool(CodedTool):
                 missing or fails to parse (see the loader for the
                 self-healing semantics). The returned list is a copy, so
                 callers may mutate it without corrupting the shared cache.
-                Callers that PERSIST a network want get_mcp_servers_or_none
+                Callers that PERSIST a network want get_mcp_servers_load
                 instead, so a broken file (unknown set) is not mistaken for
                 "no file servers".
         """
-        return (await GetMcpTool.get_mcp_servers_or_none()) or []
+        return (await GetMcpTool.get_mcp_servers_load()).urls
 
     @staticmethod
-    async def get_mcp_servers_or_none() -> list[str] | None:
+    async def get_mcp_servers_load() -> McpServersLoad:
         """
-        Like get_mcp_servers, but returns None when mcp_info.hocon exists yet
-        could not be read or parsed — as opposed to [] for a genuinely
-        missing or empty file.
+        Like get_mcp_servers, but also reports whether mcp_info.hocon was
+        actually read: loaded_ok is False when the file exists yet could
+        not be read or parsed, as opposed to urls == [] with loaded_ok True
+        for a genuinely missing or empty file.
 
         The file-vs-client classification ("a sly_data server not in the
         file list is client-token") is only sound when the file list is
         complete. When the file failed to load, the set is unknown, so a
-        caller that persists a network uses None here to decline emitting a
-        client-token sly_data_schema rather than bake a wrong one from an
+        caller that persists a network checks loaded_ok to decline emitting
+        a client-token sly_data_schema rather than bake a wrong one from an
         incomplete list (see AgentNetworkPersistenceMiddleware).
 
-        :return: A fresh copy of the MCP server URLs on a successful load
-                (possibly empty), or None when the file could not be read.
+        :return: The load result. urls is a fresh copy, so callers may
+                mutate it without corrupting the shared cache.
         """
-        load: _McpServersLoad = await GetMcpTool._shared_mcp_servers_cache.aget()
-        return list(load.urls) if load.loaded_ok else None
+        load: McpServersLoad = await GetMcpTool._shared_mcp_servers_cache.aget()
+        return McpServersLoad(list(load.urls), load.loaded_ok)
 
     @staticmethod
     def sly_data_http_header_urls(sly_data: dict[str, Any] | None) -> list[str]:
@@ -568,13 +477,14 @@ class GetMcpTool(CodedTool):
         designer's allow.to_downstream forwards the key to this network).
 
         Only http(s) URLs that carry at least one usable header (a legal
-        header name with a non-blank string value — see usable_header_names)
-        are returned; everything else is skipped rather than raising, since
-        chat clients control this input. That covers a missing/non-dict
-        http_headers, a non-string or non-http(s) key (which must never
-        reach URL validation as an accepted reference), a non-dict header
-        value, and a header-less or blank-valued entry (which supplies no
-        credential to fetch with, declare, or gate on).
+        header name with a non-blank string value — see
+        McpHeaderHygiene.usable_header_names) are returned; everything else
+        is skipped rather than raising, since chat clients control this
+        input. That covers a missing/non-dict http_headers, a non-string or
+        non-http(s) key (which must never reach URL validation as an
+        accepted reference), a non-dict header value, and a header-less or
+        blank-valued entry (which supplies no credential to fetch with,
+        declare, or gate on).
 
         :param sly_data: The conversation's sly_data (may be None).
         :return: URLs in first-appearance order. Values are URLs only — no
@@ -589,109 +499,8 @@ class GetMcpTool(CodedTool):
             if isinstance(url, str)
             and url.startswith(("http://", "https://"))
             and isinstance(headers, dict)
-            and GetMcpTool.usable_header_names(headers)
+            and McpHeaderHygiene.usable_header_names(headers)
         ]
-
-    @staticmethod
-    def usable_header_names(headers: dict[Any, Any]) -> list[str]:
-        """
-        Get the header names in a per-URL header dict that supply a usable
-        credential: a legal HTTP header name (see _usable_header_name)
-        whose value is a string that is not blank after stripping.
-
-        Single owner of what counts as a usable client-supplied header.
-        Three call sites keep the story consistent: URL classification
-        (sly_data_http_header_urls treats a server as client-token only
-        when this is non-empty), the fetch path (_sanitized_headers sends
-        exactly these names, values cleaned), and the persisted contract
-        (AgentNetworkPersistenceMiddleware declares these names in the
-        generated sly_data_schema) — so a network never requires a header
-        that would not actually be sent.
-
-        :param headers: A per-URL header dict from sly_data["http_headers"].
-        :return: The stripped names in first-appearance order, deduped (two
-                raw spellings of one name collapse into the first). Names
-                only — no header value leaves this function.
-        """
-        names: dict[str, None] = {}
-        for name, value in headers.items():
-            usable_name: str | None = GetMcpTool._usable_header_name(name)
-            if usable_name is not None and isinstance(value, str) and value.strip():
-                names[usable_name] = None
-        return list(names)
-
-    @staticmethod
-    def _usable_header_name(name: Any) -> str | None:
-        """
-        Validate and normalize one conversation-supplied header name.
-
-        Outer whitespace is stripped (recoverable, the same treatment
-        values get). What remains must be a legal HTTP field name (RFC
-        9110 token — see _HEADER_NAME_RE): the HTTP stack validates names
-        on send exactly like values, so a blank name or one holding a
-        colon, space, control, or non-ASCII character would fail the whole
-        request rather than just this header.
-
-        :param name: One key from a per-URL header dict.
-        :return: The stripped name, or None when the name is not a string
-                or not a legal field name.
-        """
-        if not isinstance(name, str):
-            return None
-        stripped: str = name.strip()
-        if not _HEADER_NAME_RE.fullmatch(stripped):
-            return None
-        return stripped
-
-    @staticmethod
-    def _sanitized_headers(server: str, headers: dict[str, Any]) -> dict[str, str]:
-        """
-        Clean a conversation's per-URL header dict before it reaches the
-        HTTP stack.
-
-        The HTTP client validates outgoing names AND values and raises on
-        the first illegal one — failing the whole listing for this server,
-        and, for values, embedding the raw value (most often a token read
-        with a trailing newline) in the exception, which would put token
-        material on the drop path. So both halves are cleaned here.
-
-        Names: outer whitespace is stripped; what remains must be a legal
-        field name (see _usable_header_name) or the header is dropped with
-        a warning that does NOT echo the name — an arbitrary junk name
-        could hold anything, including a misplaced secret. Values: outer
-        whitespace is stripped (the common, recoverable case, so a
-        newline-tailed token still authenticates); a blank value supplies
-        no credential and is skipped silently, matching
-        usable_header_names; a value still holding a control character is
-        genuinely malformed and dropped, logging the (already validated)
-        header name only. Non-string names/values are skipped. A value is
-        never logged.
-
-        :param server: The MCP server URL, for the drop warning.
-        :param headers: The conversation's per-URL header dict (from
-                sly_data["http_headers"][server]).
-        :return: The cleaned headers to hand to the adapter; may be empty,
-                in which case the fetch runs unauthenticated and a private
-                server simply drops out of the listing (attempt-and-drop).
-        """
-        cleaned: dict[str, str] = {}
-        for name, value in headers.items():
-            if not isinstance(name, str) or not isinstance(value, str):
-                continue
-            usable_name: str | None = GetMcpTool._usable_header_name(name)
-            if usable_name is None:
-                logger.warning("Dropping malformed MCP header for %s (illegal name characters).", server)
-                continue
-            stripped: str = value.strip()
-            if not stripped:
-                continue
-            if any((ord(char) < 0x20 and char != "\t") or ord(char) == 0x7F for char in stripped):
-                logger.warning(
-                    "Dropping malformed MCP header %r for %s (illegal value characters).", usable_name, server
-                )
-                continue
-            cleaned[usable_name] = stripped
-        return cleaned
 
     @staticmethod
     async def _fetch_sly_data_tool_descriptions(sly_data: dict[str, Any], exclude: set[str]) -> dict[str, str]:
@@ -722,13 +531,14 @@ class GetMcpTool(CodedTool):
         http_headers: dict[str, Any] = sly_data["http_headers"]
         fetch_timeout: float | None = GetMcpTool._mcp_tools_fetch_timeout_seconds()
         # return_exceptions=False is safe here because
-        # _fetch_tool_descriptions swallows its own errors. Values are
-        # sanitized per URL first (see _sanitized_headers) so a malformed
-        # header can neither raise a value-bearing error nor reach a log.
+        # _fetch_tool_descriptions swallows its own errors. Headers are
+        # sanitized per URL first (see McpHeaderHygiene.sanitized_headers)
+        # so a malformed header can neither raise a value-bearing error nor
+        # reach a log.
         results = await asyncio.gather(
             *[
                 GetMcpTool._fetch_tool_descriptions(
-                    url, fetch_timeout, GetMcpTool._sanitized_headers(url, http_headers[url])
+                    url, fetch_timeout, McpHeaderHygiene.sanitized_headers(url, http_headers[url])
                 )
                 for url in urls
             ]

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -15,6 +15,7 @@
 # END COPYRIGHT
 
 import asyncio
+import json
 import logging
 import os
 from math import isfinite
@@ -34,6 +35,15 @@ from neuro_san_studio import mcp as _mcp_pkg
 # Resolved via the imported package's __file__ so it works both in-repo and
 # after `pip install` on every platform. Mirrors run.py.
 BUNDLED_MCP_INFO_FILE: Path = Path(_mcp_pkg.__file__).parent / "mcp_info.hocon"
+
+# Where nsflow persists its MCP OAuth credentials (see nsflow's
+# mcp_token_storage.py): a tokens.json keyed by MCP server URL, written
+# atomically, in NSFLOW_MCP_STORAGE_DIR or the same default nsflow uses.
+# Reading it lets the designer list tools from OAuth-protected MCP servers
+# whose bearer tokens were obtained by the nsflow client on this machine.
+NSFLOW_MCP_STORAGE_DIR_ENV: str = "NSFLOW_MCP_STORAGE_DIR"
+DEFAULT_NSFLOW_MCP_STORAGE_DIR: str = "~/.nsflow/mcp_oauth"
+NSFLOW_MCP_TOKENS_FILE_NAME: str = "tokens.json"
 
 # Default cap on how long one MCP server may take to answer a tool listing
 # (see _mcp_tools_fetch_timeout_seconds for the env-var override). The
@@ -88,53 +98,141 @@ class GetMcpTool(CodedTool):
         return str(BUNDLED_MCP_INFO_FILE)
 
     @staticmethod
-    def _mcp_info_fingerprint() -> tuple[str, int | None]:
+    def get_nsflow_tokens_file() -> str:
+        """Resolve the path of nsflow's MCP OAuth token store at call time.
+
+        NSFLOW_MCP_STORAGE_DIR (expanduser'd, mirroring nsflow's
+        _default_storage_dir) when non-empty, else ~/.nsflow/mcp_oauth;
+        the file inside it is tokens.json.
+
+        :return: The tokens.json path. Never raises — this resolver runs
+                inside fingerprint probes; when no home directory can be
+                resolved the unexpanded path is returned, which simply
+                stats to None ("no token store").
+        """
+        base: str = os.getenv(NSFLOW_MCP_STORAGE_DIR_ENV) or DEFAULT_NSFLOW_MCP_STORAGE_DIR
+        try:
+            return str(Path(base).expanduser() / NSFLOW_MCP_TOKENS_FILE_NAME)
+        except (OSError, RuntimeError):
+            # expanduser raises when the home directory cannot be resolved.
+            return str(Path(base) / NSFLOW_MCP_TOKENS_FILE_NAME)
+
+    @staticmethod
+    def _load_storage_access_tokens() -> dict[str, str]:
+        """
+        Read nsflow's MCP OAuth token store into {server URL: access token}.
+
+        An entry is included iff it is a dict whose "tokens" value is a dict
+        holding a non-empty string "access_token" — the minimum needed to
+        attempt an authenticated tool listing. Entries marked needs_reauth
+        or past their expires_at are deliberately NOT filtered out here:
+        the policy is attempt-and-drop — a stale token fails its listing
+        fetch downstream and that server is simply omitted from the result,
+        exactly like any other unreachable server. (A cheap expires_at
+        pre-skip would save one doomed round trip, but it is intentionally
+        not implemented so attempt-and-drop stays the single behavior.)
+
+        A missing file just means nsflow has no stored connections — not
+        worth a warning. Unreadable or unparsable files degrade to {} with
+        a warning; nsflow writes the file atomically (os.replace), so torn
+        reads are impossible and no locking is needed for a read.
+
+        Token values must never be logged, and they never leave this class
+        except as Authorization headers on MCP requests.
+
+        :return: {server URL: access token}; {} when there is no usable store.
+        """
+        tokens_file: str = GetMcpTool.get_nsflow_tokens_file()
+        try:
+            with open(tokens_file, "r", encoding="utf-8") as handle:
+                blob: Any = json.load(handle)
+        except FileNotFoundError:
+            return {}
+        except (OSError, ValueError) as error:
+            logger.warning("Could not read nsflow MCP token store at %s: %s", tokens_file, error)
+            return {}
+        if not isinstance(blob, dict):
+            logger.warning("Ignoring nsflow MCP token store at %s: top level is not an object", tokens_file)
+            return {}
+
+        access_tokens: dict[str, str] = {}
+        for server_url, entry in blob.items():
+            if not isinstance(entry, dict):
+                continue
+            tokens: Any = entry.get("tokens")
+            if not isinstance(tokens, dict):
+                continue
+            access_token: Any = tokens.get("access_token")
+            if isinstance(access_token, str) and access_token:
+                access_tokens[server_url] = access_token
+        return access_tokens
+
+    @staticmethod
+    def _mcp_sources_fingerprint() -> tuple[str, int | None, str, int | None]:
         """
         Freshness probe for the shared MCP-servers cache (see
-        SharedProcessCache): the cached list is served only while this value
-        is unchanged. Unlike the designer manifest there is no time bucket:
-        mcp_info.hocon is a plain config file with no `include`s and nothing
-        writes it at runtime, so the two components cover everything the
-        probe can see —
+        SharedProcessCache): the cached value is served only while this
+        value is unchanged. It covers both sources of the union the cache
+        holds — mcp_info.hocon and nsflow's tokens.json. Unlike the
+        designer manifest there is no time bucket: both are plain files
+        whose every relevant change touches path or modification time —
 
-        * the resolved path — an env-var change or the cwd-scaffolded file
+        * the resolved paths — an env-var change or the cwd-scaffolded file
           appearing takes effect on the next read;
-        * the file's modification_time — a direct edit invalidates immediately, and a
-          missing file (modification_time None) self-heals the moment it appears.
+        * each file's modification_time — a direct edit invalidates
+          immediately, and a missing file (modification_time None)
+          self-heals the moment it appears. nsflow rewrites tokens.json on
+          every connect/refresh/disconnect, so a new OAuth connection is
+          picked up promptly.
 
         Two changes are invisible to this probe: HOCON `${...}` references
-        inside the file resolve against the environment at parse time, so
-        changing THOSE env vars alters the parse result without touching
+        inside mcp_info.hocon resolve against the environment at parse time,
+        so changing THOSE env vars alters the parse result without touching
         path or modification_time; and LangChainMcpAdapter keeps its own copy of the
         servers info, frozen at its first load — a file edit refreshes
         which URLs this class serves, but not the connection details the
         adapter already latched. Both heal on process restart (or on the
         modification_time change of the next file edit, for the first).
 
-        :return: (path, modification_time_ns or None) tuple.
+        :return: (mcp_info path, its modification_time_ns or None,
+                tokens.json path, its modification_time_ns or None) tuple.
         """
         mcp_info_file: str = GetMcpTool.get_mcp_info_file()
-        return (mcp_info_file, SharedProcessCache.stat_modification_time_ns(mcp_info_file))
+        tokens_file: str = GetMcpTool.get_nsflow_tokens_file()
+        return (
+            mcp_info_file,
+            SharedProcessCache.stat_modification_time_ns(mcp_info_file),
+            tokens_file,
+            SharedProcessCache.stat_modification_time_ns(tokens_file),
+        )
 
     @staticmethod
-    def _load_mcp_servers() -> list[str]:
+    def _load_mcp_server_infos() -> dict[str, dict[str, Any]]:
         """
-        Loader for the shared MCP-servers list (runs inside
+        Loader for the shared MCP-servers cache (runs inside
         SharedProcessCache, off the event loop when reached via aget()).
 
-        :return: List of MCP server URLs from mcp_info.hocon. A missing,
-                unreadable, or unparseable file returns an empty list, which
-                IS published: the fingerprint self-heals it — a missing file
-                flips the modification_time component when it appears, and fixing a
-                broken file changes its modification_time — so nothing can pin an empty
-                list past the next change to the file itself (env-var
-                references INSIDE the file are the one exception; see
-                _mcp_info_fingerprint).
+        :return: The UNION of mcp_info.hocon entries and nsflow token-store
+                entries holding an access token, as
+                {server URL: {"has_file_headers": bool, "access_token": str | None}}.
+                has_file_headers records whether mcp_info.hocon configures
+                http_headers for the URL (i.e. the server is authenticated
+                file-side and needs no client-supplied token); access_token
+                is the nsflow OAuth bearer token when one is stored. A
+                missing, unreadable, or unparseable mcp_info.hocon degrades
+                to the token-store half alone, which IS published: the
+                fingerprint self-heals it — a missing file flips the
+                modification_time component when it appears, and fixing a
+                broken file changes its modification_time — so nothing can pin a degraded
+                value past the next change to the files themselves (env-var
+                references INSIDE mcp_info.hocon are the one exception; see
+                _mcp_sources_fingerprint). NOTE: values hold token material —
+                never log this mapping.
         """
         mcp_info_file: str = GetMcpTool.get_mcp_info_file()
         logger.info("MCP servers info file: %s", mcp_info_file)
 
-        servers: list[str] = []
+        infos: dict[str, dict[str, Any]] = {}
         try:
             # McpServersInfoRestorer is constructed with must_exist=False, so
             # a missing file comes back as None rather than an exception.
@@ -142,26 +240,44 @@ class GetMcpTool(CodedTool):
             if info is None:
                 logger.warning("MCP servers info file not found at %s. No MCP Servers will be used.", mcp_info_file)
                 info = {}
-            servers = list(info.keys())
+            for server_url, spec in info.items():
+                headers: Any = spec.get("http_headers") if isinstance(spec, dict) else None
+                infos[server_url] = {
+                    "has_file_headers": isinstance(headers, dict) and bool(headers),
+                    "access_token": None,
+                }
         except (OSError, ValueError) as error:
             # neuro-san re-wraps HOCON parse errors as ValueError; OSError
             # covers a file that exists but cannot be read (permissions, I/O
             # failure). Neither may escape: a loader exception would fail
             # every caller sharing this load, when the healthy answer is
-            # simply "no MCP servers right now".
+            # simply "no file-configured MCP servers right now".
             logger.warning("Failed to read MCP servers info file %s: %s", mcp_info_file, error)
-        return servers
 
-    # Process-wide cache of the MCP server URLs parsed from mcp_info.hocon.
-    # Previously cached per sly_data scope, so a server handling N concurrent
-    # conversations re-parsed the same HOCON N times, on the event loop.
-    # The (path, modification_time) fingerprint picks up env-var changes and file edits
-    # immediately; there is no time bucket because nothing changes this file
-    # at runtime. Locking, publish ordering, and the async once-gate live in
-    # SharedProcessCache; access goes through the class by name (not cls) so
-    # a hypothetical subclass shares the one cache instead of splitting it.
-    _shared_mcp_servers_cache: SharedProcessCache[list[str]] = SharedProcessCache(
-        loader=_load_mcp_servers, fingerprint=_mcp_info_fingerprint
+        # Overlay nsflow's OAuth connections. A URL present in both sources
+        # keeps has_file_headers=True and gains the token: the token wins at
+        # fetch time (mirroring runtime sly_data-over-file precedence), while
+        # has_file_headers still marks the server as usable without one.
+        for server_url, access_token in GetMcpTool._load_storage_access_tokens().items():
+            entry: dict[str, Any] = infos.setdefault(server_url, {"has_file_headers": False, "access_token": None})
+            entry["access_token"] = access_token
+        return infos
+
+    # Process-wide cache of MCP server info: the union of the URLs parsed
+    # from mcp_info.hocon and the OAuth connections in nsflow's token store,
+    # with per-URL auth metadata (see _load_mcp_server_infos; the values
+    # hold token material — never log them). Previously cached per sly_data
+    # scope, so a server handling N concurrent conversations re-parsed the
+    # same HOCON N times, on the event loop.
+    # The (paths, modification_times) fingerprint picks up env-var changes
+    # and edits to either file immediately; there is no time bucket because
+    # nothing changes mcp_info.hocon at runtime and every nsflow token write
+    # touches tokens.json's modification time. Locking, publish ordering,
+    # and the async once-gate live in SharedProcessCache; access goes
+    # through the class by name (not cls) so a hypothetical subclass shares
+    # the one cache instead of splitting it.
+    _shared_mcp_servers_cache: SharedProcessCache[dict[str, dict[str, Any]]] = SharedProcessCache(
+        loader=_load_mcp_server_infos, fingerprint=_mcp_sources_fingerprint
     )
 
     @staticmethod
@@ -224,45 +340,55 @@ class GetMcpTool(CodedTool):
         return max(ttl, 2 * fetch_cap)
 
     @staticmethod
-    def _mcp_tools_fingerprint() -> tuple[str, int | None, float, int]:
+    def _mcp_tools_fingerprint() -> tuple[str, int | None, str, int | None, float, int]:
         """
         Freshness probe for the shared tool-descriptions cache: the
-        MCP-servers-list fingerprint (so an mcp_info.hocon edit refreshes the
-        listings immediately) plus the TTL and a time bucket that rolls once
-        per TTL window (see _mcp_tools_ttl_seconds; frozen when TTL <= 0).
+        MCP-sources fingerprint (so an mcp_info.hocon edit or an nsflow
+        OAuth connect/refresh refreshes the listings immediately) plus the
+        TTL and a time bucket that rolls once per TTL window (see
+        _mcp_tools_ttl_seconds; frozen when TTL <= 0).
         The TTL value itself rides along because bucket numbers from
         different TTL regimes are not comparable — after an env-var change,
         bucket N under the new TTL can collide with bucket N under the old
         one and revive a stale entry; carrying the TTL makes any change to
         it an immediate miss instead.
 
-        :return: (path, modification_time_ns or None, ttl, time bucket) tuple.
+        :return: (*_mcp_sources_fingerprint(), ttl, time bucket) tuple.
         """
-        mcp_info_file, modification_time_ns = GetMcpTool._mcp_info_fingerprint()
         ttl: float = GetMcpTool._mcp_tools_ttl_seconds()
-        return (mcp_info_file, modification_time_ns, ttl, SharedProcessCache.time_bucket(ttl))
+        return (*GetMcpTool._mcp_sources_fingerprint(), ttl, SharedProcessCache.time_bucket(ttl))
 
     @staticmethod
-    async def _fetch_tool_descriptions(server: str, fetch_timeout: float | None) -> tuple[str, str | None]:
+    async def _fetch_tool_descriptions(
+        server: str, fetch_timeout: float | None, headers: dict[str, str] | None = None
+    ) -> tuple[str, str | None]:
         """
         Fetch one MCP server's tool listing and flatten it into a
         description string, on the private event loop that
-        _load_mcp_tool_descriptions runs. LangChainMcpAdapter resolves the
-        server's connection details from its own copy of the servers info
-        (loaded once per process — see _mcp_info_fingerprint), opens a
-        session, and lists the tools.
+        _load_mcp_tool_descriptions runs. With headers=None,
+        LangChainMcpAdapter resolves the server's connection details from
+        its own copy of the servers info (loaded once per process — see
+        _mcp_sources_fingerprint), opens a session, and lists the tools.
+        Passing headers overrides the adapter's file-configured
+        http_headers for this request — used to send an nsflow OAuth bearer
+        token, mirroring the runtime precedence of sly_data headers over
+        the servers-info file.
 
         :param server: The MCP server URL.
         :param fetch_timeout: Per-server cap in seconds, or None for no cap
                 (see _mcp_tools_fetch_timeout_seconds).
+        :param headers: Optional HTTP headers for the MCP requests. Holds
+                token material when set — never log it.
         :return: (server, newline-joined tool descriptions) on success,
                 (server, None) on any failure — this never raises, so one
-                broken server cannot take out the whole gathered batch.
+                broken server cannot take out the whole gathered batch. A
+                stale or revoked token is just such a failure: its server
+                is dropped from this round's listing (attempt-and-drop).
         """
         logger.info("MCP Server: %s", server)
         try:
             tools: list[BaseTool] = await asyncio.wait_for(
-                LangChainMcpAdapter().get_mcp_tools(server), timeout=fetch_timeout
+                LangChainMcpAdapter().get_mcp_tools(server, headers=headers), timeout=fetch_timeout
             )
             logger.info("Successfully loaded the following tools: %s", str(tools))
             # Flatten the descriptions INSIDE the try: a malformed tool
@@ -282,22 +408,30 @@ class GetMcpTool(CodedTool):
         return server, description
 
     @staticmethod
-    async def _fetch_all_tool_descriptions(servers: list[str]) -> dict[str, str]:
+    async def _fetch_all_tool_descriptions(server_infos: dict[str, dict[str, Any]]) -> dict[str, str]:
         """
-        Fetch every configured server's tool listing concurrently; the
+        Fetch every known server's tool listing concurrently; the
         entry point of the private event loop that
         _load_mcp_tool_descriptions runs.
 
-        :param servers: The MCP server URLs from the shared servers cache.
+        :param server_infos: The {server URL: auth info} union from the
+                shared servers cache (see _load_mcp_server_infos). Holds
+                token material — never log it.
         :return: dict mapping each server URL that answered to its tools'
                 descriptions; servers that failed are absent.
         """
         fetch_timeout: float | None = GetMcpTool._mcp_tools_fetch_timeout_seconds()
+        coroutines: list[Any] = []
+        for server, entry in server_infos.items():
+            access_token: Any = entry.get("access_token") if isinstance(entry, dict) else None
+            # A stored nsflow OAuth token is sent as the Authorization
+            # header and takes precedence over any file-configured headers
+            # (headers=None falls back to those inside the adapter).
+            headers: dict[str, str] | None = {"Authorization": f"Bearer {access_token}"} if access_token else None
+            coroutines.append(GetMcpTool._fetch_tool_descriptions(server, fetch_timeout, headers))
         # return_exceptions=False is safe here because
         # _fetch_tool_descriptions swallows its own errors.
-        results = await asyncio.gather(
-            *[GetMcpTool._fetch_tool_descriptions(server, fetch_timeout) for server in servers]
-        )
+        results = await asyncio.gather(*coroutines)
         return {server: description for server, description in results if description is not None}
 
     @staticmethod
@@ -329,11 +463,11 @@ class GetMcpTool(CodedTool):
                 descriptions filler's all-empty guard.
         """
         # Already in a worker thread here, so the blocking get() is fine.
-        servers: list[str] = GetMcpTool._shared_mcp_servers_cache.get()
-        descriptions: dict[str, str] = asyncio.run(GetMcpTool._fetch_all_tool_descriptions(servers))
-        if servers and not descriptions and GetMcpTool._mcp_tools_ttl_seconds() <= 0:
+        server_infos: dict[str, dict[str, Any]] = GetMcpTool._shared_mcp_servers_cache.get()
+        descriptions: dict[str, str] = asyncio.run(GetMcpTool._fetch_all_tool_descriptions(server_infos))
+        if server_infos and not descriptions and GetMcpTool._mcp_tools_ttl_seconds() <= 0:
             raise RuntimeError(
-                f"all {len(servers)} MCP tool-listing fetches failed and time-based refresh is disabled; "
+                f"all {len(server_infos)} MCP tool-listing fetches failed and time-based refresh is disabled; "
                 "treating as a failed load"
             )
         return descriptions
@@ -343,8 +477,9 @@ class GetMcpTool(CodedTool):
     # scope, so every conversation paid the full network round-trip to every
     # server (sequentially). The sources are external servers with no local
     # change signal, so freshness is time-based: the fingerprint reuses the
-    # mcp_info.hocon (path, modification_time) probe — a config edit refreshes
-    # immediately — plus a TTL bucket (default 300s, see
+    # MCP-sources (paths, modification_times) probe — a config edit or an
+    # nsflow OAuth token write refreshes immediately — plus a TTL bucket
+    # (default 300s, see
     # _mcp_tools_ttl_seconds) that bounds both staleness and how long a
     # failed fetch's empty/partial result can be served. (With time-based
     # refresh disabled, an all-failed fetch raises instead of publishing —
@@ -380,19 +515,44 @@ class GetMcpTool(CodedTool):
     @staticmethod
     async def get_mcp_servers() -> list[str]:
         """
-        Get the list of MCP server URLs from mcp_info.hocon.
+        Get the list of known MCP server URLs: the union of mcp_info.hocon
+        entries and the OAuth connections stored by nsflow (see
+        _load_mcp_server_infos).
 
         Used by callers (e.g. middleware) that need to validate MCP
-        references. Reads only the config file, not the servers — and at
-        most once per process per config change, off the event loop, shared
-        by concurrent cold callers.
+        references. Reads only local files, not the servers — and at
+        most once per process per source-file change, off the event loop,
+        shared by concurrent cold callers.
 
-        :return: List of MCP server URLs, or an empty list if the file is
-                missing or fails to parse (see the loader for the
-                self-healing semantics). The returned list is a copy, so
-                callers may mutate it without corrupting the shared cache.
+        :return: List of MCP server URLs, or an empty list if neither
+                source yields any (see the loader for the self-healing
+                semantics). The returned list is a copy, so callers may
+                mutate it without corrupting the shared cache.
         """
         return list(await GetMcpTool._shared_mcp_servers_cache.aget())
+
+    @staticmethod
+    async def get_mcp_servers_auth_info() -> dict[str, bool]:
+        """
+        Get, for every known MCP server URL, whether it needs a
+        client-supplied token: True iff mcp_info.hocon configures no
+        http_headers for it (servers known only from nsflow's OAuth token
+        store are therefore always True). Used to build the data-driven
+        `required` list of the sly_data_schema emitted into generated
+        agent networks.
+
+        Same cache and fingerprint as get_mcp_servers(), so the two views
+        are always consistent. Values are bools only — no token material
+        leaves this class.
+
+        :return: {server URL: needs_client_token}. A fresh dict, so callers
+                may mutate it without corrupting the shared cache.
+        """
+        infos: dict[str, dict[str, Any]] = await GetMcpTool._shared_mcp_servers_cache.aget()
+        return {
+            server_url: not (isinstance(entry, dict) and entry.get("has_file_headers"))
+            for server_url, entry in infos.items()
+        }
 
     @staticmethod
     async def get_mcp_tool_descriptions() -> dict[str, str]:

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -21,6 +21,7 @@ import sys
 from math import isfinite
 from pathlib import Path
 from typing import Any
+from typing import NamedTuple
 
 from langchain_core.tools import BaseTool
 from neuro_san.interfaces.coded_tool import CodedTool
@@ -60,6 +61,22 @@ DEFAULT_MCP_TOOLS_TTL_SECONDS: float = 300.0
 _EXCEPTION_GROUP_TYPES: tuple[type[BaseException], ...] = (BaseExceptionGroup,) if sys.version_info >= (3, 11) else ()
 
 logger = AndLogger(logging.getLogger(__name__))
+
+
+class _McpServersLoad(NamedTuple):
+    """
+    Result of loading mcp_info.hocon: the file-configured server URLs plus
+    whether the file was read successfully.
+
+    loaded_ok separates an authoritatively empty result (a missing or empty
+    file — there really are no file-configured servers) from a degraded one
+    (the file exists but could not be read or parsed — the set is UNKNOWN).
+    Only the former makes it safe to treat a connected server as
+    client-token; see get_mcp_servers_or_none.
+    """
+
+    urls: list[str]
+    loaded_ok: bool
 
 
 class GetMcpTool(CodedTool):
@@ -137,15 +154,15 @@ class GetMcpTool(CodedTool):
         return (mcp_info_file, SharedProcessCache.stat_modification_time_ns(mcp_info_file))
 
     @staticmethod
-    def _load_mcp_servers() -> list[str]:
+    def _load_mcp_servers() -> "_McpServersLoad":
         """
         Loader for the shared MCP-servers list (runs inside
         SharedProcessCache, off the event loop when reached via aget()).
 
-        :return: List of MCP server URLs from mcp_info.hocon. A missing,
-                unreadable, or unparseable file returns an empty list, which
-                IS published: the fingerprint self-heals it — a missing file
-                flips the modification_time component when it appears, and fixing a
+        :return: A _McpServersLoad. A missing, unreadable, or unparseable
+                file returns an empty URL list, which IS published: the
+                fingerprint self-heals it — a missing file flips the
+                modification_time component when it appears, and fixing a
                 broken file changes its modification_time — so nothing can pin an empty
                 list past the next change to the file itself (env-var
                 references INSIDE the file are the one exception; see
@@ -155,13 +172,16 @@ class GetMcpTool(CodedTool):
         logger.info("MCP servers info file: %s", mcp_info_file)
 
         servers: list[str] = []
+        loaded_ok: bool = True
         try:
             # McpServersInfoRestorer is constructed with must_exist=False, so
             # a missing file comes back as None rather than an exception.
             info: dict[str, Any] = McpServersInfoRestorer().restore(file_reference=mcp_info_file)
             if info is None:
                 # Servers supplied per-conversation via sly_data http_headers
-                # (if any) are unaffected — only the file half is empty.
+                # (if any) are unaffected — only the file half is empty. A
+                # missing file is an authoritative empty (loaded_ok stays
+                # True): there genuinely are no file-configured servers.
                 logger.warning(
                     "MCP servers info file not found at %s. No file-configured MCP servers will be used.",
                     mcp_info_file,
@@ -173,9 +193,13 @@ class GetMcpTool(CodedTool):
             # covers a file that exists but cannot be read (permissions, I/O
             # failure). Neither may escape: a loader exception would fail
             # every caller sharing this load, when the healthy answer is
-            # simply "no file-configured MCP servers right now".
+            # simply "no file-configured MCP servers right now". But flag the
+            # load as FAILED (not an authoritative empty) so a caller that
+            # persists a network can tell "no file servers" from "the set is
+            # unknown" and avoid baking a wrong schema (get_mcp_servers_or_none).
             logger.warning("Failed to read MCP servers info file %s: %s", mcp_info_file, error)
-        return servers
+            loaded_ok = False
+        return _McpServersLoad(servers, loaded_ok)
 
     # Process-wide cache of the MCP server URLs parsed from mcp_info.hocon.
     # Previously cached per sly_data scope, so a server handling N concurrent
@@ -187,7 +211,7 @@ class GetMcpTool(CodedTool):
     # Locking, publish ordering, and the async once-gate live in
     # SharedProcessCache; access goes through the class by name (not cls) so
     # a hypothetical subclass shares the one cache instead of splitting it.
-    _shared_mcp_servers_cache: SharedProcessCache[list[str]] = SharedProcessCache(
+    _shared_mcp_servers_cache: SharedProcessCache[_McpServersLoad] = SharedProcessCache(
         loader=_load_mcp_servers, fingerprint=_mcp_info_fingerprint
     )
 
@@ -430,7 +454,7 @@ class GetMcpTool(CodedTool):
                 descriptions filler's all-empty guard.
         """
         # Already in a worker thread here, so the blocking get() is fine.
-        servers: list[str] = GetMcpTool._shared_mcp_servers_cache.get()
+        servers: list[str] = GetMcpTool._shared_mcp_servers_cache.get().urls
         descriptions: dict[str, str] = asyncio.run(GetMcpTool._fetch_all_tool_descriptions(servers))
         if servers and not descriptions and GetMcpTool._mcp_tools_ttl_seconds() <= 0:
             raise RuntimeError(
@@ -498,8 +522,31 @@ class GetMcpTool(CodedTool):
                 missing or fails to parse (see the loader for the
                 self-healing semantics). The returned list is a copy, so
                 callers may mutate it without corrupting the shared cache.
+                Callers that PERSIST a network want get_mcp_servers_or_none
+                instead, so a broken file (unknown set) is not mistaken for
+                "no file servers".
         """
-        return list(await GetMcpTool._shared_mcp_servers_cache.aget())
+        return (await GetMcpTool.get_mcp_servers_or_none()) or []
+
+    @staticmethod
+    async def get_mcp_servers_or_none() -> list[str] | None:
+        """
+        Like get_mcp_servers, but returns None when mcp_info.hocon exists yet
+        could not be read or parsed — as opposed to [] for a genuinely
+        missing or empty file.
+
+        The file-vs-client classification ("a sly_data server not in the
+        file list is client-token") is only sound when the file list is
+        complete. When the file failed to load, the set is unknown, so a
+        caller that persists a network uses None here to decline emitting a
+        client-token sly_data_schema rather than bake a wrong one from an
+        incomplete list (see AgentNetworkPersistenceMiddleware).
+
+        :return: A fresh copy of the MCP server URLs on a successful load
+                (possibly empty), or None when the file could not be read.
+        """
+        load: _McpServersLoad = await GetMcpTool._shared_mcp_servers_cache.aget()
+        return list(load.urls) if load.loaded_ok else None
 
     @staticmethod
     def sly_data_http_header_urls(sly_data: dict[str, Any] | None) -> list[str]:

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -103,23 +103,33 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #    Used by: GetSubnetwork.get_subnetworks() (the coded tool path).
     #
     # 5. Shared MCP servers
-    #    Holds:   the list of MCP server URLs parsed from mcp_info.hocon
+    #    Holds:   the {server URL: {"has_file_headers", "access_token"}}
+    #             union of the servers parsed from mcp_info.hocon
     #             (MCP_SERVERS_INFO_FILE, the cwd scaffold, or the bundled
-    #             copy — see GetMcpTool.get_mcp_info_file).
-    #    Lives:   get_mcp_tool.GetMcpTool (async get_mcp_servers)
-    #    Expiry:  resolved path or modification_time change — no time bucket, since
-    #             nothing writes the file at runtime.
+    #             copy — see GetMcpTool.get_mcp_info_file) and the OAuth
+    #             connections in nsflow's token store
+    #             (NSFLOW_MCP_STORAGE_DIR/tokens.json, default
+    #             ~/.nsflow/mcp_oauth — see GetMcpTool.get_nsflow_tokens_file).
+    #             Values hold token material — never log them.
+    #    Lives:   get_mcp_tool.GetMcpTool (async get_mcp_servers /
+    #             get_mcp_servers_auth_info)
+    #    Expiry:  either file's resolved path or modification_time change —
+    #             no time bucket, since nothing writes mcp_info.hocon at
+    #             runtime and every nsflow token write touches tokens.json.
     #    Used by: GetMcpTool (input to the tool-descriptions cache below);
     #             agent_network_structure_validation_middleware
     #             .AgentNetworkStructureValidationMiddleware.validate();
     #             agent_network_persistence_middleware.AgentNetworkPersistenceMiddleware
-    #             ._assemble_and_persist().
+    #             ._assemble_and_persist() (via get_mcp_servers_auth_info,
+    #             which drives the generated sly_data_schema).
     #
     # 6. Shared MCP tool descriptions
     #    Holds:   the {server URL: tool descriptions} mapping fetched from
-    #             the MCP servers themselves (network calls).
+    #             the MCP servers themselves (network calls, sent with a
+    #             stored nsflow OAuth bearer token when one exists).
     #    Lives:   get_mcp_tool.GetMcpTool (async get_mcp_tool_descriptions)
-    #    Expiry:  mcp_info.hocon path/modification_time change, or one
+    #    Expiry:  mcp_info.hocon or tokens.json path/modification_time
+    #             change, or one
     #             AGENT_NETWORK_DESIGNER_MCP_TOOLS_TTL_SECONDS window
     #             (default 300s, clamped to at least twice the per-server
     #             fetch cap; <= 0 disables time-based refresh) — the

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -103,33 +103,31 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #    Used by: GetSubnetwork.get_subnetworks() (the coded tool path).
     #
     # 5. Shared MCP servers
-    #    Holds:   the {server URL: {"in_info_file", "access_token"}}
-    #             union of the servers parsed from mcp_info.hocon
+    #    Holds:   the list of MCP server URLs parsed from mcp_info.hocon
     #             (MCP_SERVERS_INFO_FILE, the cwd scaffold, or the bundled
-    #             copy — see GetMcpTool.get_mcp_info_file) and the OAuth
-    #             connections in nsflow's token store
-    #             (NSFLOW_MCP_STORAGE_DIR/tokens.json, default
-    #             ~/.nsflow/mcp_oauth — see GetMcpTool.get_nsflow_tokens_file).
-    #             Values hold token material — never log them.
-    #    Lives:   get_mcp_tool.GetMcpTool (async get_mcp_servers /
-    #             get_mcp_servers_auth_info)
-    #    Expiry:  either file's resolved path or modification_time change —
-    #             no time bucket, since nothing writes mcp_info.hocon at
-    #             runtime and every nsflow token write touches tokens.json.
+    #             copy — see GetMcpTool.get_mcp_info_file). Per-conversation
+    #             servers supplied via sly_data http_headers are NOT part of
+    #             this cache; callers union them in via
+    #             GetMcpTool.sly_data_http_header_urls(sly_data).
+    #    Lives:   get_mcp_tool.GetMcpTool (async get_mcp_servers)
+    #    Expiry:  resolved path or modification_time change — no time bucket, since
+    #             nothing writes the file at runtime.
     #    Used by: GetMcpTool (input to the tool-descriptions cache below);
     #             agent_network_structure_validation_middleware
     #             .AgentNetworkStructureValidationMiddleware.validate();
     #             agent_network_persistence_middleware.AgentNetworkPersistenceMiddleware
-    #             ._assemble_and_persist() (via get_mcp_servers_auth_info,
-    #             which drives the generated sly_data_schema).
+    #             ._assemble_and_persist().
     #
     # 6. Shared MCP tool descriptions
     #    Holds:   the {server URL: tool descriptions} mapping fetched from
-    #             the MCP servers themselves (network calls, sent with a
-    #             stored nsflow OAuth bearer token when one exists).
+    #             the file-configured MCP servers themselves (network
+    #             calls). Listings for per-conversation sly_data servers
+    #             are deliberately NOT cached here — their auth headers
+    #             belong to one conversation, and a process-wide entry
+    #             would serve one user's authenticated listing to every
+    #             other (see GetMcpTool._fetch_sly_data_tool_descriptions).
     #    Lives:   get_mcp_tool.GetMcpTool (async get_mcp_tool_descriptions)
-    #    Expiry:  mcp_info.hocon or tokens.json path/modification_time
-    #             change, or one
+    #    Expiry:  mcp_info.hocon path/modification_time change, or one
     #             AGENT_NETWORK_DESIGNER_MCP_TOOLS_TTL_SECONDS window
     #             (default 300s, clamped to at least twice the per-server
     #             fetch cap; <= 0 disables time-based refresh) — the

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -103,7 +103,7 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #    Used by: GetSubnetwork.get_subnetworks() (the coded tool path).
     #
     # 5. Shared MCP servers
-    #    Holds:   the {server URL: {"has_file_headers", "access_token"}}
+    #    Holds:   the {server URL: {"in_info_file", "access_token"}}
     #             union of the servers parsed from mcp_info.hocon
     #             (MCP_SERVERS_INFO_FILE, the cwd scaffold, or the bundled
     #             copy — see GetMcpTool.get_mcp_info_file) and the OAuth

--- a/coded_tools/agent_network_editor/mcp_header_hygiene.py
+++ b/coded_tools/agent_network_editor/mcp_header_hygiene.py
@@ -37,6 +37,19 @@ _HEADER_NAME_RE: re.Pattern[str] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 # the plain str(error) rendering.
 _EXCEPTION_GROUP_TYPES: tuple[type[BaseException], ...] = (BaseExceptionGroup,) if sys.version_info >= (3, 11) else ()
 
+# h11's send-time validation embeds the offending raw header material in
+# its message ("Illegal header name b'...'" / "Illegal header value
+# b'...'") — the one known error shape that carries a header value
+# verbatim. redact_values masks this shape by pattern, unconditionally:
+# exact-value masking cannot cover the file-configured path, whose header
+# values live inside the MCP adapter and are never handed to this module.
+# The second group matches one Python str/bytes repr (either quote style,
+# escapes included), so masking stops at the repr's closing quote and the
+# rest of the message — other group leaves, status text — stays intact.
+_VALUE_BEARING_MESSAGE_RE: re.Pattern[str] = re.compile(
+    r"(Illegal header (?:name|value) )b?('(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\")"
+)
+
 logger = AndLogger(logging.getLogger(__name__))
 
 
@@ -211,22 +224,30 @@ class McpHeaderHygiene:
     @staticmethod
     def redact_values(text: str, headers: dict[str, str] | None) -> str:
         """
-        Mask any header value we sent out of a log-bound string.
+        Mask header material out of a log-bound string.
 
-        Defense in depth for the drop-path warning. sanitized_headers
-        already blocks the values that make the HTTP stack raise a
-        value-bearing error, but no exception renderer should be trusted
-        with token material: an illegal header value surfaces as its bytes
-        repr (h11 formats it b'...'), so each value is masked in the plain,
-        str-repr, and bytes-repr forms an error might use — longest first so
-        a shorter form cannot leave a fragment behind.
+        Defense in depth for the drop-path warning, in two layers. First,
+        the known value-bearing message shape — h11's "Illegal header
+        name/value b'...'" — is masked by pattern, unconditionally: on the
+        file-configured path the header values live inside the MCP adapter
+        (headers is None here), so a malformed operator-configured token
+        would otherwise be echoed verbatim, and exact masking below cannot
+        reach it. Second, when the headers ARE known (the sly_data path),
+        each value is masked wherever it appears: sanitized_headers already
+        blocks the values that make the HTTP stack raise a value-bearing
+        error, but no exception renderer should be trusted with token
+        material, so each value is masked in the plain, str-repr, and
+        bytes-repr forms an error might use — longest first so a shorter
+        form cannot leave a fragment behind.
 
         :param text: The rendered error summary bound for the log.
         :param headers: The header dict handed to this fetch, or None (the
                 file-configured path, whose values live in the adapter and
                 are operator-controlled, not client-supplied).
-        :return: text with every non-empty header value we sent masked.
+        :return: text with the value-bearing message shape and every
+                non-empty header value we sent masked.
         """
+        text = _VALUE_BEARING_MESSAGE_RE.sub(r"\1***", text)
         if not headers:
             return text
         for value in headers.values():

--- a/coded_tools/agent_network_editor/mcp_header_hygiene.py
+++ b/coded_tools/agent_network_editor/mcp_header_hygiene.py
@@ -217,6 +217,17 @@ class McpHeaderHygiene:
         for value in headers.values():
             if not isinstance(value, str) or not value:
                 continue
-            for form in (repr(value.encode()), repr(value), value):
+            try:
+                forms: tuple[str, ...] = (repr(value.encode()), repr(value), value)
+            except UnicodeEncodeError:
+                # A client-controlled value can hold a lone surrogate, which
+                # str.encode() rejects. Such a value has no bytes form in the
+                # error text either — the HTTP stack could not have rendered
+                # one — so masking the str forms is complete, and redaction
+                # itself must never raise (it runs inside the fetch's
+                # except handler, where an escape would fail the whole
+                # gathered listing).
+                forms = (repr(value), value)
+            for form in forms:
                 text = text.replace(form, "***")
         return text

--- a/coded_tools/agent_network_editor/mcp_header_hygiene.py
+++ b/coded_tools/agent_network_editor/mcp_header_hygiene.py
@@ -18,6 +18,7 @@ import logging
 import re
 import sys
 from typing import Any
+from urllib.parse import urlsplit
 
 from coded_tools.agent_network_editor.and_logger import AndLogger
 
@@ -70,6 +71,53 @@ class McpHeaderHygiene:
     (AgentNetworkPersistenceMiddleware) all read it, so a generated network
     never requires a header the fetch would not actually send.
     """
+
+    @staticmethod
+    def usable_server_url(url: Any) -> bool:
+        """
+        Whether a sly_data["http_headers"] key is a well-formed http(s) MCP
+        server URL, safe to fetch from, log, and declare.
+
+        An accepted URL becomes an outbound request target and appears
+        verbatim in log lines and in persisted sly_data_schema artifacts,
+        so shape problems are rejected here, at the single classification
+        gate every consumer shares: a non-string; a scheme other than
+        http(s); any control character, whitespace, or DEL anywhere in the
+        URL (a raw newline would forge log lines); userinfo (user:pass@ —
+        credentials do not belong in a URL that gets logged and persisted;
+        auth travels in the headers); and a missing host. Non-ASCII is NOT
+        rejected: international URLs are supported end to end and carry no
+        log-forgery risk.
+
+        Deliberately NOT a destination policy: no private/loopback/
+        link-local address blocking. Localhost and private-network MCP
+        servers are first-class deployments here (development runs them
+        alongside the studio), the generated networks connect to whatever
+        server URLs they are configured with at runtime anyway, and WHICH
+        servers a conversation may use is the injecting client's trust
+        decision (nsflow injects only its vetted connected-server
+        records). Resolver-level controls (DNS pinning, redirect policy)
+        need to live in the shared MCP client layer, not per coded tool.
+
+        :param url: One key from sly_data["http_headers"].
+        :return: True when the URL is well-formed enough to use.
+        """
+        if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+            return False
+        for char in url:
+            if ord(char) <= 0x20 or ord(char) == 0x7F:
+                return False
+        try:
+            parsed = urlsplit(url)
+            if parsed.username is not None or parsed.password is not None:
+                return False
+            if not parsed.hostname:
+                return False
+        except ValueError:
+            # urlsplit (or its lazy component properties) rejects some
+            # malformed inputs, e.g. an unclosed IPv6 bracket.
+            return False
+        return True
 
     @staticmethod
     def usable_header_name(name: Any) -> str | None:

--- a/coded_tools/agent_network_editor/mcp_header_hygiene.py
+++ b/coded_tools/agent_network_editor/mcp_header_hygiene.py
@@ -1,0 +1,222 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import logging
+import re
+import sys
+from typing import Any
+
+from coded_tools.agent_network_editor.and_logger import AndLogger
+
+# Legal HTTP field-name charset for validating conversation-supplied header
+# NAMES: the "token" rule of RFC 9110 §5.6.2
+# (https://www.rfc-editor.org/rfc/rfc9110#section-5.6.2). The HTTP stack
+# validates outgoing names just like values and raises on the first illegal
+# one — failing the whole request, not just the one header — so names
+# outside this set are dropped before the fetch (see usable_header_name).
+# Matched with fullmatch(); the + quantifier also rejects an empty (blank)
+# name.
+_HEADER_NAME_RE: re.Pattern[str] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
+
+# ExceptionGroup is a builtin from Python 3.11 (the repo minimum is 3.10).
+# On 3.10 the conditional's true branch never evaluates, and isinstance
+# against the empty tuple is simply always False — those interpreters keep
+# the plain str(error) rendering.
+_EXCEPTION_GROUP_TYPES: tuple[type[BaseException], ...] = (BaseExceptionGroup,) if sys.version_info >= (3, 11) else ()
+
+logger = AndLogger(logging.getLogger(__name__))
+
+
+class McpHeaderHygiene:
+    """
+    Hygiene for the per-conversation MCP auth headers a chat client supplies
+    via sly_data["http_headers"], and for the fetch errors they can cause.
+
+    The headers carry credential material a client controls, so two things
+    must hold everywhere they flow: a malformed entry must degrade to that
+    one header (or one server), never fail a whole request or conversation,
+    and no header VALUE may ever reach a log — not directly, and not echoed
+    through an exception message.
+
+    One policy, three call sites: usable_header_names decides which names
+    count, and URL classification (GetMcpTool.sly_data_http_header_urls),
+    the outgoing fetch (sanitized_headers), and the persisted schema
+    (AgentNetworkPersistenceMiddleware) all read it, so a generated network
+    never requires a header the fetch would not actually send.
+    """
+
+    @staticmethod
+    def usable_header_name(name: Any) -> str | None:
+        """
+        Validate and normalize one conversation-supplied header name.
+
+        Outer whitespace is stripped (recoverable, the same treatment
+        values get). What remains must be a legal HTTP field name (RFC
+        9110 token — see _HEADER_NAME_RE): the HTTP stack validates names
+        on send exactly like values, so a blank name or one holding a
+        colon, space, control, or non-ASCII character would fail the whole
+        request rather than just this header.
+
+        :param name: One key from a per-URL header dict.
+        :return: The stripped name, or None when the name is not a string
+                or not a legal field name.
+        """
+        if not isinstance(name, str):
+            return None
+        stripped: str = name.strip()
+        if not _HEADER_NAME_RE.fullmatch(stripped):
+            return None
+        return stripped
+
+    @staticmethod
+    def usable_header_names(headers: dict[Any, Any]) -> list[str]:
+        """
+        Get the header names in a per-URL header dict that supply a usable
+        credential: a legal HTTP header name (see usable_header_name)
+        whose value is a string that is not blank after stripping.
+
+        Single owner of what counts as a usable client-supplied header —
+        see the class docstring for the three call sites that read it.
+
+        :param headers: A per-URL header dict from sly_data["http_headers"].
+        :return: The stripped names in first-appearance order, deduped (two
+                raw spellings of one name collapse into the first). Names
+                only — no header value leaves this function.
+        """
+        names: dict[str, None] = {}
+        for name, value in headers.items():
+            usable_name: str | None = McpHeaderHygiene.usable_header_name(name)
+            if usable_name is not None and isinstance(value, str) and value.strip():
+                names[usable_name] = None
+        return list(names)
+
+    @staticmethod
+    def sanitized_headers(server: str, headers: dict[str, Any]) -> dict[str, str]:
+        """
+        Clean a conversation's per-URL header dict before it reaches the
+        HTTP stack.
+
+        The HTTP client validates outgoing names AND values and raises on
+        the first illegal one — failing the whole listing for this server,
+        and, for values, embedding the raw value (most often a token read
+        with a trailing newline) in the exception, which would put token
+        material on the drop path. So both halves are cleaned here.
+
+        Names: outer whitespace is stripped; what remains must be a legal
+        field name (see usable_header_name) or the header is dropped with
+        a warning that does NOT echo the name — an arbitrary junk name
+        could hold anything, including a misplaced secret. Values: outer
+        whitespace is stripped (the common, recoverable case, so a
+        newline-tailed token still authenticates); a blank value supplies
+        no credential and is skipped silently, matching
+        usable_header_names; a value still holding a control character is
+        genuinely malformed and dropped, logging the (already validated)
+        header name only. Non-string names/values are skipped. A value is
+        never logged.
+
+        :param server: The MCP server URL, for the drop warning.
+        :param headers: The conversation's per-URL header dict (from
+                sly_data["http_headers"][server]).
+        :return: The cleaned headers to hand to the adapter; may be empty,
+                in which case the fetch runs unauthenticated and a private
+                server simply drops out of the listing (attempt-and-drop).
+        """
+        cleaned: dict[str, str] = {}
+        for name, value in headers.items():
+            if not isinstance(name, str) or not isinstance(value, str):
+                continue
+            usable_name: str | None = McpHeaderHygiene.usable_header_name(name)
+            if usable_name is None:
+                logger.warning("Dropping malformed MCP header for %s (illegal name characters).", server)
+                continue
+            stripped: str = value.strip()
+            if not stripped:
+                continue
+            if any((ord(char) < 0x20 and char != "\t") or ord(char) == 0x7F for char in stripped):
+                logger.warning(
+                    "Dropping malformed MCP header %r for %s (illegal value characters).", usable_name, server
+                )
+                continue
+            cleaned[usable_name] = stripped
+        return cleaned
+
+    @staticmethod
+    def error_summary(error: BaseException) -> str:
+        """
+        Render a fetch failure as the end error message an operator acts on.
+
+        The MCP streamable-http client surfaces failures as an anyio
+        ExceptionGroup whose own str() is just "unhandled errors in a
+        TaskGroup (1 sub-exception)" — hiding the actual cause (e.g. a 401
+        from a stale or revoked token), which is the one hint that picks
+        the right remedy (re-auth in the client vs. a server outage). For a
+        group, only the leaf messages are returned ("Type: message; ...");
+        the group's own text adds nothing once its leaves are shown. No
+        traceback is ever rendered.
+
+        Leaf messages from this stack usually carry only the URL and
+        status line, but a header VALIDATION failure (e.g. h11's
+        LocalProtocolError) can embed the raw header value, so the caller
+        validates the values it sends up front (see sanitized_headers) and
+        redacts them from this string before logging (see redact_values) —
+        this renderer itself makes no such guarantee.
+
+        :param error: The exception caught by the fetch.
+        :return: str(error) for a plain exception; the flattened
+                "Type: message; ..." leaves for an ExceptionGroup.
+        """
+        if not isinstance(error, _EXCEPTION_GROUP_TYPES):
+            return str(error)
+        leaves: list[str] = []
+        stack: list[BaseException] = list(error.exceptions)
+        while stack:
+            sub: BaseException = stack.pop(0)
+            if isinstance(sub, _EXCEPTION_GROUP_TYPES):
+                stack.extend(sub.exceptions)
+            else:
+                leaves.append(f"{type(sub).__name__}: {sub}")
+        # A group is constructed with at least one exception, so leaves is
+        # only empty if a group nested nothing but empty groups — fall back
+        # to str(error) rather than returning an empty message.
+        return "; ".join(leaves) if leaves else str(error)
+
+    @staticmethod
+    def redact_values(text: str, headers: dict[str, str] | None) -> str:
+        """
+        Mask any header value we sent out of a log-bound string.
+
+        Defense in depth for the drop-path warning. sanitized_headers
+        already blocks the values that make the HTTP stack raise a
+        value-bearing error, but no exception renderer should be trusted
+        with token material: an illegal header value surfaces as its bytes
+        repr (h11 formats it b'...'), so each value is masked in the plain,
+        str-repr, and bytes-repr forms an error might use — longest first so
+        a shorter form cannot leave a fragment behind.
+
+        :param text: The rendered error summary bound for the log.
+        :param headers: The header dict handed to this fetch, or None (the
+                file-configured path, whose values live in the adapter and
+                are operator-controlled, not client-supplied).
+        :return: text with every non-empty header value we sent masked.
+        """
+        if not headers:
+            return text
+        for value in headers.values():
+            if not isinstance(value, str) or not value:
+                continue
+            for form in (repr(value.encode()), repr(value), value):
+                text = text.replace(form, "***")
+        return text

--- a/coded_tools/agent_network_editor/mcp_header_hygiene.py
+++ b/coded_tools/agent_network_editor/mcp_header_hygiene.py
@@ -145,13 +145,28 @@ class McpHeaderHygiene:
             stripped: str = value.strip()
             if not stripped:
                 continue
-            if any((ord(char) < 0x20 and char != "\t") or ord(char) == 0x7F for char in stripped):
+            if McpHeaderHygiene._has_illegal_value_character(stripped):
                 logger.warning(
                     "Dropping malformed MCP header %r for %s (illegal value characters).", usable_name, server
                 )
                 continue
             cleaned[usable_name] = stripped
         return cleaned
+
+    @staticmethod
+    def _has_illegal_value_character(value: str) -> bool:
+        """
+        Whether a header value holds a character the HTTP stack rejects:
+        any control character except horizontal tab, which is the one
+        control character legal inside an HTTP field value.
+
+        :param value: A header value, already stripped of outer whitespace.
+        :return: True if any character would fail send-time validation.
+        """
+        for char in value:
+            if (ord(char) < 0x20 and char != "\t") or ord(char) == 0x7F:
+                return True
+        return False
 
     @staticmethod
     def error_summary(error: BaseException) -> str:

--- a/coded_tools/agent_network_editor/mcp_servers_load.py
+++ b/coded_tools/agent_network_editor/mcp_servers_load.py
@@ -1,0 +1,39 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import NamedTuple
+
+
+class McpServersLoad(NamedTuple):
+    """
+    Result of loading mcp_info.hocon: the file-configured MCP server URLs
+    plus whether the file was read successfully.
+
+    loaded_ok separates an authoritatively empty result (a missing or empty
+    file — there really are no file-configured servers) from a degraded one
+    (the file exists but could not be read or parsed — the set is UNKNOWN).
+    Only the former makes it safe to treat a conversation-connected server
+    as client-token; see GetMcpTool.get_mcp_servers_load and
+    AgentNetworkPersistenceMiddleware for the caller that acts on the
+    difference.
+    """
+
+    urls: list[str]
+    """The MCP server URLs read from the file; [] when missing or unreadable."""
+
+    loaded_ok: bool
+    """True when the file was read (or is genuinely absent); False when it
+    exists but could not be read or parsed, making urls non-authoritative."""

--- a/middleware/agent_network_designer/persistence/agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/agent_network_assembler.py
@@ -17,14 +17,19 @@
 from typing import Any
 
 
-# pylint: disable=too-few-public-methods
 class AgentNetworkAssembler:
     """
     Interface for a policy class that assembles an agent network from an agent network definition
     """
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     async def assemble_agent_network(
-        self, network_def: dict[str, Any], top_agent_name: str, agent_network_name: str, sample_queries: list[str]
+        self,
+        network_def: dict[str, Any],
+        top_agent_name: str,
+        agent_network_name: str,
+        sample_queries: list[str],
+        mcp_servers_auth: dict[str, bool] | None = None,
     ) -> Any:
         """
         Assemble the agent network from the definition.
@@ -33,7 +38,88 @@ class AgentNetworkAssembler:
         :param top_agent_name: The name of the top agent
         :param agent_network_name: The file name, without the .hocon extension
         :param sample_queries: List of sample queries for the agent network
+        :param mcp_servers_auth: Optional {MCP server URL: needs_client_token} mapping
+                for every known MCP server (see GetMcpTool.get_mcp_servers_auth_info).
+                Drives the sly_data_schema emitted into the assembled network;
+                None or {} means no schema is emitted.
 
         :return: Some representation of the agent network
         """
         raise NotImplementedError
+
+    @staticmethod
+    def build_mcp_sly_data_schema(
+        network_def: dict[str, Any], mcp_servers_auth: dict[str, bool] | None
+    ) -> dict[str, Any] | None:
+        """
+        Build the sly_data_schema declaring the HTTP headers the assembled
+        network's MCP tools need, for placement inside the front man's
+        "function" block.
+
+        Generic clients read this schema to learn what private inputs to
+        supply outside the chat stream. In particular, nsflow reads
+        properties.http_headers.properties to know which MCP server URLs to
+        opportunistically inject stored OAuth bearer tokens for (as
+        sly_data["http_headers"][<url>]["Authorization"]), and
+        properties.http_headers.required to know which of them must be
+        connected before chat is allowed. See registries/tools/you_search.hocon
+        for the hand-written reference of this exact shape.
+
+        The `required` list is data-driven: a URL is required only when it
+        needs a client-supplied token (no http_headers configured for it in
+        mcp_info.hocon — the mapping computed by
+        GetMcpTool.get_mcp_servers_auth_info). The key is always emitted,
+        even when empty: omitting `required` makes nsflow gate every
+        declared URL, while [] disables the gate but keeps opportunistic
+        token injection.
+
+        :param network_def: Agent network definition. MCP server URLs are
+                recognized as tools-list entries present in mcp_servers_auth —
+                a set intersection, never URL pattern matching, since tools
+                lists also hold agent names and subnetwork references.
+        :param mcp_servers_auth: {MCP server URL: needs_client_token} for every
+                known MCP server, or None.
+        :return: The sly_data_schema dict, or None when the network uses no
+                MCP servers (no schema should be emitted at all).
+        """
+        if not mcp_servers_auth:
+            return None
+
+        # Collect the MCP URLs the network actually uses, deduped in
+        # first-appearance order so the emitted schema is deterministic.
+        used_urls: dict[str, None] = {}
+        for agent in network_def.values():
+            if not isinstance(agent, dict):
+                continue
+            for tool in agent.get("tools") or []:
+                if isinstance(tool, str) and tool in mcp_servers_auth:
+                    used_urls[tool] = None
+        if not used_urls:
+            return None
+
+        url_properties: dict[str, Any] = {}
+        for url in used_urls:
+            url_properties[url] = {
+                "type": "object",
+                "description": f"HTTP headers for the MCP server at {url}.",
+                "properties": {
+                    "Authorization": {
+                        "type": "string",
+                        "description": "Authorization header, e.g. 'Bearer <token_value>'.",
+                    }
+                },
+                "required": ["Authorization"],
+            }
+
+        return {
+            "type": "object",
+            "properties": {
+                "http_headers": {
+                    "type": "object",
+                    "description": "HTTP headers to be sent with MCP tool requests.",
+                    "properties": url_properties,
+                    "required": [url for url in used_urls if mcp_servers_auth.get(url)],
+                }
+            },
+            "required": ["http_headers"],
+        }

--- a/middleware/agent_network_designer/persistence/agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/agent_network_assembler.py
@@ -15,6 +15,7 @@
 # END COPYRIGHT
 
 from collections.abc import Collection
+from collections.abc import Mapping
 from typing import Any
 
 from neuro_san.internals.validation.network.abstract_network_validator import AbstractNetworkValidator
@@ -32,7 +33,7 @@ class AgentNetworkAssembler:
         top_agent_name: str,
         agent_network_name: str,
         sample_queries: list[str],
-        client_token_mcp_urls: Collection[str] | None = None,
+        client_token_mcp_headers: Mapping[str, Collection[str]] | None = None,
     ) -> Any:
         """
         Assemble the agent network from the definition.
@@ -41,11 +42,11 @@ class AgentNetworkAssembler:
         :param top_agent_name: The name of the top agent
         :param agent_network_name: The file name, without the .hocon extension
         :param sample_queries: List of sample queries for the agent network
-        :param client_token_mcp_urls: Optional collection of MCP server URLs whose
-                auth is client-supplied (the conversation's sly_data http_headers
-                servers that are not configured in mcp_info.hocon). Drives the
-                sly_data_schema emitted into the assembled network; None or empty
-                means no schema is emitted.
+        :param client_token_mcp_headers: Optional mapping of client-token MCP
+                server URL to the header names the conversation supplied for it
+                (the sly_data http_headers servers not configured in
+                mcp_info.hocon). Drives the sly_data_schema emitted into the
+                assembled network; None or empty means no schema is emitted.
 
         :return: Some representation of the agent network
         """
@@ -53,7 +54,7 @@ class AgentNetworkAssembler:
 
     @staticmethod
     def build_mcp_sly_data_schema(
-        network_def: dict[str, Any], client_token_mcp_urls: Collection[str] | None
+        network_def: dict[str, Any], client_token_mcp_headers: Mapping[str, Collection[str]] | None
     ) -> dict[str, Any] | None:
         """
         Build the sly_data_schema declaring the HTTP headers the assembled
@@ -63,9 +64,8 @@ class AgentNetworkAssembler:
         Generic clients read this schema to learn what private inputs to
         supply outside the chat stream. In particular, nsflow reads
         properties.http_headers.properties to know which MCP server URLs to
-        inject stored OAuth bearer tokens for (as
-        sly_data["http_headers"][<url>]["Authorization"]), and
-        properties.http_headers.required to know which of them must be
+        inject stored tokens for (as sly_data["http_headers"][<url>][<header>]),
+        and properties.http_headers.required to know which of them must be
         connected before chat is allowed. See registries/tools/you_search.hocon
         for the hand-written reference of this exact shape.
 
@@ -78,17 +78,24 @@ class AgentNetworkAssembler:
         declared URL is also in `required`, so clients like nsflow gate
         chat until the user has connected it.
 
+        The header names a server needs are taken from what the conversation
+        actually supplied (client_token_mcp_headers[url]), not assumed to be
+        "Authorization", so an API-key or other custom-header server is
+        described correctly. Only header names are used here — no header
+        value ever enters the schema.
+
         :param network_def: Agent network definition. MCP server URLs are
                 recognized as tools-list entries present in
-                client_token_mcp_urls — a membership test, never URL pattern
+                client_token_mcp_headers — a membership test, never URL pattern
                 matching, since tools lists also hold agent names and
                 subnetwork references.
-        :param client_token_mcp_urls: MCP server URLs whose auth is
-                client-supplied, or None.
+        :param client_token_mcp_headers: Mapping of client-token MCP server URL
+                to the header names the conversation supplied for it, or None.
+                The keys are the URLs whose auth is client-supplied.
         :return: The sly_data_schema dict, or None when the network uses no
                 client-token MCP servers (no schema should be emitted at all).
         """
-        if not client_token_mcp_urls:
+        if not client_token_mcp_headers:
             return None
 
         # Collect the client-token MCP URLs the network actually uses,
@@ -102,23 +109,29 @@ class AgentNetworkAssembler:
             if not isinstance(agent, dict):
                 continue
             for tool in AbstractNetworkValidator.coerce_tools(agent):
-                if isinstance(tool, str) and tool in client_token_mcp_urls:
+                if isinstance(tool, str) and tool in client_token_mcp_headers:
                     used_urls[tool] = None
         if not used_urls:
             return None
 
         url_properties: dict[str, Any] = {}
         for url in used_urls:
+            header_names: list[str] = list(client_token_mcp_headers[url])
+            name_properties: dict[str, Any] = {}
+            for name in header_names:
+                name_properties[name] = {
+                    "type": "string",
+                    "description": (
+                        "Authorization header, e.g. 'Bearer <token_value>'."
+                        if name == "Authorization"
+                        else f"The {name!r} header sent with MCP tool requests."
+                    ),
+                }
             url_properties[url] = {
                 "type": "object",
                 "description": f"HTTP headers for the MCP server at {url}.",
-                "properties": {
-                    "Authorization": {
-                        "type": "string",
-                        "description": "Authorization header, e.g. 'Bearer <token_value>'.",
-                    }
-                },
-                "required": ["Authorization"],
+                "properties": name_properties,
+                "required": header_names,
             }
 
         return {

--- a/middleware/agent_network_designer/persistence/agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/agent_network_assembler.py
@@ -93,10 +93,10 @@ class AgentNetworkAssembler:
                 to the header names the conversation supplied for it, or None.
                 The keys are the URLs whose auth is client-supplied. Names are
                 declared verbatim: the producing side supplies stripped, legal,
-                deduped names (GetMcpTool.usable_header_names is the single
-                owner of that policy), which keeps the schema, the fetch, and
-                URL classification telling one story — re-normalizing here
-                would just fork the policy.
+                deduped names (McpHeaderHygiene.usable_header_names is the
+                single owner of that policy), which keeps the schema, the
+                fetch, and URL classification telling one story —
+                re-normalizing here would just fork the policy.
         :return: The sly_data_schema dict, or None when the network uses no
                 client-token MCP servers (no schema should be emitted at all).
         """

--- a/middleware/agent_network_designer/persistence/agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/agent_network_assembler.py
@@ -91,7 +91,12 @@ class AgentNetworkAssembler:
                 subnetwork references.
         :param client_token_mcp_headers: Mapping of client-token MCP server URL
                 to the header names the conversation supplied for it, or None.
-                The keys are the URLs whose auth is client-supplied.
+                The keys are the URLs whose auth is client-supplied. Names are
+                declared verbatim: the producing side supplies stripped, legal,
+                deduped names (GetMcpTool.usable_header_names is the single
+                owner of that policy), which keeps the schema, the fetch, and
+                URL classification telling one story — re-normalizing here
+                would just fork the policy.
         :return: The sly_data_schema dict, or None when the network uses no
                 client-token MCP servers (no schema should be emitted at all).
         """

--- a/middleware/agent_network_designer/persistence/agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/agent_network_assembler.py
@@ -14,7 +14,10 @@
 #
 # END COPYRIGHT
 
+from collections.abc import Collection
 from typing import Any
+
+from neuro_san.internals.validation.network.abstract_network_validator import AbstractNetworkValidator
 
 
 class AgentNetworkAssembler:
@@ -29,7 +32,7 @@ class AgentNetworkAssembler:
         top_agent_name: str,
         agent_network_name: str,
         sample_queries: list[str],
-        mcp_servers_auth: dict[str, bool] | None = None,
+        client_token_mcp_urls: Collection[str] | None = None,
     ) -> Any:
         """
         Assemble the agent network from the definition.
@@ -38,10 +41,11 @@ class AgentNetworkAssembler:
         :param top_agent_name: The name of the top agent
         :param agent_network_name: The file name, without the .hocon extension
         :param sample_queries: List of sample queries for the agent network
-        :param mcp_servers_auth: Optional {MCP server URL: needs_client_token} mapping
-                for every known MCP server (see GetMcpTool.get_mcp_servers_auth_info).
-                Drives the sly_data_schema emitted into the assembled network;
-                None or {} means no schema is emitted.
+        :param client_token_mcp_urls: Optional collection of MCP server URLs whose
+                auth is client-supplied (the conversation's sly_data http_headers
+                servers that are not configured in mcp_info.hocon). Drives the
+                sly_data_schema emitted into the assembled network; None or empty
+                means no schema is emitted.
 
         :return: Some representation of the agent network
         """
@@ -49,7 +53,7 @@ class AgentNetworkAssembler:
 
     @staticmethod
     def build_mcp_sly_data_schema(
-        network_def: dict[str, Any], mcp_servers_auth: dict[str, bool] | None
+        network_def: dict[str, Any], client_token_mcp_urls: Collection[str] | None
     ) -> dict[str, Any] | None:
         """
         Build the sly_data_schema declaring the HTTP headers the assembled
@@ -65,36 +69,40 @@ class AgentNetworkAssembler:
         connected before chat is allowed. See registries/tools/you_search.hocon
         for the hand-written reference of this exact shape.
 
-        Only servers that need a client-supplied token are declared — those
-        known from nsflow's OAuth token store rather than mcp_info.hocon
-        (the mapping computed by GetMcpTool.get_mcp_servers_auth_info).
-        Servers configured in mcp_info.hocon are omitted entirely: their
-        auth (if any) lives server-side, so a client has nothing to supply
-        for them — matching you_search.hocon, which declares only its OAuth
-        server. Every declared URL is also in `required`, so clients like
-        nsflow gate chat until the user has connected it.
+        Only servers whose auth is client-supplied are declared — the ones
+        the designing conversation itself provided headers for via sly_data
+        (nsflow injects one per connected server). Servers configured in
+        mcp_info.hocon are omitted entirely: their auth (if any) lives
+        server-side, so a client has nothing to supply for them — matching
+        you_search.hocon, which declares only its OAuth server. Every
+        declared URL is also in `required`, so clients like nsflow gate
+        chat until the user has connected it.
 
         :param network_def: Agent network definition. MCP server URLs are
-                recognized as tools-list entries present in mcp_servers_auth —
-                a set intersection, never URL pattern matching, since tools
-                lists also hold agent names and subnetwork references.
-        :param mcp_servers_auth: {MCP server URL: needs_client_token} for every
-                known MCP server, or None.
+                recognized as tools-list entries present in
+                client_token_mcp_urls — a membership test, never URL pattern
+                matching, since tools lists also hold agent names and
+                subnetwork references.
+        :param client_token_mcp_urls: MCP server URLs whose auth is
+                client-supplied, or None.
         :return: The sly_data_schema dict, or None when the network uses no
                 client-token MCP servers (no schema should be emitted at all).
         """
-        if not mcp_servers_auth:
+        if not client_token_mcp_urls:
             return None
 
         # Collect the client-token MCP URLs the network actually uses,
         # deduped in first-appearance order so the emitted schema is
-        # deterministic.
+        # deterministic. coerce_tools is the framework's guard for
+        # malformed tools shapes (a str-valued tools field reads as []
+        # instead of iterating characters), keeping this walk consistent
+        # with neuro-san's own network validators.
         used_urls: dict[str, None] = {}
         for agent in network_def.values():
             if not isinstance(agent, dict):
                 continue
-            for tool in agent.get("tools") or []:
-                if isinstance(tool, str) and mcp_servers_auth.get(tool):
+            for tool in AbstractNetworkValidator.coerce_tools(agent):
+                if isinstance(tool, str) and tool in client_token_mcp_urls:
                     used_urls[tool] = None
         if not used_urls:
             return None

--- a/middleware/agent_network_designer/persistence/agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/agent_network_assembler.py
@@ -59,19 +59,20 @@ class AgentNetworkAssembler:
         Generic clients read this schema to learn what private inputs to
         supply outside the chat stream. In particular, nsflow reads
         properties.http_headers.properties to know which MCP server URLs to
-        opportunistically inject stored OAuth bearer tokens for (as
+        inject stored OAuth bearer tokens for (as
         sly_data["http_headers"][<url>]["Authorization"]), and
         properties.http_headers.required to know which of them must be
         connected before chat is allowed. See registries/tools/you_search.hocon
         for the hand-written reference of this exact shape.
 
-        The `required` list is data-driven: a URL is required only when it
-        needs a client-supplied token (no http_headers configured for it in
-        mcp_info.hocon — the mapping computed by
-        GetMcpTool.get_mcp_servers_auth_info). The key is always emitted,
-        even when empty: omitting `required` makes nsflow gate every
-        declared URL, while [] disables the gate but keeps opportunistic
-        token injection.
+        Only servers that need a client-supplied token are declared — those
+        known from nsflow's OAuth token store rather than mcp_info.hocon
+        (the mapping computed by GetMcpTool.get_mcp_servers_auth_info).
+        Servers configured in mcp_info.hocon are omitted entirely: their
+        auth (if any) lives server-side, so a client has nothing to supply
+        for them — matching you_search.hocon, which declares only its OAuth
+        server. Every declared URL is also in `required`, so clients like
+        nsflow gate chat until the user has connected it.
 
         :param network_def: Agent network definition. MCP server URLs are
                 recognized as tools-list entries present in mcp_servers_auth —
@@ -80,19 +81,20 @@ class AgentNetworkAssembler:
         :param mcp_servers_auth: {MCP server URL: needs_client_token} for every
                 known MCP server, or None.
         :return: The sly_data_schema dict, or None when the network uses no
-                MCP servers (no schema should be emitted at all).
+                client-token MCP servers (no schema should be emitted at all).
         """
         if not mcp_servers_auth:
             return None
 
-        # Collect the MCP URLs the network actually uses, deduped in
-        # first-appearance order so the emitted schema is deterministic.
+        # Collect the client-token MCP URLs the network actually uses,
+        # deduped in first-appearance order so the emitted schema is
+        # deterministic.
         used_urls: dict[str, None] = {}
         for agent in network_def.values():
             if not isinstance(agent, dict):
                 continue
             for tool in agent.get("tools") or []:
-                if isinstance(tool, str) and tool in mcp_servers_auth:
+                if isinstance(tool, str) and mcp_servers_auth.get(tool):
                     used_urls[tool] = None
         if not used_urls:
             return None
@@ -118,7 +120,7 @@ class AgentNetworkAssembler:
                     "type": "object",
                     "description": "HTTP headers to be sent with MCP tool requests.",
                     "properties": url_properties,
-                    "required": [url for url in used_urls if mcp_servers_auth.get(url)],
+                    "required": list(used_urls),
                 }
             },
             "required": ["http_headers"],

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -268,10 +268,18 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         # headers for via sly_data (nsflow injects one per connected server
         # when chatting with the designer) that are not file-configured.
         # These drive the generated network's sly_data_schema.
-        client_token_mcp_urls: list[str] = [
-            url for url in GetMcpTool.sly_data_http_header_urls(self.sly_data) if url not in file_servers
-        ]
-        mcp_servers: list[str] = file_servers + client_token_mcp_urls
+        # Map each client-token URL to the header names the conversation
+        # supplied for it (names only, never values), so the generated
+        # sly_data_schema declares the actual headers a server needs rather
+        # than assuming "Authorization". sly_data_http_header_urls only
+        # yields URLs whose sly_data["http_headers"][url] is a dict, so the
+        # index below is safe.
+        client_token_mcp_headers: dict[str, list[str]] = {
+            url: [name for name in self.sly_data["http_headers"][url] if isinstance(name, str)]
+            for url in GetMcpTool.sly_data_http_header_urls(self.sly_data)
+            if url not in file_servers
+        }
+        mcp_servers: list[str] = file_servers + list(client_token_mcp_headers)
         persistor: AgentNetworkPersistor = AgentNetworkPersistorFactory.create_persistor(
             {"reservationist": self.reservationist},
             WRITE_TO_FILE,
@@ -288,7 +296,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             top_agent_name,
             agent_network_name,
             sample_queries,
-            client_token_mcp_urls=client_token_mcp_urls,
+            client_token_mcp_headers=client_token_mcp_headers,
         )
         self.logger.info("The resulting agent network content: \n %s", persisted_content)
         self.sly_data[AGENT_NETWORK_HOCON_TEXT] = persisted_content
@@ -307,7 +315,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
                 top_agent_name,
                 agent_network_name,
                 sample_queries,
-                client_token_mcp_urls=client_token_mcp_urls,
+                client_token_mcp_headers=client_token_mcp_headers,
             )
         # Persist the agent network
         persisted_reference: str | list[dict[str, Any]] = await persistor.async_persist(

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -263,7 +263,10 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.logger.info("Agent Network Name: %s", agent_network_name)
 
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names()
-        mcp_servers: list[str] = await GetMcpTool.get_mcp_servers()
+        # The url -> needs-client-token view drives the generated sly_data_schema;
+        # its keys are the same server list get_mcp_servers() would return.
+        mcp_servers_auth: dict[str, bool] = await GetMcpTool.get_mcp_servers_auth_info()
+        mcp_servers: list[str] = list(mcp_servers_auth)
         persistor: AgentNetworkPersistor = AgentNetworkPersistorFactory.create_persistor(
             {"reservationist": self.reservationist},
             WRITE_TO_FILE,
@@ -276,7 +279,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
 
         # Always assemble and store HOCON content for client consumption.
         persisted_content: str = await HoconAgentNetworkAssembler(DEMO_MODE).assemble_agent_network(
-            network_def, top_agent_name, agent_network_name, sample_queries
+            network_def, top_agent_name, agent_network_name, sample_queries, mcp_servers_auth=mcp_servers_auth
         )
         self.logger.info("The resulting agent network content: \n %s", persisted_content)
         self.sly_data[AGENT_NETWORK_HOCON_TEXT] = persisted_content
@@ -291,7 +294,7 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             assembler: AgentNetworkAssembler = persistor.get_assembler()
             # The persisted content for reservations is config.
             persisted_content: dict[str, Any] = await assembler.assemble_agent_network(
-                network_def, top_agent_name, agent_network_name, sample_queries
+                network_def, top_agent_name, agent_network_name, sample_queries, mcp_servers_auth=mcp_servers_auth
             )
         # Persist the agent network
         persisted_reference: str | list[dict[str, Any]] = await persistor.async_persist(

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -263,10 +263,15 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.logger.info("Agent Network Name: %s", agent_network_name)
 
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names()
-        # The url -> needs-client-token view drives the generated sly_data_schema;
-        # its keys are the same server list get_mcp_servers() would return.
-        mcp_servers_auth: dict[str, bool] = await GetMcpTool.get_mcp_servers_auth_info()
-        mcp_servers: list[str] = list(mcp_servers_auth)
+        file_servers: list[str] = await GetMcpTool.get_mcp_servers()
+        # Client-token servers: the ones this conversation supplied auth
+        # headers for via sly_data (nsflow injects one per connected server
+        # when chatting with the designer) that are not file-configured.
+        # These drive the generated network's sly_data_schema.
+        client_token_mcp_urls: list[str] = [
+            url for url in GetMcpTool.sly_data_http_header_urls(self.sly_data) if url not in file_servers
+        ]
+        mcp_servers: list[str] = file_servers + client_token_mcp_urls
         persistor: AgentNetworkPersistor = AgentNetworkPersistorFactory.create_persistor(
             {"reservationist": self.reservationist},
             WRITE_TO_FILE,
@@ -279,7 +284,11 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
 
         # Always assemble and store HOCON content for client consumption.
         persisted_content: str = await HoconAgentNetworkAssembler(DEMO_MODE).assemble_agent_network(
-            network_def, top_agent_name, agent_network_name, sample_queries, mcp_servers_auth=mcp_servers_auth
+            network_def,
+            top_agent_name,
+            agent_network_name,
+            sample_queries,
+            client_token_mcp_urls=client_token_mcp_urls,
         )
         self.logger.info("The resulting agent network content: \n %s", persisted_content)
         self.sly_data[AGENT_NETWORK_HOCON_TEXT] = persisted_content
@@ -294,7 +303,11 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             assembler: AgentNetworkAssembler = persistor.get_assembler()
             # The persisted content for reservations is config.
             persisted_content: dict[str, Any] = await assembler.assemble_agent_network(
-                network_def, top_agent_name, agent_network_name, sample_queries, mcp_servers_auth=mcp_servers_auth
+                network_def,
+                top_agent_name,
+                agent_network_name,
+                sample_queries,
+                client_token_mcp_urls=client_token_mcp_urls,
             )
         # Persist the agent network
         persisted_reference: str | list[dict[str, Any]] = await persistor.async_persist(

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -33,6 +33,8 @@ from coded_tools.agent_network_editor.constants import AGENT_NETWORK_HOCON_TEXT
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
 from coded_tools.agent_network_editor.get_mcp_tool import GetMcpTool
 from coded_tools.agent_network_editor.get_subnetwork import GetSubnetwork
+from coded_tools.agent_network_editor.mcp_header_hygiene import McpHeaderHygiene
+from coded_tools.agent_network_editor.mcp_servers_load import McpServersLoad
 from coded_tools.agent_network_query_generator.set_sample_queries import AGENT_NETWORK_QUERIES
 from middleware.agent_network_designer.agent_network_definition_middleware import SKIP_DESIGNER
 from middleware.agent_network_designer.persistence.agent_network_assembler import AgentNetworkAssembler
@@ -242,6 +244,49 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         )
         return structure_errors, instructions_errors
 
+    def _client_token_mcp_headers(self, load: McpServersLoad) -> dict[str, list[str]]:
+        """
+        Map each client-token MCP server to the header names to declare for
+        it in the persisted network's sly_data_schema.
+
+        Client-token servers are the ones this conversation supplied auth
+        headers for via sly_data (nsflow injects one per connected server
+        when chatting with the designer) that are not file-configured. Each
+        maps to the usable header names supplied for it (names only, never
+        values), so the schema declares the actual headers a server needs
+        rather than assuming "Authorization". McpHeaderHygiene.usable_header_names
+        owns which names count — stripped, legal field names with non-blank
+        values, exactly what the fetch would send — so the persisted schema
+        never requires a header that would not actually authenticate.
+        sly_data_http_header_urls only yields URLs whose
+        sly_data["http_headers"][url] is a dict with at least one such
+        name, so the index below is safe and no entry comes out empty.
+
+        When mcp_info.hocon exists but could not be read (loaded_ok False),
+        the file-server set is UNKNOWN, so genuinely client-token servers
+        cannot be told apart from file-configured-but-unreadable ones. Emit
+        no client-token schema in that case rather than bake a wrong
+        required-list into the persisted (durable) network; a re-persist
+        once the config is fixed produces the correct schema.
+
+        :param load: The mcp_info.hocon load result.
+        :return: {server URL: header names}, empty when the file load
+                failed or the conversation supplied no client-token server.
+        """
+        if not load.loaded_ok:
+            self.logger.warning(
+                "MCP servers info file could not be read; omitting client-token sly_data_schema "
+                "from the persisted network until the file is valid again."
+            )
+            return {}
+        client_token_mcp_headers: dict[str, list[str]] = {}
+        for url in GetMcpTool.sly_data_http_header_urls(self.sly_data):
+            if url not in load.urls:
+                client_token_mcp_headers[url] = McpHeaderHygiene.usable_header_names(
+                    self.sly_data["http_headers"][url]
+                )
+        return client_token_mcp_headers
+
     async def _assemble_and_persist(
         self,
         network_def: dict[str, Any],
@@ -263,40 +308,9 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.logger.info("Agent Network Name: %s", agent_network_name)
 
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names()
-        # None when mcp_info.hocon exists but could not be read/parsed: the
-        # file-server set is then UNKNOWN, so we cannot tell which sly_data
-        # servers are genuinely client-token vs file-configured-but-unreadable.
-        # Emit no client-token schema in that case rather than bake a wrong
-        # required-list into the persisted (durable) network; a re-persist
-        # once the config is fixed produces the correct schema.
-        file_servers: list[str] | None = await GetMcpTool.get_mcp_servers_or_none()
-        if file_servers is None:
-            self.logger.warning(
-                "MCP servers info file could not be read; omitting client-token sly_data_schema "
-                "from the persisted network until the file is valid again."
-            )
-            file_servers = []
-            client_token_mcp_headers: dict[str, list[str]] = {}
-        else:
-            # Client-token servers: the ones this conversation supplied auth
-            # headers for via sly_data (nsflow injects one per connected server
-            # when chatting with the designer) that are not file-configured.
-            # Map each to the usable header names supplied for it (names only,
-            # never values), so the schema declares the actual headers a server
-            # needs rather than assuming "Authorization". usable_header_names
-            # owns which names count — stripped, legal field names with
-            # non-blank values, exactly what the fetch would send — so the
-            # persisted schema never requires a header that would not
-            # actually authenticate. sly_data_http_header_urls only yields
-            # URLs whose sly_data["http_headers"][url] is a dict with at
-            # least one such name, so the index below is safe and no entry
-            # comes out empty.
-            client_token_mcp_headers = {
-                url: GetMcpTool.usable_header_names(self.sly_data["http_headers"][url])
-                for url in GetMcpTool.sly_data_http_header_urls(self.sly_data)
-                if url not in file_servers
-            }
-        mcp_servers: list[str] = file_servers + list(client_token_mcp_headers)
+        load: McpServersLoad = await GetMcpTool.get_mcp_servers_load()
+        client_token_mcp_headers: dict[str, list[str]] = self._client_token_mcp_headers(load)
+        mcp_servers: list[str] = load.urls + list(client_token_mcp_headers)
         persistor: AgentNetworkPersistor = AgentNetworkPersistorFactory.create_persistor(
             {"reservationist": self.reservationist},
             WRITE_TO_FILE,

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -281,13 +281,18 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
             # Client-token servers: the ones this conversation supplied auth
             # headers for via sly_data (nsflow injects one per connected server
             # when chatting with the designer) that are not file-configured.
-            # Map each to the header names supplied for it (names only, never
-            # values), so the schema declares the actual headers a server
-            # needs rather than assuming "Authorization". sly_data_http_header_urls
-            # only yields URLs whose sly_data["http_headers"][url] is a dict,
-            # so the index below is safe.
+            # Map each to the usable header names supplied for it (names only,
+            # never values), so the schema declares the actual headers a server
+            # needs rather than assuming "Authorization". usable_header_names
+            # owns which names count — stripped, legal field names with
+            # non-blank values, exactly what the fetch would send — so the
+            # persisted schema never requires a header that would not
+            # actually authenticate. sly_data_http_header_urls only yields
+            # URLs whose sly_data["http_headers"][url] is a dict with at
+            # least one such name, so the index below is safe and no entry
+            # comes out empty.
             client_token_mcp_headers = {
-                url: [name for name in self.sly_data["http_headers"][url] if isinstance(name, str)]
+                url: GetMcpTool.usable_header_names(self.sly_data["http_headers"][url])
                 for url in GetMcpTool.sly_data_http_header_urls(self.sly_data)
                 if url not in file_servers
             }

--- a/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
+++ b/middleware/agent_network_designer/persistence/agent_network_persistence_middleware.py
@@ -263,22 +263,34 @@ class AgentNetworkPersistenceMiddleware(AgentMiddleware):
         self.logger.info("Agent Network Name: %s", agent_network_name)
 
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names()
-        file_servers: list[str] = await GetMcpTool.get_mcp_servers()
-        # Client-token servers: the ones this conversation supplied auth
-        # headers for via sly_data (nsflow injects one per connected server
-        # when chatting with the designer) that are not file-configured.
-        # These drive the generated network's sly_data_schema.
-        # Map each client-token URL to the header names the conversation
-        # supplied for it (names only, never values), so the generated
-        # sly_data_schema declares the actual headers a server needs rather
-        # than assuming "Authorization". sly_data_http_header_urls only
-        # yields URLs whose sly_data["http_headers"][url] is a dict, so the
-        # index below is safe.
-        client_token_mcp_headers: dict[str, list[str]] = {
-            url: [name for name in self.sly_data["http_headers"][url] if isinstance(name, str)]
-            for url in GetMcpTool.sly_data_http_header_urls(self.sly_data)
-            if url not in file_servers
-        }
+        # None when mcp_info.hocon exists but could not be read/parsed: the
+        # file-server set is then UNKNOWN, so we cannot tell which sly_data
+        # servers are genuinely client-token vs file-configured-but-unreadable.
+        # Emit no client-token schema in that case rather than bake a wrong
+        # required-list into the persisted (durable) network; a re-persist
+        # once the config is fixed produces the correct schema.
+        file_servers: list[str] | None = await GetMcpTool.get_mcp_servers_or_none()
+        if file_servers is None:
+            self.logger.warning(
+                "MCP servers info file could not be read; omitting client-token sly_data_schema "
+                "from the persisted network until the file is valid again."
+            )
+            file_servers = []
+            client_token_mcp_headers: dict[str, list[str]] = {}
+        else:
+            # Client-token servers: the ones this conversation supplied auth
+            # headers for via sly_data (nsflow injects one per connected server
+            # when chatting with the designer) that are not file-configured.
+            # Map each to the header names supplied for it (names only, never
+            # values), so the schema declares the actual headers a server
+            # needs rather than assuming "Authorization". sly_data_http_header_urls
+            # only yields URLs whose sly_data["http_headers"][url] is a dict,
+            # so the index below is safe.
+            client_token_mcp_headers = {
+                url: [name for name in self.sly_data["http_headers"][url] if isinstance(name, str)]
+                for url in GetMcpTool.sly_data_http_header_urls(self.sly_data)
+                if url not in file_servers
+            }
         mcp_servers: list[str] = file_servers + list(client_token_mcp_headers)
         persistor: AgentNetworkPersistor = AgentNetworkPersistorFactory.create_persistor(
             {"reservationist": self.reservationist},

--- a/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
@@ -14,6 +14,7 @@
 #
 # END COPYRIGHT
 
+from collections.abc import Collection
 from copy import copy as shallow_copy
 from copy import deepcopy
 from typing import Any
@@ -57,7 +58,7 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
         top_agent_name: str,
         agent_network_name: str,
         sample_queries: list[str],
-        mcp_servers_auth: dict[str, bool] | None = None,
+        client_token_mcp_urls: Collection[str] | None = None,
     ) -> dict[str, Any]:
         """
         Assemble the agent network from the definition.
@@ -66,8 +67,9 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
         :param top_agent_name: The name of the top agent
         :param agent_network_name: The file name, without the .hocon extension
         :param sample_queries: List of sample queries for the agent network
-        :param mcp_servers_auth: Optional {MCP server URL: needs_client_token} mapping
-                driving the front man's sly_data_schema (see the base class)
+        :param client_token_mcp_urls: Optional collection of MCP server URLs whose
+                auth is client-supplied, driving the front man's sly_data_schema
+                (see the base class)
 
         :return: Some representation of the agent network
         """
@@ -91,10 +93,8 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
         if sample_queries:
             agent_network["metadata"] = {"sample_queries": sample_queries}
 
-        # None when the network uses no MCP servers; otherwise placed in the
-        # top agent's function block below so clients (e.g. nsflow) know
-        # which MCP URLs need Authorization headers passed via sly_data.
-        sly_data_schema: dict[str, Any] | None = self.build_mcp_sly_data_schema(use_network_def, mcp_servers_auth)
+        # None when the network uses no client-token MCP servers.
+        sly_data_schema: dict[str, Any] | None = self.build_mcp_sly_data_schema(use_network_def, client_token_mcp_urls)
 
         agent_name: str = None
         agent_def: dict[str, Any] = {}

--- a/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
@@ -15,6 +15,7 @@
 # END COPYRIGHT
 
 from collections.abc import Collection
+from collections.abc import Mapping
 from copy import copy as shallow_copy
 from copy import deepcopy
 from typing import Any
@@ -58,7 +59,7 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
         top_agent_name: str,
         agent_network_name: str,
         sample_queries: list[str],
-        client_token_mcp_urls: Collection[str] | None = None,
+        client_token_mcp_headers: Mapping[str, Collection[str]] | None = None,
     ) -> dict[str, Any]:
         """
         Assemble the agent network from the definition.
@@ -67,9 +68,9 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
         :param top_agent_name: The name of the top agent
         :param agent_network_name: The file name, without the .hocon extension
         :param sample_queries: List of sample queries for the agent network
-        :param client_token_mcp_urls: Optional collection of MCP server URLs whose
-                auth is client-supplied, driving the front man's sly_data_schema
-                (see the base class)
+        :param client_token_mcp_headers: Optional mapping of client-token MCP
+                server URL to the header names the conversation supplied for it,
+                driving the front man's sly_data_schema (see the base class)
 
         :return: Some representation of the agent network
         """
@@ -94,7 +95,9 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
             agent_network["metadata"] = {"sample_queries": sample_queries}
 
         # None when the network uses no client-token MCP servers.
-        sly_data_schema: dict[str, Any] | None = self.build_mcp_sly_data_schema(use_network_def, client_token_mcp_urls)
+        sly_data_schema: dict[str, Any] | None = self.build_mcp_sly_data_schema(
+            use_network_def, client_token_mcp_headers
+        )
 
         agent_name: str = None
         agent_def: dict[str, Any] = {}

--- a/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
@@ -50,9 +50,14 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
         self.template: dict[str, Any] = None
         self.aaosa_defs: dict[str, Any] = None
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals, too-many-arguments, too-many-positional-arguments
     async def assemble_agent_network(
-        self, network_def: dict[str, Any], top_agent_name: str, agent_network_name: str, sample_queries: list[str]
+        self,
+        network_def: dict[str, Any],
+        top_agent_name: str,
+        agent_network_name: str,
+        sample_queries: list[str],
+        mcp_servers_auth: dict[str, bool] | None = None,
     ) -> dict[str, Any]:
         """
         Assemble the agent network from the definition.
@@ -61,6 +66,8 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
         :param top_agent_name: The name of the top agent
         :param agent_network_name: The file name, without the .hocon extension
         :param sample_queries: List of sample queries for the agent network
+        :param mcp_servers_auth: Optional {MCP server URL: needs_client_token} mapping
+                driving the front man's sly_data_schema (see the base class)
 
         :return: Some representation of the agent network
         """
@@ -83,6 +90,11 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
         # Add metadata if sample queries are provided
         if sample_queries:
             agent_network["metadata"] = {"sample_queries": sample_queries}
+
+        # None when the network uses no MCP servers; otherwise placed in the
+        # top agent's function block below so clients (e.g. nsflow) know
+        # which MCP URLs need Authorization headers passed via sly_data.
+        sly_data_schema: dict[str, Any] | None = self.build_mcp_sly_data_schema(use_network_def, mcp_servers_auth)
 
         agent_name: str = None
         agent_def: dict[str, Any] = {}
@@ -131,6 +143,12 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
                     agent_spec["function"]["description"] = (
                         agent_description or "An assistant that answers inquiries from the user."
                     )
+                    # Injected after filter_agent() on purpose: there is no
+                    # template placeholder to delete for the no-MCP case, and
+                    # the URL keys never pass through the string filter's
+                    # {placeholder} replacement.
+                    if sly_data_schema:
+                        agent_spec["function"]["sly_data_schema"] = sly_data_schema
                 else:
                     agent_spec["function"]["description"] = agent_description
 

--- a/middleware/agent_network_designer/persistence/deployable_template.hocon
+++ b/middleware/agent_network_designer/persistence/deployable_template.hocon
@@ -53,6 +53,10 @@ Do not mention what you can NOT do. Only mention what you can do.
     "tools": [
 
         # Top agent template
+        # Note: the assembler sets "function.description" in code after
+        # filtering, and — when the network uses MCP servers — also injects
+        # a "function.sly_data_schema" declaring the http_headers clients
+        # must pass via sly_data (see DeployableAgentNetworkAssembler).
         {
             "name": "{agent_name}",
             "function": "aaosa_call",

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -256,7 +256,12 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
             return ""
         indent: str = " " * 16
         lines: list[str] = json.dumps(schema, indent=4, ensure_ascii=False).splitlines()
-        body: str = "\n".join([lines[0]] + [indent + line for line in lines[1:]])
+        # Re-indent every line but the first ("{"), which lands right after
+        # the key on the same line and needs no leading spaces of its own.
+        body_lines: list[str] = [lines[0]]
+        for line in lines[1:]:
+            body_lines.append(indent + line)
+        body: str = "\n".join(body_lines)
         return f',\n{indent}"sly_data_schema": {body}'
 
     def _render_agent_block(

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -16,6 +16,7 @@
 
 import datetime
 import json
+from collections.abc import Collection
 from copy import copy as shallow_copy
 from typing import Any
 
@@ -141,7 +142,7 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         top_agent_name: str,
         agent_network_name: str,
         sample_queries: list[str],
-        mcp_servers_auth: dict[str, bool] | None = None,
+        client_token_mcp_urls: Collection[str] | None = None,
     ) -> str:
         """
         Substitutes value from agent network definition into the template of agent network HOCON file
@@ -150,8 +151,9 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         :param top_agent_name: The name of the top agent
         :param agent_network_name: The file name, without the .hocon extension
         :param sample_queries: List of sample queries for the agent network
-        :param mcp_servers_auth: Optional {MCP server URL: needs_client_token} mapping
-                driving the front man's sly_data_schema (see the base class)
+        :param client_token_mcp_urls: Optional collection of MCP server URLs whose
+                auth is client-supplied, driving the front man's sly_data_schema
+                (see the base class)
 
         :return: A full agent network HOCON as a string.
         """
@@ -161,7 +163,7 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         header: str = self._build_header(agent_network_name, sample_queries)
 
         sly_data_schema_block: str = self._render_sly_data_schema_block(
-            self.build_mcp_sly_data_schema(use_network_def, mcp_servers_auth)
+            self.build_mcp_sly_data_schema(use_network_def, client_token_mcp_urls)
         )
 
         body: list[str] = []
@@ -239,9 +241,12 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         :return: "" when there is no schema (leaving the template output
                 unchanged), else a block starting with the comma that
                 separates it from the description entry. JSON is valid
-                HOCON, and json.dumps output keeps the URL keys quoted and
-                cannot contain ${...} substitutions, so the fragment always
-                parses as written.
+                HOCON, and the fragment always parses as written because
+                json.dumps keeps every key and value double-quoted and
+                HOCON performs no ${...} substitution inside double-quoted
+                strings (json.dumps does NOT escape $ or { — a URL
+                containing ${...} survives verbatim, safely, only thanks to
+                the quoting).
         """
         if not schema:
             return ""

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -17,6 +17,7 @@
 import datetime
 import json
 from collections.abc import Collection
+from collections.abc import Mapping
 from copy import copy as shallow_copy
 from typing import Any
 
@@ -142,7 +143,7 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         top_agent_name: str,
         agent_network_name: str,
         sample_queries: list[str],
-        client_token_mcp_urls: Collection[str] | None = None,
+        client_token_mcp_headers: Mapping[str, Collection[str]] | None = None,
     ) -> str:
         """
         Substitutes value from agent network definition into the template of agent network HOCON file
@@ -151,9 +152,9 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         :param top_agent_name: The name of the top agent
         :param agent_network_name: The file name, without the .hocon extension
         :param sample_queries: List of sample queries for the agent network
-        :param client_token_mcp_urls: Optional collection of MCP server URLs whose
-                auth is client-supplied, driving the front man's sly_data_schema
-                (see the base class)
+        :param client_token_mcp_headers: Optional mapping of client-token MCP
+                server URL to the header names the conversation supplied for it,
+                driving the front man's sly_data_schema (see the base class)
 
         :return: A full agent network HOCON as a string.
         """
@@ -163,7 +164,7 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         header: str = self._build_header(agent_network_name, sample_queries)
 
         sly_data_schema_block: str = self._render_sly_data_schema_block(
-            self.build_mcp_sly_data_schema(use_network_def, client_token_mcp_urls)
+            self.build_mcp_sly_data_schema(use_network_def, client_token_mcp_headers)
         )
 
         body: list[str] = []
@@ -246,12 +247,15 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
                 HOCON performs no ${...} substitution inside double-quoted
                 strings (json.dumps does NOT escape $ or { — a URL
                 containing ${...} survives verbatim, safely, only thanks to
-                the quoting).
+                the quoting). ensure_ascii=False keeps a non-ASCII URL key
+                as its raw character: pyhocon does not decode \\uXXXX
+                escapes, so an escaped key would read back as literal text
+                that no longer matches the raw URL in the tools list.
         """
         if not schema:
             return ""
         indent: str = " " * 16
-        lines: list[str] = json.dumps(schema, indent=4).splitlines()
+        lines: list[str] = json.dumps(schema, indent=4, ensure_ascii=False).splitlines()
         body: str = "\n".join([lines[0]] + [indent + line for line in lines[1:]])
         return f',\n{indent}"sly_data_schema": {body}'
 

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -15,6 +15,7 @@
 # END COPYRIGHT
 
 import datetime
+import json
 from copy import copy as shallow_copy
 from typing import Any
 
@@ -67,7 +68,10 @@ TOP_AGENT_TEMPLATE = (
     '            "function": ${aaosa_call}{\n'
     '                "description": """\n'
     "%s\n"
-    '                """\n'
+    # The slot after the closing triple quotes takes the optional
+    # sly_data_schema block (see _render_sly_data_schema_block), which
+    # starts with the separating comma when present.
+    '                """%s\n'
     "            },\n"
     '            "instructions": ${instructions_prefix} """\n'
     "            Never express irrelevance unless you have first consulted all your tools.\n"
@@ -111,7 +115,6 @@ TOOLBOX_AGENT_TEMPLATE = "        {\n" '            "name": "%s",\n' '          
 # fmt: on
 
 
-# pylint: disable=too-few-public-methods
 class HoconAgentNetworkAssembler(AgentNetworkAssembler):
     """
     AgentNetworkAssembler implementation which creates a full hocon of a designed agent network
@@ -131,8 +134,14 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         """
         self.demo_mode: bool = demo_mode
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     async def assemble_agent_network(
-        self, network_def: dict[str, Any], top_agent_name: str, agent_network_name: str, sample_queries: list[str]
+        self,
+        network_def: dict[str, Any],
+        top_agent_name: str,
+        agent_network_name: str,
+        sample_queries: list[str],
+        mcp_servers_auth: dict[str, bool] | None = None,
     ) -> str:
         """
         Substitutes value from agent network definition into the template of agent network HOCON file
@@ -141,6 +150,8 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         :param top_agent_name: The name of the top agent
         :param agent_network_name: The file name, without the .hocon extension
         :param sample_queries: List of sample queries for the agent network
+        :param mcp_servers_auth: Optional {MCP server URL: needs_client_token} mapping
+                driving the front man's sly_data_schema (see the base class)
 
         :return: A full agent network HOCON as a string.
         """
@@ -149,9 +160,13 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
 
         header: str = self._build_header(agent_network_name, sample_queries)
 
+        sly_data_schema_block: str = self._render_sly_data_schema_block(
+            self.build_mcp_sly_data_schema(use_network_def, mcp_servers_auth)
+        )
+
         body: list[str] = []
         for agent_name, agent in use_network_def.items():
-            body.append(self._render_agent_block(agent_name, agent, top_agent_name))
+            body.append(self._render_agent_block(agent_name, agent, top_agent_name, sly_data_schema_block))
 
         return header + "".join(body) + "]\n}\n"
 
@@ -212,13 +227,40 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
             + HOCON_HEADER_REMAINDER % demo_mode_block
         )
 
-    def _render_agent_block(self, agent_name: str, agent: dict[str, Any], top_agent_name: str) -> str:
+    @staticmethod
+    def _render_sly_data_schema_block(schema: dict[str, Any] | None) -> str:
+        """
+        Render the front man's sly_data_schema as a HOCON fragment for the
+        TOP_AGENT_TEMPLATE slot that follows the description's closing
+        triple quotes.
+
+        :param schema: The schema dict from build_mcp_sly_data_schema, or None
+
+        :return: "" when there is no schema (leaving the template output
+                unchanged), else a block starting with the comma that
+                separates it from the description entry. JSON is valid
+                HOCON, and json.dumps output keeps the URL keys quoted and
+                cannot contain ${...} substitutions, so the fragment always
+                parses as written.
+        """
+        if not schema:
+            return ""
+        indent: str = " " * 16
+        lines: list[str] = json.dumps(schema, indent=4).splitlines()
+        body: str = "\n".join([lines[0]] + [indent + line for line in lines[1:]])
+        return f',\n{indent}"sly_data_schema": {body}'
+
+    def _render_agent_block(
+        self, agent_name: str, agent: dict[str, Any], top_agent_name: str, sly_data_schema_block: str = ""
+    ) -> str:
         """
         Render a single agent block depending on its type.
 
         :param agent_name: The name of the agent
         :param agent: The agent definition
         :param top_agent_name: The name of the top agent
+        :param sly_data_schema_block: Rendered sly_data_schema fragment for the
+                top agent's function block ("" for none)
 
         :return: The rendered agent block as a string.
         """
@@ -230,7 +272,7 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
 
         if agent_name == top_agent_name:
             use_description = description or "An assistant that answers inquiries from the user."
-            return TOP_AGENT_TEMPLATE % (agent_name, use_description, instructions, tools)
+            return TOP_AGENT_TEMPLATE % (agent_name, use_description, sly_data_schema_block, instructions, tools)
 
         if raw_tools:
             return REGULAR_AGENT_TEMPLATE % (agent_name, description, instructions, tools)

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -64,7 +64,13 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
         # are only saved into the local manifest on local runs, where the
         # fingerprint TTL bounds any staleness from the designer's own saves.
         subnetwork_names: list[str] = await GetSubnetwork.get_subnetwork_names()
+        # File-configured servers plus the per-conversation servers the
+        # client supplied auth headers for via sly_data (nsflow injects one
+        # per connected server when chatting with the designer) — the same
+        # union get_mcp_tool listed for the LLM, so a network referencing a
+        # connected-only server validates.
         mcp_servers: list[str] = await GetMcpTool.get_mcp_servers()
+        mcp_servers += [url for url in GetMcpTool.sly_data_http_header_urls(self.sly_data) if url not in mcp_servers]
         toolbox_tools: dict[str, Any] = await GetToolbox.get_toolbox_info()
 
         return (

--- a/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
+++ b/middleware/agent_network_designer/validation/agent_network_structure_validation_middleware.py
@@ -68,9 +68,12 @@ class AgentNetworkStructureValidationMiddleware(AgentNetworkValidationMiddleware
         # client supplied auth headers for via sly_data (nsflow injects one
         # per connected server when chatting with the designer) — the same
         # union get_mcp_tool listed for the LLM, so a network referencing a
-        # connected-only server validates.
+        # connected-only server validates. get_mcp_servers returns a fresh
+        # copy, so appending here cannot corrupt the shared cache.
         mcp_servers: list[str] = await GetMcpTool.get_mcp_servers()
-        mcp_servers += [url for url in GetMcpTool.sly_data_http_header_urls(self.sly_data) if url not in mcp_servers]
+        for url in GetMcpTool.sly_data_http_header_urls(self.sly_data):
+            if url not in mcp_servers:
+                mcp_servers.append(url)
         toolbox_tools: dict[str, Any] = await GetToolbox.get_toolbox_info()
 
         return (

--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -145,6 +145,17 @@ This can be used to invoke the newly created network later on the same server/cl
                                 }
                             }
                         },
+                        "http_headers": {
+                            "type": "object",
+                            "description": """
+Optional per-MCP-server HTTP headers, keyed by server URL, e.g.
+{"https://mcp.example.com/mcp": {"Authorization": "Bearer <token>"}}.
+Lets the designer list tools from OAuth-protected MCP servers and declare them in
+generated networks. nsflow injects headers for every connected server automatically
+when chatting with this network; other clients may supply them explicitly.
+No specific URLs are declared here because the set depends on what the user has connected.
+"""
+                        },
                         "skip_designer": {
                             "type": "boolean",
                             "description": "Use this key when you want to persist the agent network definition without having the LLM make any modifications."
@@ -255,9 +266,15 @@ Operational notes:
                     "messages": ["/agent_network_editor", "/agent_network_query_generator", "/agent_network_instructions_editor"]
                 },
                 "to_downstream": {
+                    # http_headers carries the per-conversation MCP auth headers an OAuth-capable
+                    # client (nsflow) injects into sly_data for the designer (nsflow injects ALL
+                    # connected servers' tokens when chatting with this network). It must flow to
+                    # /agent_network_editor so its get_mcp_tool can list OAuth-protected MCP
+                    # servers' tools. The other subnetworks ignore it, and no to_upstream /
+                    # to_tracing allowlist includes it, so tokens never leave the server side.
                     # Optionally propagate any BYOK keys to downstream tools.
                     "sly_data": ["agent_network_definition", "agent_network_name", "agent_network_queries",
-                                 ${?llm_config_key}]
+                                 "http_headers", ${?llm_config_key}]
                 },
                 "to_tracing": {
                     # These keys are not considered private and OK to send to an Observability backend

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Neuro SAN
 leaf-common>=1.2.51
 neuro-san==0.6.91
-nsflow==0.6.17
+nsflow==0.6.18
 
 # For config parsing
 pyhocon>=0.3.60

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -324,12 +324,17 @@ class TestGetMcpToolDescriptions(TestCase):
 
         return mock.patch.object(GetMcpTool, "_fetch_tool_descriptions", new=fake_fetch)
 
-    def _patched_servers(self, servers: list[str] | None = None, tokens: dict[str, str] | None = None):
+    def _patched_servers(
+        self,
+        servers: list[str] | None = None,
+        tokens: dict[str, str] | None = None,
+        in_info_file: bool = False,
+    ):
         """Pin the servers half so these tests never read the real config file."""
         pinned = MCP_SERVERS if servers is None else servers
         tokens = tokens or {}
         infos: dict[str, dict] = {
-            server: {"has_file_headers": False, "access_token": tokens.get(server)} for server in pinned
+            server: {"in_info_file": in_info_file, "access_token": tokens.get(server)} for server in pinned
         }
         return mock.patch.object(GetMcpTool._shared_mcp_servers_cache, "get", new=mock.Mock(return_value=infos))
 
@@ -436,6 +441,21 @@ class TestGetMcpToolDescriptions(TestCase):
         self.assertIsNone(self.headers_log[MCP_SERVERS[1]])
         # The token itself never surfaces in what the LLM will see.
         self.assertNotIn("tok-0", str(result))
+
+    def test_an_info_file_server_ignores_a_stored_token(self):
+        """File-configured servers keep their (refreshable) file auth: a leftover
+        stored token could be stale and would hide the server on a 401."""
+        tokens = {server: f"tok-{i}" for i, server in enumerate(MCP_SERVERS)}
+
+        with (
+            mock.patch.dict(os.environ, {TTL_ENV: "100000"}),
+            self._patched_servers(tokens=tokens, in_info_file=True),
+            self._patched_fetches(),
+        ):
+            asyncio.run(GetMcpTool.get_mcp_tool_descriptions())
+
+        for server in MCP_SERVERS:
+            self.assertIsNone(self.headers_log[server])
 
     def test_registry_covers_both_mcp_caches(self):
         """globals' REGISTRY triples must resolve now that get_mcp_tool is imported."""

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -189,6 +189,29 @@ class TestSlyDataHttpHeaderUrls(TestCase):
         }
         self.assertEqual(GetMcpTool.sly_data_http_header_urls(sly_data), ["https://good.example/mcp"])
 
+    def test_non_http_urls_are_skipped(self):
+        """Only http(s) MCP URLs count; a '/'-path or other scheme is not a server."""
+        sly_data = {
+            "http_headers": {
+                "/internal_admin_network": {"Authorization": "Bearer x"},
+                "ftp://host/mcp": {"Authorization": "Bearer y"},
+                "https://ok.example/mcp": {"Authorization": "Bearer z"},
+            }
+        }
+        self.assertEqual(GetMcpTool.sly_data_http_header_urls(sly_data), ["https://ok.example/mcp"])
+
+    def test_urls_without_a_usable_header_are_skipped(self):
+        """An empty dict, a blank value, or a non-string value supplies no credential."""
+        sly_data = {
+            "http_headers": {
+                "https://empty.example/mcp": {},
+                "https://blank.example/mcp": {"Authorization": "   "},
+                "https://nonstr.example/mcp": {"Authorization": 123},
+                "https://ok.example/mcp": {"Authorization": "Bearer tok"},
+            }
+        }
+        self.assertEqual(GetMcpTool.sly_data_http_header_urls(sly_data), ["https://ok.example/mcp"])
+
 
 class TestGetMcpToolDescriptions(TestCase):
     """Publish/degrade policy for the shared cache, plus the sly_data path."""

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -42,8 +42,8 @@ from coded_tools.agent_network_editor.get_mcp_tool import BUNDLED_MCP_INFO_FILE 
 from coded_tools.agent_network_editor.get_mcp_tool import DEFAULT_MCP_TOOLS_FETCH_TIMEOUT_SECONDS  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import DEFAULT_MCP_TOOLS_TTL_SECONDS  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import GetMcpTool  # noqa: E402
-from coded_tools.agent_network_editor.get_mcp_tool import _McpServersLoad  # noqa: E402
 from coded_tools.agent_network_editor.globals import ProcessGlobals  # noqa: E402
+from coded_tools.agent_network_editor.mcp_servers_load import McpServersLoad  # noqa: E402
 
 MCP_SERVERS: list[str] = ["https://one.example/mcp", "https://two.example/mcp"]
 
@@ -157,13 +157,14 @@ class TestGetMcpServers(TestCase):
             ):
                 self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers()), [])
 
-    def test_or_none_returns_none_only_when_the_file_load_failed(self):
-        """A broken file is 'unknown' (None); missing/empty/good files are not."""
+    def test_load_reports_a_failure_only_when_the_file_load_failed(self):
+        """A broken file is 'unknown' (loaded_ok False); missing, empty, and
+        good files all load ok."""
         # A missing file is an authoritative empty, not a failure.
         with mock.patch.dict(os.environ, {"MCP_SERVERS_INFO_FILE": "/nonexistent/mcp_info.hocon"}):
-            self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers_or_none()), [])
+            self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers_load()), McpServersLoad([], True))
 
-        # A file that exists but cannot be read/parsed is unknown → None.
+        # A file that exists but cannot be read/parsed is unknown.
         for error in (OSError("permission denied"), ValueError("bad hocon")):
             GetMcpTool.clear_shared_mcp_servers_for_testing()
             restorer = mock.Mock()
@@ -171,14 +172,16 @@ class TestGetMcpServers(TestCase):
             with mock.patch(
                 "coded_tools.agent_network_editor.get_mcp_tool.McpServersInfoRestorer", return_value=restorer
             ):
-                self.assertIsNone(asyncio.run(GetMcpTool.get_mcp_servers_or_none()))
+                self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers_load()), McpServersLoad([], False))
 
-        # A file that loads returns its URLs (never None), even if empty.
+        # A file that loads reports its URLs with loaded_ok True.
         GetMcpTool.clear_shared_mcp_servers_for_testing()
         restorer = mock.Mock()
         restorer.restore.return_value = {"https://one.example/mcp": {}}
         with mock.patch("coded_tools.agent_network_editor.get_mcp_tool.McpServersInfoRestorer", return_value=restorer):
-            self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers_or_none()), ["https://one.example/mcp"])
+            self.assertEqual(
+                asyncio.run(GetMcpTool.get_mcp_servers_load()), McpServersLoad(["https://one.example/mcp"], True)
+            )
 
 
 class TestSlyDataHttpHeaderUrls(TestCase):
@@ -267,7 +270,7 @@ class TestGetMcpToolDescriptions(TestCase):
     def _patched_servers(self, servers: list[str] | None = None):
         """Pin the servers half so these tests never read the real config file."""
         pinned = MCP_SERVERS if servers is None else servers
-        loaded = _McpServersLoad(list(pinned), True)
+        loaded = McpServersLoad(list(pinned), True)
         return mock.patch.object(GetMcpTool._shared_mcp_servers_cache, "get", new=mock.Mock(return_value=loaded))
 
     def test_concurrent_callers_share_one_fetch_and_warm_reads_are_free(self):
@@ -524,7 +527,8 @@ class TestFetchToolDescriptions(TestCase):
 
     def test_exception_group_leaves_surface_in_the_failure_log(self):
         """The drop-path warning must show the buried cause (e.g. a 401),
-        not just anyio's opaque 'unhandled errors in a TaskGroup' text."""
+        not anyio's opaque 'unhandled errors in a TaskGroup' text (the leaf
+        rendering itself is pinned in test_mcp_header_hygiene.py)."""
         if sys.version_info < (3, 11):
             self.skipTest("ExceptionGroup is a 3.11+ builtin")
 
@@ -532,9 +536,6 @@ class TestFetchToolDescriptions(TestCase):
             "unhandled errors in a TaskGroup",
             [ExceptionGroup("inner", [ValueError("401 Unauthorized for url 'https://auth.example'")]), KeyError("k")],
         )
-        summary = GetMcpTool._error_summary(nested)
-        self.assertIn("401 Unauthorized", summary)
-        self.assertIn("KeyError", summary)
 
         async def raises_the_group(_server: str, headers: dict | None = None) -> list:
             raise nested
@@ -542,8 +543,10 @@ class TestFetchToolDescriptions(TestCase):
         with self._patched_adapter(raises_the_group), self.assertLogs(level="WARNING") as captured:
             _server, description = asyncio.run(GetMcpTool._fetch_tool_descriptions("https://auth.example", 5.0))
 
+        logged = "\n".join(captured.output)
         self.assertIsNone(description)
-        self.assertIn("401 Unauthorized", "\n".join(captured.output))
+        self.assertIn("401 Unauthorized", logged)
+        self.assertNotIn("TaskGroup", logged)
 
     def test_a_leaked_header_value_is_redacted_from_the_failure_log(self):
         """A value-bearing error (mimicking h11) must not put the token in the log."""
@@ -562,107 +565,3 @@ class TestFetchToolDescriptions(TestCase):
         self.assertIsNone(description)
         self.assertNotIn("FAKE-SECRET-xyz", logged)
         self.assertIn("***", logged)
-
-
-class TestSanitizedHeaders(TestCase):
-    """Boundary cleaning of the per-conversation header dict before it is sent."""
-
-    def test_outer_whitespace_is_stripped(self):
-        """A newline-tailed token is trimmed so it still authenticates."""
-        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": "  Bearer tok\n"})
-        self.assertEqual(cleaned, {"Authorization": "Bearer tok"})
-
-    def test_a_clean_value_passes_through_unchanged(self):
-        """A well-formed value is returned as-is."""
-        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": "Bearer tok", "X-Api-Key": "k"})
-        self.assertEqual(cleaned, {"Authorization": "Bearer tok", "X-Api-Key": "k"})
-
-    def test_a_mid_value_tab_is_allowed(self):
-        """Tab is a legal header-value character; only other controls are illegal."""
-        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"X-Api-Key": "a\tb"})
-        self.assertEqual(cleaned, {"X-Api-Key": "a\tb"})
-
-    def test_an_embedded_control_char_drops_the_header_and_logs_name_only(self):
-        """A value with an embedded control char is dropped; the value never logs."""
-        with self.assertLogs(level="WARNING") as captured:
-            cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": "Bearer\nSECRET"})
-
-        self.assertEqual(cleaned, {})
-        logged = "\n".join(captured.output)
-        self.assertIn("Authorization", logged)
-        self.assertNotIn("SECRET", logged)
-
-    def test_non_string_names_and_values_are_skipped(self):
-        """Malformed shapes are dropped rather than raising."""
-        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": 123, 42: "x", "X-Api-Key": "k"})
-        self.assertEqual(cleaned, {"X-Api-Key": "k"})
-
-    def test_a_name_with_outer_whitespace_is_stripped(self):
-        """Names get the same recoverable-trim treatment as values."""
-        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {" Authorization ": "Bearer tok"})
-        self.assertEqual(cleaned, {"Authorization": "Bearer tok"})
-
-    def test_an_illegal_name_drops_the_header_without_echoing_it(self):
-        """A name that is still illegal after the outer-whitespace trim (an
-        EMBEDDED control char, space, or colon) would fail the whole request
-        at send time, so it is dropped up front — and never echoed, since
-        junk in the name slot could be a misplaced secret. Well-formed
-        headers still go through."""
-        with self.assertLogs(level="WARNING") as captured:
-            cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"X-NAME\rSECRET": "v", "  ": "w", "X-Api-Key": "k"})
-
-        self.assertEqual(cleaned, {"X-Api-Key": "k"})
-        logged = "\n".join(captured.output)
-        self.assertNotIn("SECRET", logged)
-        self.assertIn(CLIENT_URL, logged)
-
-    def test_a_blank_value_is_skipped_silently(self):
-        """A blank value supplies no credential: not sent, and not worth a
-        warning — mirroring how usable_header_names classifies it."""
-        with self.assertNoLogs(level="WARNING"):
-            cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": "  \n", "X-Api-Key": "k"})
-        self.assertEqual(cleaned, {"X-Api-Key": "k"})
-
-
-class TestUsableHeaderNames(TestCase):
-    """The single owner of which client-supplied header names count."""
-
-    def test_names_are_stripped_and_deduped_in_first_appearance_order(self):
-        """Two raw spellings of one name collapse; order is preserved."""
-        headers = {" Authorization ": "Bearer a", "Authorization": "Bearer b", "X-Api-Key": "k"}
-        self.assertEqual(GetMcpTool.usable_header_names(headers), ["Authorization", "X-Api-Key"])
-
-    def test_illegal_names_and_credential_less_values_are_excluded(self):
-        """Only a legal field name with a non-blank string value counts."""
-        headers = {
-            "Auth orization": "Bearer x",
-            "X-Blank": "   ",
-            "X-Non-Str": 123,
-            42: "v",
-            "X-Good": "v",
-        }
-        self.assertEqual(GetMcpTool.usable_header_names(headers), ["X-Good"])
-
-    def test_an_empty_dict_reads_as_no_names(self):
-        """No headers, no contract."""
-        self.assertEqual(GetMcpTool.usable_header_names({}), [])
-
-
-class TestRedactValues(TestCase):
-    """The drop-path log backstop that masks any header value we sent."""
-
-    def test_masks_plain_str_repr_and_bytes_repr_forms(self):
-        """A value must not survive in any form an exception renderer might use."""
-        value = "Bearer FAKE-SECRET-xyz\n"
-        text = f"raw={value} str={value!r} bytes={value.encode()!r}"
-        redacted = GetMcpTool._redact_values(text, {"Authorization": value})
-        self.assertNotIn("FAKE-SECRET-xyz", redacted)
-        self.assertIn("***", redacted)
-
-    def test_none_headers_pass_through(self):
-        """The file-configured path (headers=None) leaves the text untouched."""
-        self.assertEqual(GetMcpTool._redact_values("401 Unauthorized", None), "401 Unauthorized")
-
-    def test_empty_values_are_ignored(self):
-        """An empty header value must not blank-mask unrelated text."""
-        self.assertEqual(GetMcpTool._redact_values("some text", {"X": ""}), "some text")

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -14,21 +14,20 @@
 #
 # END COPYRIGHT
 """
-Policy tests for GetMcpTool's process-wide caches: how the TTL and
-per-server fetch cap are validated, what gets published, what must never be
-published, and how failures degrade. The generic cache mechanism itself is
-covered by test_shared_process_cache.py; these tests pin the policy layered
-on top of it, with the MCP client layer stubbed out.
+Policy tests for GetMcpTool's process-wide caches and its per-conversation
+sly_data path: how the TTL and per-server fetch cap are validated, what gets
+published, what must never be published (or cached), and how failures
+degrade. The generic cache mechanism itself is covered by
+test_shared_process_cache.py; these tests pin the policy layered on top of
+it, with the MCP client layer stubbed out.
 
 Skipped (not failed) in environments whose neuro-san predates the imports
 get_mcp_tool needs, so the suite still collects everywhere.
 """
 
 import asyncio
-import json
 import os
-import tempfile
-from pathlib import Path
+import sys
 from unittest import TestCase
 from unittest import mock
 
@@ -42,27 +41,16 @@ pytest.importorskip("coded_tools.agent_network_editor.get_mcp_tool")
 from coded_tools.agent_network_editor.get_mcp_tool import BUNDLED_MCP_INFO_FILE  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import DEFAULT_MCP_TOOLS_FETCH_TIMEOUT_SECONDS  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import DEFAULT_MCP_TOOLS_TTL_SECONDS  # noqa: E402
-from coded_tools.agent_network_editor.get_mcp_tool import NSFLOW_MCP_TOKENS_FILE_NAME  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import GetMcpTool  # noqa: E402
 from coded_tools.agent_network_editor.globals import ProcessGlobals  # noqa: E402
 
 MCP_SERVERS: list[str] = ["https://one.example/mcp", "https://two.example/mcp"]
 
+# A server the conversation supplies auth headers for (not file-configured).
+CLIENT_URL: str = "https://oauth.example/mcp"
+
 TTL_ENV: str = "AGENT_NETWORK_DESIGNER_MCP_TOOLS_TTL_SECONDS"
 FETCH_TIMEOUT_ENV: str = "AGENT_NETWORK_DESIGNER_MCP_TOOLS_FETCH_TIMEOUT_SECONDS"
-STORAGE_DIR_ENV: str = "NSFLOW_MCP_STORAGE_DIR"
-
-# Points the nsflow token-store resolver away from any real ~/.nsflow on the
-# machine running the tests; the file never exists, so the storage half of
-# the servers union is empty unless a test writes its own store.
-NO_TOKEN_STORE: dict[str, str] = {STORAGE_DIR_ENV: "/nonexistent/mcp_oauth"}
-
-
-def write_token_store(directory: str, entries: dict) -> str:
-    """Write a tokens.json with the given entries; returns the file path."""
-    path = Path(directory) / NSFLOW_MCP_TOKENS_FILE_NAME
-    path.write_text(json.dumps(entries), encoding="utf-8")
-    return str(path)
 
 
 class TestGetMcpToolConfig(TestCase):
@@ -151,23 +139,9 @@ class TestGetMcpServers(TestCase):
         # when run directly through unittest.
         GetMcpTool.clear_shared_mcp_servers_for_testing()
         GetMcpTool.clear_shared_mcp_tool_descriptions_for_testing()
-        # Keep the storage half hermetic: a real ~/.nsflow on the developer
-        # machine must not leak servers into these assertions.
-        env_patch = mock.patch.dict(os.environ, NO_TOKEN_STORE)
-        env_patch.start()
-        self.addCleanup(env_patch.stop)
-
-    @staticmethod
-    def _patched_info_file(info: dict | None):
-        """Patch the mcp_info.hocon half to parse to the given mapping."""
-        restorer = mock.Mock()
-        restorer.restore.return_value = info
-        return mock.patch(
-            "coded_tools.agent_network_editor.get_mcp_tool.McpServersInfoRestorer", return_value=restorer
-        )
 
     def test_a_missing_file_publishes_an_empty_list(self):
-        """No config file means no MCP servers, not an error."""
+        """No config file means no file-configured MCP servers, not an error."""
         with mock.patch.dict(os.environ, {"MCP_SERVERS_INFO_FILE": "/nonexistent/mcp_info.hocon"}):
             self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers()), [])
 
@@ -182,129 +156,46 @@ class TestGetMcpServers(TestCase):
             ):
                 self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers()), [])
 
-    def test_servers_are_the_union_of_file_and_storage(self):
-        """mcp_info.hocon URLs and nsflow OAuth connections merge into one list."""
-        info = {MCP_SERVERS[0]: {"http_headers": {"X-Api-Key": "from-env"}}}
-        with tempfile.TemporaryDirectory() as storage_dir:
-            write_token_store(storage_dir, {MCP_SERVERS[1]: {"tokens": {"access_token": "tok-1"}}})
-            with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}), self._patched_info_file(info):
-                self.assertEqual(sorted(asyncio.run(GetMcpTool.get_mcp_servers())), sorted(MCP_SERVERS))
 
-    def test_a_storage_entry_without_an_access_token_is_not_a_server(self):
-        """Pre-seeded client_info, corrupt entries, and empty tokens don't count."""
-        entries = {
-            "https://client-info-only.example/mcp": {"client_info": {"client_id": "abc"}},
-            "https://corrupt.example/mcp": "not-a-dict",
-            "https://empty-token.example/mcp": {"tokens": {"access_token": ""}},
-            MCP_SERVERS[0]: {"tokens": {"access_token": "tok-0"}},
+class TestSlyDataHttpHeaderUrls(TestCase):
+    """Extraction of the per-conversation MCP header URLs from sly_data."""
+
+    def test_urls_are_extracted_in_order(self):
+        """Well-formed http_headers yields its URL keys, order preserved."""
+        sly_data = {
+            "http_headers": {
+                "https://a.example/mcp": {"Authorization": "Bearer x"},
+                "https://b.example/mcp": {"X-Api-Key": "y"},
+            }
         }
-        with tempfile.TemporaryDirectory() as storage_dir:
-            write_token_store(storage_dir, entries)
-            with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}), self._patched_info_file(None):
-                self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers()), [MCP_SERVERS[0]])
-
-    def test_a_token_store_rewrite_is_a_fingerprint_miss(self):
-        """A new OAuth connection (tokens.json write) must invalidate the cache."""
-        with tempfile.TemporaryDirectory() as storage_dir:
-            with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}):
-                before = GetMcpTool._mcp_sources_fingerprint()
-                tokens_file = write_token_store(storage_dir, {MCP_SERVERS[0]: {"tokens": {"access_token": "tok"}}})
-                after = GetMcpTool._mcp_sources_fingerprint()
-        self.assertNotEqual(before, after)
-        self.assertEqual(after[2], tokens_file)
-
-
-class TestNsflowTokenStorage(TestCase):
-    """Read policy for nsflow's tokens.json: tolerant, attempt-and-drop."""
-
-    def test_a_missing_store_reads_as_empty(self):
-        """No tokens.json just means nsflow has no connections — no error."""
-        with mock.patch.dict(os.environ, NO_TOKEN_STORE):
-            self.assertEqual(GetMcpTool._load_storage_access_tokens(), {})
-
-    def test_corrupt_json_and_a_non_object_top_level_read_as_empty(self):
-        """A hand-edited or truncated store degrades to {} instead of raising."""
-        for content in ("{not json", '["a", "list"]', '"just a string"'):
-            with tempfile.TemporaryDirectory() as storage_dir:
-                Path(storage_dir, NSFLOW_MCP_TOKENS_FILE_NAME).write_text(content, encoding="utf-8")
-                with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}):
-                    self.assertEqual(GetMcpTool._load_storage_access_tokens(), {})
-
-    def test_needs_reauth_and_expired_entries_are_still_read(self):
-        """Attempt-and-drop: stale tokens are tried (and fail downstream), not filtered."""
-        entries = {
-            MCP_SERVERS[0]: {"tokens": {"access_token": "stale"}, "needs_reauth": True, "expires_at": 1},
-        }
-        with tempfile.TemporaryDirectory() as storage_dir:
-            write_token_store(storage_dir, entries)
-            with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}):
-                self.assertEqual(GetMcpTool._load_storage_access_tokens(), {MCP_SERVERS[0]: "stale"})
-
-    def test_the_storage_dir_env_var_is_respected_and_expanded(self):
-        """The resolver honors NSFLOW_MCP_STORAGE_DIR and expands ~."""
-        with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: "~/custom_mcp_store"}):
-            resolved = GetMcpTool.get_nsflow_tokens_file()
-        self.assertEqual(resolved, str(Path("~/custom_mcp_store").expanduser() / NSFLOW_MCP_TOKENS_FILE_NAME))
-        with mock.patch.dict(os.environ):
-            os.environ.pop(STORAGE_DIR_ENV, None)
-            default_resolved = GetMcpTool.get_nsflow_tokens_file()
-        self.assertEqual(default_resolved, str(Path("~/.nsflow/mcp_oauth").expanduser() / NSFLOW_MCP_TOKENS_FILE_NAME))
-
-
-class TestGetMcpServersAuthInfo(TestCase):
-    """The url -> needs-client-token view that drives generated sly_data_schema."""
-
-    def setUp(self):
-        GetMcpTool.clear_shared_mcp_servers_for_testing()
-        GetMcpTool.clear_shared_mcp_tool_descriptions_for_testing()
-
-    def test_info_file_servers_need_no_client_token(self):
-        """mcp_info.hocon servers are a server-side concern — with headers or without."""
-        info = {
-            MCP_SERVERS[0]: {"http_headers": {"X-Api-Key": "from-env"}},
-            MCP_SERVERS[1]: {},  # public/no-auth file server: still not a client concern
-        }
-        with tempfile.TemporaryDirectory() as storage_dir:
-            write_token_store(storage_dir, {"https://oauth-only.example/mcp": {"tokens": {"access_token": "tok"}}})
-            with (
-                mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}),
-                TestGetMcpServers._patched_info_file(info),
-            ):
-                auth_info = asyncio.run(GetMcpTool.get_mcp_servers_auth_info())
-
         self.assertEqual(
-            auth_info,
-            {
-                MCP_SERVERS[0]: False,
-                MCP_SERVERS[1]: False,
-                "https://oauth-only.example/mcp": True,
-            },
+            GetMcpTool.sly_data_http_header_urls(sly_data),
+            ["https://a.example/mcp", "https://b.example/mcp"],
         )
-        for value in auth_info.values():
-            self.assertIsInstance(value, bool)
 
-    def test_a_stored_token_does_not_flip_an_info_file_server(self):
-        """A URL in both sources stays a server-side concern (no client gating)."""
-        info = {MCP_SERVERS[0]: {"http_headers": {"Authorization": "Bearer from-env"}}}
-        with tempfile.TemporaryDirectory() as storage_dir:
-            write_token_store(storage_dir, {MCP_SERVERS[0]: {"tokens": {"access_token": "tok"}}})
-            with (
-                mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}),
-                TestGetMcpServers._patched_info_file(info),
-            ):
-                auth_info = asyncio.run(GetMcpTool.get_mcp_servers_auth_info())
-        self.assertEqual(auth_info, {MCP_SERVERS[0]: False})
+    def test_missing_or_malformed_shapes_read_as_no_urls(self):
+        """Clients control this input: absent/broken shapes must not raise."""
+        for sly_data in (None, {}, {"http_headers": None}, {"http_headers": "not-a-dict"}, {"http_headers": []}):
+            self.assertEqual(GetMcpTool.sly_data_http_header_urls(sly_data), [])
+
+    def test_malformed_entries_are_skipped(self):
+        """Non-string keys and non-dict header values are dropped, not fatal."""
+        sly_data = {
+            "http_headers": {
+                "https://good.example/mcp": {"Authorization": "Bearer x"},
+                42: {"Authorization": "Bearer y"},
+                "https://bad.example/mcp": "not-a-dict",
+            }
+        }
+        self.assertEqual(GetMcpTool.sly_data_http_header_urls(sly_data), ["https://good.example/mcp"])
 
 
 class TestGetMcpToolDescriptions(TestCase):
-    """Publish/degrade policy for the shared tool-descriptions cache."""
+    """Publish/degrade policy for the shared cache, plus the sly_data path."""
 
     def setUp(self):
         GetMcpTool.clear_shared_mcp_servers_for_testing()
         GetMcpTool.clear_shared_mcp_tool_descriptions_for_testing()
-        env_patch = mock.patch.dict(os.environ, NO_TOKEN_STORE)
-        env_patch.start()
-        self.addCleanup(env_patch.stop)
         self.fetch_log: list[str] = []
         self.headers_log: dict[str, dict | None] = {}
         self.listings: dict[str, str] = {server: f"tools of {server}" for server in MCP_SERVERS}
@@ -324,19 +215,10 @@ class TestGetMcpToolDescriptions(TestCase):
 
         return mock.patch.object(GetMcpTool, "_fetch_tool_descriptions", new=fake_fetch)
 
-    def _patched_servers(
-        self,
-        servers: list[str] | None = None,
-        tokens: dict[str, str] | None = None,
-        in_info_file: bool = False,
-    ):
+    def _patched_servers(self, servers: list[str] | None = None):
         """Pin the servers half so these tests never read the real config file."""
         pinned = MCP_SERVERS if servers is None else servers
-        tokens = tokens or {}
-        infos: dict[str, dict] = {
-            server: {"in_info_file": in_info_file, "access_token": tokens.get(server)} for server in pinned
-        }
-        return mock.patch.object(GetMcpTool._shared_mcp_servers_cache, "get", new=mock.Mock(return_value=infos))
+        return mock.patch.object(GetMcpTool._shared_mcp_servers_cache, "get", new=mock.Mock(return_value=list(pinned)))
 
     def test_concurrent_callers_share_one_fetch_and_warm_reads_are_free(self):
         """A cold burst fetches each server once; warm reads fetch nothing."""
@@ -424,38 +306,51 @@ class TestGetMcpToolDescriptions(TestCase):
 
         self.assertEqual(result, str(self.listings))
 
-    def test_a_storage_token_is_sent_as_a_bearer_header(self):
-        """A server with a stored nsflow token gets it as an Authorization header."""
-        tokens = {MCP_SERVERS[0]: "tok-0"}
+    def test_async_invoke_merges_sly_data_server_listings(self):
+        """sly_data http_headers servers are fetched with their own headers."""
+        tool: GetMcpTool = GetMcpTool.__new__(GetMcpTool)
+        self.listings[CLIENT_URL] = f"tools of {CLIENT_URL}"
+        sly_data = {"http_headers": {CLIENT_URL: {"Authorization": "Bearer tok-0"}}}
 
-        with (
-            mock.patch.dict(os.environ, {TTL_ENV: "100000"}),
-            self._patched_servers(tokens=tokens),
-            self._patched_fetches(),
-        ):
-            result = asyncio.run(GetMcpTool.get_mcp_tool_descriptions())
+        with mock.patch.dict(os.environ, {TTL_ENV: "100000"}), self._patched_servers(), self._patched_fetches():
+            result = asyncio.run(tool.async_invoke(args={}, sly_data=sly_data))
 
-        self.assertEqual(self.headers_log[MCP_SERVERS[0]], {"Authorization": "Bearer tok-0"})
-        # A server with no stored token keeps headers=None, preserving the
-        # adapter's fallback to mcp_info.hocon http_headers.
-        self.assertIsNone(self.headers_log[MCP_SERVERS[1]])
-        # The token itself never surfaces in what the LLM will see.
-        self.assertNotIn("tok-0", str(result))
-
-    def test_an_info_file_server_ignores_a_stored_token(self):
-        """File-configured servers keep their (refreshable) file auth: a leftover
-        stored token could be stale and would hide the server on a 401."""
-        tokens = {server: f"tok-{i}" for i, server in enumerate(MCP_SERVERS)}
-
-        with (
-            mock.patch.dict(os.environ, {TTL_ENV: "100000"}),
-            self._patched_servers(tokens=tokens, in_info_file=True),
-            self._patched_fetches(),
-        ):
-            asyncio.run(GetMcpTool.get_mcp_tool_descriptions())
-
+        # The client server got exactly the conversation's header dict...
+        self.assertEqual(self.headers_log[CLIENT_URL], {"Authorization": "Bearer tok-0"})
+        # ...file servers got none, and everything landed in the output.
         for server in MCP_SERVERS:
             self.assertIsNone(self.headers_log[server])
+            self.assertIn(f"tools of {server}", result)
+        self.assertIn(f"tools of {CLIENT_URL}", result)
+        # The token itself never surfaces in what the LLM will see.
+        self.assertNotIn("tok-0", result)
+
+    def test_a_file_configured_server_ignores_sly_data_headers(self):
+        """A URL in both sources stays a server-side concern: no client fetch."""
+        tool: GetMcpTool = GetMcpTool.__new__(GetMcpTool)
+        sly_data = {"http_headers": {MCP_SERVERS[0]: {"Authorization": "Bearer stale"}}}
+
+        with mock.patch.dict(os.environ, {TTL_ENV: "100000"}), self._patched_servers(), self._patched_fetches():
+            asyncio.run(tool.async_invoke(args={}, sly_data=sly_data))
+
+        # Exactly one (shared, headerless) fetch — no second, client-headed one.
+        self.assertEqual(self.fetch_log.count(MCP_SERVERS[0]), 1)
+        self.assertIsNone(self.headers_log[MCP_SERVERS[0]])
+
+    def test_sly_data_listings_are_fetched_per_call_not_cached(self):
+        """Client-authenticated listings must never be served across calls."""
+        tool: GetMcpTool = GetMcpTool.__new__(GetMcpTool)
+        self.listings[CLIENT_URL] = "client tools"
+        sly_data = {"http_headers": {CLIENT_URL: {"Authorization": "Bearer tok"}}}
+
+        with mock.patch.dict(os.environ, {TTL_ENV: "100000"}), self._patched_servers(), self._patched_fetches():
+            asyncio.run(tool.async_invoke(args={}, sly_data=sly_data))
+            asyncio.run(tool.async_invoke(args={}, sly_data=sly_data))
+
+        # File servers: one shared fetch each; the client server: one per call.
+        for server in MCP_SERVERS:
+            self.assertEqual(self.fetch_log.count(server), 1)
+        self.assertEqual(self.fetch_log.count(CLIENT_URL), 2)
 
     def test_registry_covers_both_mcp_caches(self):
         """globals' REGISTRY triples must resolve now that get_mcp_tool is imported."""
@@ -533,3 +428,26 @@ class TestFetchToolDescriptions(TestCase):
             )
 
         self.assertEqual(seen["https://auth.example"], {"Authorization": "Bearer tok"})
+
+    def test_exception_group_leaves_surface_in_the_failure_log(self):
+        """The drop-path warning must show the buried cause (e.g. a 401),
+        not just anyio's opaque 'unhandled errors in a TaskGroup' text."""
+        if sys.version_info < (3, 11):
+            self.skipTest("ExceptionGroup is a 3.11+ builtin")
+
+        nested = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ExceptionGroup("inner", [ValueError("401 Unauthorized for url 'https://auth.example'")]), KeyError("k")],
+        )
+        summary = GetMcpTool._error_summary(nested)
+        self.assertIn("401 Unauthorized", summary)
+        self.assertIn("KeyError", summary)
+
+        async def raises_the_group(_server: str, headers: dict | None = None) -> list:  # pylint: disable=unused-argument
+            raise nested
+
+        with self._patched_adapter(raises_the_group), self.assertLogs(level="WARNING") as captured:
+            _server, description = asyncio.run(GetMcpTool._fetch_tool_descriptions("https://auth.example", 5.0))
+
+        self.assertIsNone(description)
+        self.assertIn("401 Unauthorized", "\n".join(captured.output))

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -225,12 +225,14 @@ class TestSlyDataHttpHeaderUrls(TestCase):
         self.assertEqual(GetMcpTool.sly_data_http_header_urls(sly_data), ["https://ok.example/mcp"])
 
     def test_urls_without_a_usable_header_are_skipped(self):
-        """An empty dict, a blank value, or a non-string value supplies no credential."""
+        """An empty dict, a blank value, a non-string value, or an illegal
+        header name supplies no credential the fetch could send."""
         sly_data = {
             "http_headers": {
                 "https://empty.example/mcp": {},
                 "https://blank.example/mcp": {"Authorization": "   "},
                 "https://nonstr.example/mcp": {"Authorization": 123},
+                "https://badname.example/mcp": {"Auth orization": "Bearer x"},
                 "https://ok.example/mcp": {"Authorization": "Bearer tok"},
             }
         }
@@ -594,6 +596,56 @@ class TestSanitizedHeaders(TestCase):
         """Malformed shapes are dropped rather than raising."""
         cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": 123, 42: "x", "X-Api-Key": "k"})
         self.assertEqual(cleaned, {"X-Api-Key": "k"})
+
+    def test_a_name_with_outer_whitespace_is_stripped(self):
+        """Names get the same recoverable-trim treatment as values."""
+        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {" Authorization ": "Bearer tok"})
+        self.assertEqual(cleaned, {"Authorization": "Bearer tok"})
+
+    def test_an_illegal_name_drops_the_header_without_echoing_it(self):
+        """A name that is still illegal after the outer-whitespace trim (an
+        EMBEDDED control char, space, or colon) would fail the whole request
+        at send time, so it is dropped up front — and never echoed, since
+        junk in the name slot could be a misplaced secret. Well-formed
+        headers still go through."""
+        with self.assertLogs(level="WARNING") as captured:
+            cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"X-NAME\rSECRET": "v", "  ": "w", "X-Api-Key": "k"})
+
+        self.assertEqual(cleaned, {"X-Api-Key": "k"})
+        logged = "\n".join(captured.output)
+        self.assertNotIn("SECRET", logged)
+        self.assertIn(CLIENT_URL, logged)
+
+    def test_a_blank_value_is_skipped_silently(self):
+        """A blank value supplies no credential: not sent, and not worth a
+        warning — mirroring how usable_header_names classifies it."""
+        with self.assertNoLogs(level="WARNING"):
+            cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": "  \n", "X-Api-Key": "k"})
+        self.assertEqual(cleaned, {"X-Api-Key": "k"})
+
+
+class TestUsableHeaderNames(TestCase):
+    """The single owner of which client-supplied header names count."""
+
+    def test_names_are_stripped_and_deduped_in_first_appearance_order(self):
+        """Two raw spellings of one name collapse; order is preserved."""
+        headers = {" Authorization ": "Bearer a", "Authorization": "Bearer b", "X-Api-Key": "k"}
+        self.assertEqual(GetMcpTool.usable_header_names(headers), ["Authorization", "X-Api-Key"])
+
+    def test_illegal_names_and_credential_less_values_are_excluded(self):
+        """Only a legal field name with a non-blank string value counts."""
+        headers = {
+            "Auth orization": "Bearer x",
+            "X-Blank": "   ",
+            "X-Non-Str": 123,
+            42: "v",
+            "X-Good": "v",
+        }
+        self.assertEqual(GetMcpTool.usable_header_names(headers), ["X-Good"])
+
+    def test_an_empty_dict_reads_as_no_names(self):
+        """No headers, no contract."""
+        self.assertEqual(GetMcpTool.usable_header_names({}), [])
 
 
 class TestRedactValues(TestCase):

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -352,6 +352,18 @@ class TestGetMcpToolDescriptions(TestCase):
             self.assertEqual(self.fetch_log.count(server), 1)
         self.assertEqual(self.fetch_log.count(CLIENT_URL), 2)
 
+    def test_sly_data_header_values_are_sanitized_before_fetch(self):
+        """A token with surrounding whitespace is stripped before it is sent."""
+        tool: GetMcpTool = GetMcpTool.__new__(GetMcpTool)
+        self.listings[CLIENT_URL] = f"tools of {CLIENT_URL}"
+        sly_data = {"http_headers": {CLIENT_URL: {"Authorization": "  Bearer tok-0\n"}}}
+
+        with mock.patch.dict(os.environ, {TTL_ENV: "100000"}), self._patched_servers(), self._patched_fetches():
+            asyncio.run(tool.async_invoke(args={}, sly_data=sly_data))
+
+        # The adapter receives the trimmed value, not the raw client input.
+        self.assertEqual(self.headers_log[CLIENT_URL], {"Authorization": "Bearer tok-0"})
+
     def test_registry_covers_both_mcp_caches(self):
         """globals' REGISTRY triples must resolve now that get_mcp_tool is imported."""
         with mock.patch.dict(os.environ, {TTL_ENV: "100000"}), self._patched_servers(), self._patched_fetches():
@@ -443,7 +455,7 @@ class TestFetchToolDescriptions(TestCase):
         self.assertIn("401 Unauthorized", summary)
         self.assertIn("KeyError", summary)
 
-        async def raises_the_group(_server: str, headers: dict | None = None) -> list:  # pylint: disable=unused-argument
+        async def raises_the_group(_server: str, headers: dict | None = None) -> list:
             raise nested
 
         with self._patched_adapter(raises_the_group), self.assertLogs(level="WARNING") as captured:
@@ -451,3 +463,75 @@ class TestFetchToolDescriptions(TestCase):
 
         self.assertIsNone(description)
         self.assertIn("401 Unauthorized", "\n".join(captured.output))
+
+    def test_a_leaked_header_value_is_redacted_from_the_failure_log(self):
+        """A value-bearing error (mimicking h11) must not put the token in the log."""
+        token = "Bearer FAKE-SECRET-xyz\n"
+
+        async def raises_with_value(_server: str, headers: dict | None = None) -> list:
+            # h11 renders an illegal header value as its bytes repr.
+            raise ValueError(f"Illegal header value {token.encode()!r}")
+
+        with self._patched_adapter(raises_with_value), self.assertLogs(level="WARNING") as captured:
+            _server, description = asyncio.run(
+                GetMcpTool._fetch_tool_descriptions("https://auth.example", 5.0, headers={"Authorization": token})
+            )
+
+        logged = "\n".join(captured.output)
+        self.assertIsNone(description)
+        self.assertNotIn("FAKE-SECRET-xyz", logged)
+        self.assertIn("***", logged)
+
+
+class TestSanitizedHeaders(TestCase):
+    """Boundary cleaning of the per-conversation header dict before it is sent."""
+
+    def test_outer_whitespace_is_stripped(self):
+        """A newline-tailed token is trimmed so it still authenticates."""
+        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": "  Bearer tok\n"})
+        self.assertEqual(cleaned, {"Authorization": "Bearer tok"})
+
+    def test_a_clean_value_passes_through_unchanged(self):
+        """A well-formed value is returned as-is."""
+        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": "Bearer tok", "X-Api-Key": "k"})
+        self.assertEqual(cleaned, {"Authorization": "Bearer tok", "X-Api-Key": "k"})
+
+    def test_a_mid_value_tab_is_allowed(self):
+        """Tab is a legal header-value character; only other controls are illegal."""
+        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"X-Api-Key": "a\tb"})
+        self.assertEqual(cleaned, {"X-Api-Key": "a\tb"})
+
+    def test_an_embedded_control_char_drops_the_header_and_logs_name_only(self):
+        """A value with an embedded control char is dropped; the value never logs."""
+        with self.assertLogs(level="WARNING") as captured:
+            cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": "Bearer\nSECRET"})
+
+        self.assertEqual(cleaned, {})
+        logged = "\n".join(captured.output)
+        self.assertIn("Authorization", logged)
+        self.assertNotIn("SECRET", logged)
+
+    def test_non_string_names_and_values_are_skipped(self):
+        """Malformed shapes are dropped rather than raising."""
+        cleaned = GetMcpTool._sanitized_headers(CLIENT_URL, {"Authorization": 123, 42: "x", "X-Api-Key": "k"})
+        self.assertEqual(cleaned, {"X-Api-Key": "k"})
+
+
+class TestRedactValues(TestCase):
+    """The drop-path log backstop that masks any header value we sent."""
+
+    def test_masks_plain_str_repr_and_bytes_repr_forms(self):
+        """A value must not survive in any form an exception renderer might use."""
+        value = "Bearer FAKE-SECRET-xyz\n"
+        text = f"raw={value} str={value!r} bytes={value.encode()!r}"
+        redacted = GetMcpTool._redact_values(text, {"Authorization": value})
+        self.assertNotIn("FAKE-SECRET-xyz", redacted)
+        self.assertIn("***", redacted)
+
+    def test_none_headers_pass_through(self):
+        """The file-configured path (headers=None) leaves the text untouched."""
+        self.assertEqual(GetMcpTool._redact_values("401 Unauthorized", None), "401 Unauthorized")
+
+    def test_empty_values_are_ignored(self):
+        """An empty header value must not blank-mask unrelated text."""
+        self.assertEqual(GetMcpTool._redact_values("some text", {"X": ""}), "some text")

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -42,6 +42,7 @@ from coded_tools.agent_network_editor.get_mcp_tool import BUNDLED_MCP_INFO_FILE 
 from coded_tools.agent_network_editor.get_mcp_tool import DEFAULT_MCP_TOOLS_FETCH_TIMEOUT_SECONDS  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import DEFAULT_MCP_TOOLS_TTL_SECONDS  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import GetMcpTool  # noqa: E402
+from coded_tools.agent_network_editor.get_mcp_tool import _McpServersLoad  # noqa: E402
 from coded_tools.agent_network_editor.globals import ProcessGlobals  # noqa: E402
 
 MCP_SERVERS: list[str] = ["https://one.example/mcp", "https://two.example/mcp"]
@@ -156,6 +157,29 @@ class TestGetMcpServers(TestCase):
             ):
                 self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers()), [])
 
+    def test_or_none_returns_none_only_when_the_file_load_failed(self):
+        """A broken file is 'unknown' (None); missing/empty/good files are not."""
+        # A missing file is an authoritative empty, not a failure.
+        with mock.patch.dict(os.environ, {"MCP_SERVERS_INFO_FILE": "/nonexistent/mcp_info.hocon"}):
+            self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers_or_none()), [])
+
+        # A file that exists but cannot be read/parsed is unknown → None.
+        for error in (OSError("permission denied"), ValueError("bad hocon")):
+            GetMcpTool.clear_shared_mcp_servers_for_testing()
+            restorer = mock.Mock()
+            restorer.restore.side_effect = error
+            with mock.patch(
+                "coded_tools.agent_network_editor.get_mcp_tool.McpServersInfoRestorer", return_value=restorer
+            ):
+                self.assertIsNone(asyncio.run(GetMcpTool.get_mcp_servers_or_none()))
+
+        # A file that loads returns its URLs (never None), even if empty.
+        GetMcpTool.clear_shared_mcp_servers_for_testing()
+        restorer = mock.Mock()
+        restorer.restore.return_value = {"https://one.example/mcp": {}}
+        with mock.patch("coded_tools.agent_network_editor.get_mcp_tool.McpServersInfoRestorer", return_value=restorer):
+            self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers_or_none()), ["https://one.example/mcp"])
+
 
 class TestSlyDataHttpHeaderUrls(TestCase):
     """Extraction of the per-conversation MCP header URLs from sly_data."""
@@ -241,7 +265,8 @@ class TestGetMcpToolDescriptions(TestCase):
     def _patched_servers(self, servers: list[str] | None = None):
         """Pin the servers half so these tests never read the real config file."""
         pinned = MCP_SERVERS if servers is None else servers
-        return mock.patch.object(GetMcpTool._shared_mcp_servers_cache, "get", new=mock.Mock(return_value=list(pinned)))
+        loaded = _McpServersLoad(list(pinned), True)
+        return mock.patch.object(GetMcpTool._shared_mcp_servers_cache, "get", new=mock.Mock(return_value=loaded))
 
     def test_concurrent_callers_share_one_fetch_and_warm_reads_are_free(self):
         """A cold burst fetches each server once; warm reads fetch nothing."""

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -227,6 +227,19 @@ class TestSlyDataHttpHeaderUrls(TestCase):
         }
         self.assertEqual(GetMcpTool.sly_data_http_header_urls(sly_data), ["https://ok.example/mcp"])
 
+    def test_malformed_urls_are_skipped(self):
+        """An accepted URL becomes a fetch target and a verbatim log line,
+        so a control-character (log-forging) or userinfo-bearing key never
+        classifies (shape rules pinned in test_mcp_header_hygiene.py)."""
+        sly_data = {
+            "http_headers": {
+                "https://ok.example/mcp\nFORGED": {"Authorization": "Bearer x"},
+                "https://user:pass@ok.example/mcp": {"Authorization": "Bearer y"},
+                "https://ok.example/mcp": {"Authorization": "Bearer z"},
+            }
+        }
+        self.assertEqual(GetMcpTool.sly_data_http_header_urls(sly_data), ["https://ok.example/mcp"])
+
     def test_urls_without_a_usable_header_are_skipped(self):
         """An empty dict, a blank value, a non-string value, or an illegal
         header name supplies no credential the fetch could send."""

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -25,7 +25,10 @@ get_mcp_tool needs, so the suite still collects everywhere.
 """
 
 import asyncio
+import json
 import os
+import tempfile
+from pathlib import Path
 from unittest import TestCase
 from unittest import mock
 
@@ -39,6 +42,7 @@ pytest.importorskip("coded_tools.agent_network_editor.get_mcp_tool")
 from coded_tools.agent_network_editor.get_mcp_tool import BUNDLED_MCP_INFO_FILE  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import DEFAULT_MCP_TOOLS_FETCH_TIMEOUT_SECONDS  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import DEFAULT_MCP_TOOLS_TTL_SECONDS  # noqa: E402
+from coded_tools.agent_network_editor.get_mcp_tool import NSFLOW_MCP_TOKENS_FILE_NAME  # noqa: E402
 from coded_tools.agent_network_editor.get_mcp_tool import GetMcpTool  # noqa: E402
 from coded_tools.agent_network_editor.globals import ProcessGlobals  # noqa: E402
 
@@ -46,6 +50,19 @@ MCP_SERVERS: list[str] = ["https://one.example/mcp", "https://two.example/mcp"]
 
 TTL_ENV: str = "AGENT_NETWORK_DESIGNER_MCP_TOOLS_TTL_SECONDS"
 FETCH_TIMEOUT_ENV: str = "AGENT_NETWORK_DESIGNER_MCP_TOOLS_FETCH_TIMEOUT_SECONDS"
+STORAGE_DIR_ENV: str = "NSFLOW_MCP_STORAGE_DIR"
+
+# Points the nsflow token-store resolver away from any real ~/.nsflow on the
+# machine running the tests; the file never exists, so the storage half of
+# the servers union is empty unless a test writes its own store.
+NO_TOKEN_STORE: dict[str, str] = {STORAGE_DIR_ENV: "/nonexistent/mcp_oauth"}
+
+
+def write_token_store(directory: str, entries: dict) -> str:
+    """Write a tokens.json with the given entries; returns the file path."""
+    path = Path(directory) / NSFLOW_MCP_TOKENS_FILE_NAME
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return str(path)
 
 
 class TestGetMcpToolConfig(TestCase):
@@ -70,7 +87,8 @@ class TestGetMcpToolConfig(TestCase):
             for raw, expected in (("0", 0.0), ("-5", -5.0)):
                 os.environ[TTL_ENV] = raw
                 self.assertEqual(GetMcpTool._mcp_tools_ttl_seconds(), expected)
-                self.assertEqual(GetMcpTool._mcp_tools_fingerprint()[3], 0)
+                # The time bucket is the last fingerprint component.
+                self.assertEqual(GetMcpTool._mcp_tools_fingerprint()[-1], 0)
 
     def test_ttl_is_clamped_to_twice_the_fetch_cap(self):
         """A TTL shorter than one fetch would livelock the cache; clamp it."""
@@ -133,6 +151,20 @@ class TestGetMcpServers(TestCase):
         # when run directly through unittest.
         GetMcpTool.clear_shared_mcp_servers_for_testing()
         GetMcpTool.clear_shared_mcp_tool_descriptions_for_testing()
+        # Keep the storage half hermetic: a real ~/.nsflow on the developer
+        # machine must not leak servers into these assertions.
+        env_patch = mock.patch.dict(os.environ, NO_TOKEN_STORE)
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
+
+    @staticmethod
+    def _patched_info_file(info: dict | None):
+        """Patch the mcp_info.hocon half to parse to the given mapping."""
+        restorer = mock.Mock()
+        restorer.restore.return_value = info
+        return mock.patch(
+            "coded_tools.agent_network_editor.get_mcp_tool.McpServersInfoRestorer", return_value=restorer
+        )
 
     def test_a_missing_file_publishes_an_empty_list(self):
         """No config file means no MCP servers, not an error."""
@@ -150,6 +182,119 @@ class TestGetMcpServers(TestCase):
             ):
                 self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers()), [])
 
+    def test_servers_are_the_union_of_file_and_storage(self):
+        """mcp_info.hocon URLs and nsflow OAuth connections merge into one list."""
+        info = {MCP_SERVERS[0]: {"http_headers": {"X-Api-Key": "from-env"}}}
+        with tempfile.TemporaryDirectory() as storage_dir:
+            write_token_store(storage_dir, {MCP_SERVERS[1]: {"tokens": {"access_token": "tok-1"}}})
+            with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}), self._patched_info_file(info):
+                self.assertEqual(sorted(asyncio.run(GetMcpTool.get_mcp_servers())), sorted(MCP_SERVERS))
+
+    def test_a_storage_entry_without_an_access_token_is_not_a_server(self):
+        """Pre-seeded client_info, corrupt entries, and empty tokens don't count."""
+        entries = {
+            "https://client-info-only.example/mcp": {"client_info": {"client_id": "abc"}},
+            "https://corrupt.example/mcp": "not-a-dict",
+            "https://empty-token.example/mcp": {"tokens": {"access_token": ""}},
+            MCP_SERVERS[0]: {"tokens": {"access_token": "tok-0"}},
+        }
+        with tempfile.TemporaryDirectory() as storage_dir:
+            write_token_store(storage_dir, entries)
+            with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}), self._patched_info_file(None):
+                self.assertEqual(asyncio.run(GetMcpTool.get_mcp_servers()), [MCP_SERVERS[0]])
+
+    def test_a_token_store_rewrite_is_a_fingerprint_miss(self):
+        """A new OAuth connection (tokens.json write) must invalidate the cache."""
+        with tempfile.TemporaryDirectory() as storage_dir:
+            with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}):
+                before = GetMcpTool._mcp_sources_fingerprint()
+                tokens_file = write_token_store(storage_dir, {MCP_SERVERS[0]: {"tokens": {"access_token": "tok"}}})
+                after = GetMcpTool._mcp_sources_fingerprint()
+        self.assertNotEqual(before, after)
+        self.assertEqual(after[2], tokens_file)
+
+
+class TestNsflowTokenStorage(TestCase):
+    """Read policy for nsflow's tokens.json: tolerant, attempt-and-drop."""
+
+    def test_a_missing_store_reads_as_empty(self):
+        """No tokens.json just means nsflow has no connections — no error."""
+        with mock.patch.dict(os.environ, NO_TOKEN_STORE):
+            self.assertEqual(GetMcpTool._load_storage_access_tokens(), {})
+
+    def test_corrupt_json_and_a_non_object_top_level_read_as_empty(self):
+        """A hand-edited or truncated store degrades to {} instead of raising."""
+        for content in ("{not json", '["a", "list"]', '"just a string"'):
+            with tempfile.TemporaryDirectory() as storage_dir:
+                Path(storage_dir, NSFLOW_MCP_TOKENS_FILE_NAME).write_text(content, encoding="utf-8")
+                with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}):
+                    self.assertEqual(GetMcpTool._load_storage_access_tokens(), {})
+
+    def test_needs_reauth_and_expired_entries_are_still_read(self):
+        """Attempt-and-drop: stale tokens are tried (and fail downstream), not filtered."""
+        entries = {
+            MCP_SERVERS[0]: {"tokens": {"access_token": "stale"}, "needs_reauth": True, "expires_at": 1},
+        }
+        with tempfile.TemporaryDirectory() as storage_dir:
+            write_token_store(storage_dir, entries)
+            with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}):
+                self.assertEqual(GetMcpTool._load_storage_access_tokens(), {MCP_SERVERS[0]: "stale"})
+
+    def test_the_storage_dir_env_var_is_respected_and_expanded(self):
+        """The resolver honors NSFLOW_MCP_STORAGE_DIR and expands ~."""
+        with mock.patch.dict(os.environ, {STORAGE_DIR_ENV: "~/custom_mcp_store"}):
+            resolved = GetMcpTool.get_nsflow_tokens_file()
+        self.assertEqual(resolved, str(Path("~/custom_mcp_store").expanduser() / NSFLOW_MCP_TOKENS_FILE_NAME))
+        with mock.patch.dict(os.environ):
+            os.environ.pop(STORAGE_DIR_ENV, None)
+            default_resolved = GetMcpTool.get_nsflow_tokens_file()
+        self.assertEqual(default_resolved, str(Path("~/.nsflow/mcp_oauth").expanduser() / NSFLOW_MCP_TOKENS_FILE_NAME))
+
+
+class TestGetMcpServersAuthInfo(TestCase):
+    """The url -> needs-client-token view that drives generated sly_data_schema."""
+
+    def setUp(self):
+        GetMcpTool.clear_shared_mcp_servers_for_testing()
+        GetMcpTool.clear_shared_mcp_tool_descriptions_for_testing()
+
+    def test_file_headers_mean_no_client_token_is_needed(self):
+        """Servers authenticated via mcp_info.hocon http_headers are not gated."""
+        info = {
+            MCP_SERVERS[0]: {"http_headers": {"X-Api-Key": "from-env"}},
+            MCP_SERVERS[1]: {},  # configured, but no headers: needs a client token
+        }
+        with tempfile.TemporaryDirectory() as storage_dir:
+            write_token_store(storage_dir, {"https://oauth-only.example/mcp": {"tokens": {"access_token": "tok"}}})
+            with (
+                mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}),
+                TestGetMcpServers._patched_info_file(info),
+            ):
+                auth_info = asyncio.run(GetMcpTool.get_mcp_servers_auth_info())
+
+        self.assertEqual(
+            auth_info,
+            {
+                MCP_SERVERS[0]: False,
+                MCP_SERVERS[1]: True,
+                "https://oauth-only.example/mcp": True,
+            },
+        )
+        for value in auth_info.values():
+            self.assertIsInstance(value, bool)
+
+    def test_a_stored_token_does_not_flip_a_file_authenticated_server(self):
+        """A URL in both sources keeps needs_client_token=False: file auth suffices."""
+        info = {MCP_SERVERS[0]: {"http_headers": {"Authorization": "Bearer from-env"}}}
+        with tempfile.TemporaryDirectory() as storage_dir:
+            write_token_store(storage_dir, {MCP_SERVERS[0]: {"tokens": {"access_token": "tok"}}})
+            with (
+                mock.patch.dict(os.environ, {STORAGE_DIR_ENV: storage_dir}),
+                TestGetMcpServers._patched_info_file(info),
+            ):
+                auth_info = asyncio.run(GetMcpTool.get_mcp_servers_auth_info())
+        self.assertEqual(auth_info, {MCP_SERVERS[0]: False})
+
 
 class TestGetMcpToolDescriptions(TestCase):
     """Publish/degrade policy for the shared tool-descriptions cache."""
@@ -157,24 +302,36 @@ class TestGetMcpToolDescriptions(TestCase):
     def setUp(self):
         GetMcpTool.clear_shared_mcp_servers_for_testing()
         GetMcpTool.clear_shared_mcp_tool_descriptions_for_testing()
+        env_patch = mock.patch.dict(os.environ, NO_TOKEN_STORE)
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
         self.fetch_log: list[str] = []
+        self.headers_log: dict[str, dict | None] = {}
         self.listings: dict[str, str] = {server: f"tools of {server}" for server in MCP_SERVERS}
 
     def _patched_fetches(self):
         """Stub the per-server fetch; a server absent from self.listings fails."""
         fetch_log = self.fetch_log
+        headers_log = self.headers_log
         listings = self.listings
 
-        async def fake_fetch(server: str, _fetch_timeout: float | None) -> tuple[str, str | None]:
+        async def fake_fetch(
+            server: str, _fetch_timeout: float | None, headers: dict | None = None
+        ) -> tuple[str, str | None]:
             fetch_log.append(server)
+            headers_log[server] = headers
             return server, listings.get(server)
 
         return mock.patch.object(GetMcpTool, "_fetch_tool_descriptions", new=fake_fetch)
 
-    def _patched_servers(self, servers: list[str] | None = None):
+    def _patched_servers(self, servers: list[str] | None = None, tokens: dict[str, str] | None = None):
         """Pin the servers half so these tests never read the real config file."""
         pinned = MCP_SERVERS if servers is None else servers
-        return mock.patch.object(GetMcpTool._shared_mcp_servers_cache, "get", new=mock.Mock(return_value=list(pinned)))
+        tokens = tokens or {}
+        infos: dict[str, dict] = {
+            server: {"has_file_headers": False, "access_token": tokens.get(server)} for server in pinned
+        }
+        return mock.patch.object(GetMcpTool._shared_mcp_servers_cache, "get", new=mock.Mock(return_value=infos))
 
     def test_concurrent_callers_share_one_fetch_and_warm_reads_are_free(self):
         """A cold burst fetches each server once; warm reads fetch nothing."""
@@ -262,6 +419,24 @@ class TestGetMcpToolDescriptions(TestCase):
 
         self.assertEqual(result, str(self.listings))
 
+    def test_a_storage_token_is_sent_as_a_bearer_header(self):
+        """A server with a stored nsflow token gets it as an Authorization header."""
+        tokens = {MCP_SERVERS[0]: "tok-0"}
+
+        with (
+            mock.patch.dict(os.environ, {TTL_ENV: "100000"}),
+            self._patched_servers(tokens=tokens),
+            self._patched_fetches(),
+        ):
+            result = asyncio.run(GetMcpTool.get_mcp_tool_descriptions())
+
+        self.assertEqual(self.headers_log[MCP_SERVERS[0]], {"Authorization": "Bearer tok-0"})
+        # A server with no stored token keeps headers=None, preserving the
+        # adapter's fallback to mcp_info.hocon http_headers.
+        self.assertIsNone(self.headers_log[MCP_SERVERS[1]])
+        # The token itself never surfaces in what the LLM will see.
+        self.assertNotIn("tok-0", str(result))
+
     def test_registry_covers_both_mcp_caches(self):
         """globals' REGISTRY triples must resolve now that get_mcp_tool is imported."""
         with mock.patch.dict(os.environ, {TTL_ENV: "100000"}), self._patched_servers(), self._patched_fetches():
@@ -286,7 +461,7 @@ class TestFetchToolDescriptions(TestCase):
     def test_a_server_exceeding_the_cap_degrades_to_a_failure(self):
         """A hung server is cut off at the cap and reported as failed."""
 
-        async def never_answers(_server: str) -> list:
+        async def never_answers(_server: str, headers: dict | None = None) -> list:  # pylint: disable=unused-argument
             await asyncio.sleep(10)
             return []
 
@@ -299,7 +474,9 @@ class TestFetchToolDescriptions(TestCase):
     def test_a_malformed_tool_degrades_to_that_server_only(self):
         """A tool with no description must fail this server, not the whole load."""
 
-        async def returns_a_broken_tool(_server: str) -> list:
+        async def returns_a_broken_tool(  # pylint: disable=unused-argument
+            _server: str, headers: dict | None = None
+        ) -> list:
             return [mock.Mock(description=None)]
 
         with self._patched_adapter(returns_a_broken_tool):
@@ -310,10 +487,29 @@ class TestFetchToolDescriptions(TestCase):
     def test_descriptions_are_newline_joined(self):
         """A healthy server's tool descriptions flatten into one string."""
 
-        async def returns_two_tools(_server: str) -> list:
+        async def returns_two_tools(  # pylint: disable=unused-argument
+            _server: str, headers: dict | None = None
+        ) -> list:
             return [mock.Mock(description="alpha"), mock.Mock(description="beta")]
 
         with self._patched_adapter(returns_two_tools):
             _server, description = asyncio.run(GetMcpTool._fetch_tool_descriptions("https://good.example", 5.0))
 
         self.assertEqual(description, "alpha\nbeta\n")
+
+    def test_headers_are_forwarded_to_the_adapter(self):
+        """The per-server fetch passes its headers through to get_mcp_tools."""
+        seen: dict[str, dict | None] = {}
+
+        async def records_headers(server: str, headers: dict | None = None) -> list:
+            seen[server] = headers
+            return [mock.Mock(description="alpha")]
+
+        with self._patched_adapter(records_headers):
+            asyncio.run(
+                GetMcpTool._fetch_tool_descriptions(
+                    "https://auth.example", 5.0, headers={"Authorization": "Bearer tok"}
+                )
+            )
+
+        self.assertEqual(seen["https://auth.example"], {"Authorization": "Bearer tok"})

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -387,6 +387,37 @@ class TestGetMcpToolDescriptions(TestCase):
         # The adapter receives the trimmed value, not the raw client input.
         self.assertEqual(self.headers_log[CLIENT_URL], {"Authorization": "Bearer tok-0"})
 
+    def test_client_listings_do_not_leak_across_conversations(self):
+        """Two conversations' client-token servers stay isolated: neither
+        conversation's sly_data servers may surface in the other's output,
+        because those listings are fetched per call and never cached."""
+        tool: GetMcpTool = GetMcpTool.__new__(GetMcpTool)
+        alice_url = "https://alice.example/mcp"
+        bob_url = "https://bob.example/mcp"
+        self.listings[alice_url] = "tools of alice"
+        self.listings[bob_url] = "tools of bob"
+        alice_sly = {"http_headers": {alice_url: {"Authorization": "Bearer alice-tok"}}}
+        bob_sly = {"http_headers": {bob_url: {"Authorization": "Bearer bob-tok"}}}
+
+        # Back-to-back in one process, sharing the file-descriptions cache.
+        with mock.patch.dict(os.environ, {TTL_ENV: "100000"}), self._patched_servers(), self._patched_fetches():
+            result_alice = asyncio.run(tool.async_invoke(args={}, sly_data=alice_sly))
+            result_bob = asyncio.run(tool.async_invoke(args={}, sly_data=bob_sly))
+
+        # Each conversation sees its own client server...
+        self.assertIn("tools of alice", result_alice)
+        self.assertIn("tools of bob", result_bob)
+        # ...and never the other conversation's.
+        self.assertNotIn("tools of bob", result_alice)
+        self.assertNotIn("tools of alice", result_bob)
+        # The shared, file-configured servers appear in both (same for everyone).
+        for server in MCP_SERVERS:
+            self.assertIn(f"tools of {server}", result_alice)
+            self.assertIn(f"tools of {server}", result_bob)
+        # Neither token reaches the LLM-visible output.
+        self.assertNotIn("alice-tok", result_alice)
+        self.assertNotIn("bob-tok", result_bob)
+
     def test_registry_covers_both_mcp_caches(self):
         """globals' REGISTRY triples must resolve now that get_mcp_tool is imported."""
         with mock.patch.dict(os.environ, {TTL_ENV: "100000"}), self._patched_servers(), self._patched_fetches():

--- a/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
+++ b/tests/coded_tools/agent_network_editor/test_get_mcp_tool.py
@@ -258,11 +258,11 @@ class TestGetMcpServersAuthInfo(TestCase):
         GetMcpTool.clear_shared_mcp_servers_for_testing()
         GetMcpTool.clear_shared_mcp_tool_descriptions_for_testing()
 
-    def test_file_headers_mean_no_client_token_is_needed(self):
-        """Servers authenticated via mcp_info.hocon http_headers are not gated."""
+    def test_info_file_servers_need_no_client_token(self):
+        """mcp_info.hocon servers are a server-side concern — with headers or without."""
         info = {
             MCP_SERVERS[0]: {"http_headers": {"X-Api-Key": "from-env"}},
-            MCP_SERVERS[1]: {},  # configured, but no headers: needs a client token
+            MCP_SERVERS[1]: {},  # public/no-auth file server: still not a client concern
         }
         with tempfile.TemporaryDirectory() as storage_dir:
             write_token_store(storage_dir, {"https://oauth-only.example/mcp": {"tokens": {"access_token": "tok"}}})
@@ -276,15 +276,15 @@ class TestGetMcpServersAuthInfo(TestCase):
             auth_info,
             {
                 MCP_SERVERS[0]: False,
-                MCP_SERVERS[1]: True,
+                MCP_SERVERS[1]: False,
                 "https://oauth-only.example/mcp": True,
             },
         )
         for value in auth_info.values():
             self.assertIsInstance(value, bool)
 
-    def test_a_stored_token_does_not_flip_a_file_authenticated_server(self):
-        """A URL in both sources keeps needs_client_token=False: file auth suffices."""
+    def test_a_stored_token_does_not_flip_an_info_file_server(self):
+        """A URL in both sources stays a server-side concern (no client gating)."""
         info = {MCP_SERVERS[0]: {"http_headers": {"Authorization": "Bearer from-env"}}}
         with tempfile.TemporaryDirectory() as storage_dir:
             write_token_store(storage_dir, {MCP_SERVERS[0]: {"tokens": {"access_token": "tok"}}})

--- a/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
+++ b/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
@@ -1,0 +1,169 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit tests for McpHeaderHygiene: which client-supplied header names count,
+how a per-URL header dict is cleaned before it reaches the HTTP stack, how
+fetch errors are rendered for the drop-path log, and how header values we
+sent are redacted out of it. How GetMcpTool wires these into the fetch
+pipeline is covered by test_get_mcp_tool.py.
+"""
+
+import sys
+from unittest import TestCase
+
+import pytest
+
+pytest.importorskip("coded_tools.agent_network_editor.mcp_header_hygiene")
+
+# The import must stay below importorskip so environments whose dependencies
+# predate this module's needs skip cleanly.
+# pylint: disable=wrong-import-position
+from coded_tools.agent_network_editor.mcp_header_hygiene import McpHeaderHygiene  # noqa: E402
+
+# A server the conversation supplies auth headers for.
+CLIENT_URL: str = "https://oauth.example/mcp"
+
+
+class TestUsableHeaderNames(TestCase):
+    """The single owner of which client-supplied header names count."""
+
+    def test_names_are_stripped_and_deduped_in_first_appearance_order(self):
+        """Two raw spellings of one name collapse; order is preserved."""
+        headers = {" Authorization ": "Bearer a", "Authorization": "Bearer b", "X-Api-Key": "k"}
+        self.assertEqual(McpHeaderHygiene.usable_header_names(headers), ["Authorization", "X-Api-Key"])
+
+    def test_illegal_names_and_credential_less_values_are_excluded(self):
+        """Only a legal field name with a non-blank string value counts."""
+        headers = {
+            "Auth orization": "Bearer x",
+            "X-Blank": "   ",
+            "X-Non-Str": 123,
+            42: "v",
+            "X-Good": "v",
+        }
+        self.assertEqual(McpHeaderHygiene.usable_header_names(headers), ["X-Good"])
+
+    def test_an_empty_dict_reads_as_no_names(self):
+        """No headers, no contract."""
+        self.assertEqual(McpHeaderHygiene.usable_header_names({}), [])
+
+
+class TestSanitizedHeaders(TestCase):
+    """Boundary cleaning of the per-conversation header dict before it is sent."""
+
+    def test_outer_whitespace_is_stripped(self):
+        """A newline-tailed token is trimmed so it still authenticates."""
+        cleaned = McpHeaderHygiene.sanitized_headers(CLIENT_URL, {"Authorization": "  Bearer tok\n"})
+        self.assertEqual(cleaned, {"Authorization": "Bearer tok"})
+
+    def test_a_clean_value_passes_through_unchanged(self):
+        """A well-formed value is returned as-is."""
+        cleaned = McpHeaderHygiene.sanitized_headers(CLIENT_URL, {"Authorization": "Bearer tok", "X-Api-Key": "k"})
+        self.assertEqual(cleaned, {"Authorization": "Bearer tok", "X-Api-Key": "k"})
+
+    def test_a_mid_value_tab_is_allowed(self):
+        """Tab is a legal header-value character; only other controls are illegal."""
+        cleaned = McpHeaderHygiene.sanitized_headers(CLIENT_URL, {"X-Api-Key": "a\tb"})
+        self.assertEqual(cleaned, {"X-Api-Key": "a\tb"})
+
+    def test_an_embedded_control_char_drops_the_header_and_logs_name_only(self):
+        """A value with an embedded control char is dropped; the value never logs."""
+        with self.assertLogs(level="WARNING") as captured:
+            cleaned = McpHeaderHygiene.sanitized_headers(CLIENT_URL, {"Authorization": "Bearer\nSECRET"})
+
+        self.assertEqual(cleaned, {})
+        logged = "\n".join(captured.output)
+        self.assertIn("Authorization", logged)
+        self.assertNotIn("SECRET", logged)
+
+    def test_non_string_names_and_values_are_skipped(self):
+        """Malformed shapes are dropped rather than raising."""
+        cleaned = McpHeaderHygiene.sanitized_headers(CLIENT_URL, {"Authorization": 123, 42: "x", "X-Api-Key": "k"})
+        self.assertEqual(cleaned, {"X-Api-Key": "k"})
+
+    def test_a_name_with_outer_whitespace_is_stripped(self):
+        """Names get the same recoverable-trim treatment as values."""
+        cleaned = McpHeaderHygiene.sanitized_headers(CLIENT_URL, {" Authorization ": "Bearer tok"})
+        self.assertEqual(cleaned, {"Authorization": "Bearer tok"})
+
+    def test_an_illegal_name_drops_the_header_without_echoing_it(self):
+        """A name that is still illegal after the outer-whitespace trim (an
+        EMBEDDED control char, space, or colon) would fail the whole request
+        at send time, so it is dropped up front — and never echoed, since
+        junk in the name slot could be a misplaced secret. Well-formed
+        headers still go through."""
+        with self.assertLogs(level="WARNING") as captured:
+            cleaned = McpHeaderHygiene.sanitized_headers(
+                CLIENT_URL, {"X-NAME\rSECRET": "v", "  ": "w", "X-Api-Key": "k"}
+            )
+
+        self.assertEqual(cleaned, {"X-Api-Key": "k"})
+        logged = "\n".join(captured.output)
+        self.assertNotIn("SECRET", logged)
+        self.assertIn(CLIENT_URL, logged)
+
+    def test_a_blank_value_is_skipped_silently(self):
+        """A blank value supplies no credential: not sent, and not worth a
+        warning — mirroring how usable_header_names classifies it."""
+        with self.assertNoLogs(level="WARNING"):
+            cleaned = McpHeaderHygiene.sanitized_headers(CLIENT_URL, {"Authorization": "  \n", "X-Api-Key": "k"})
+        self.assertEqual(cleaned, {"X-Api-Key": "k"})
+
+
+class TestErrorSummary(TestCase):
+    """Rendering a fetch failure as the end message an operator acts on."""
+
+    def test_a_plain_exception_renders_as_its_message(self):
+        """No group, no rewriting: str(error) is already the end message."""
+        self.assertEqual(McpHeaderHygiene.error_summary(ValueError("401 Unauthorized")), "401 Unauthorized")
+
+    def test_group_leaves_replace_the_group_text(self):
+        """Only the buried causes are rendered — anyio's own 'unhandled
+        errors in a TaskGroup (N sub-exceptions)' adds nothing once its
+        leaves are shown, and the leaves (e.g. a 401) are what pick the
+        remedy."""
+        if sys.version_info < (3, 11):
+            self.skipTest("ExceptionGroup is a 3.11+ builtin")
+
+        nested = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ExceptionGroup("inner", [ValueError("401 Unauthorized for url 'https://auth.example'")]), KeyError("k")],
+        )
+        summary = McpHeaderHygiene.error_summary(nested)
+        self.assertIn("ValueError: 401 Unauthorized", summary)
+        self.assertIn("KeyError", summary)
+        self.assertNotIn("TaskGroup", summary)
+        self.assertNotIn("sub-exception", summary)
+
+
+class TestRedactValues(TestCase):
+    """The drop-path log backstop that masks any header value we sent."""
+
+    def test_masks_plain_str_repr_and_bytes_repr_forms(self):
+        """A value must not survive in any form an exception renderer might use."""
+        value = "Bearer FAKE-SECRET-xyz\n"
+        text = f"raw={value} str={value!r} bytes={value.encode()!r}"
+        redacted = McpHeaderHygiene.redact_values(text, {"Authorization": value})
+        self.assertNotIn("FAKE-SECRET-xyz", redacted)
+        self.assertIn("***", redacted)
+
+    def test_none_headers_pass_through(self):
+        """The file-configured path (headers=None) leaves the text untouched."""
+        self.assertEqual(McpHeaderHygiene.redact_values("401 Unauthorized", None), "401 Unauthorized")
+
+    def test_empty_values_are_ignored(self):
+        """An empty header value must not blank-mask unrelated text."""
+        self.assertEqual(McpHeaderHygiene.redact_values("some text", {"X": ""}), "some text")

--- a/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
+++ b/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
@@ -56,7 +56,16 @@ class TestUsableServerUrl(TestCase):
 
     def test_non_strings_and_other_schemes_are_rejected(self):
         """Only http(s) strings can be MCP server references."""
-        for url in (None, 42, b"https://x/mcp", "ftp://host/mcp", "/internal_admin_network", "file:///etc/passwd"):
+        for url in (
+            None,
+            42,
+            # bytes, not str — the host is example.com so the CI link
+            # checker (lychee, which scans string literals) skips it.
+            b"https://example.com/mcp",
+            "ftp://host/mcp",
+            "/internal_admin_network",
+            "file:///etc/passwd",
+        ):
             self.assertFalse(McpHeaderHygiene.usable_server_url(url), repr(url))
 
     def test_control_characters_and_whitespace_are_rejected(self):

--- a/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
+++ b/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
@@ -37,6 +37,54 @@ from coded_tools.agent_network_editor.mcp_header_hygiene import McpHeaderHygiene
 CLIENT_URL: str = "https://oauth.example/mcp"
 
 
+class TestUsableServerUrl(TestCase):
+    """The classification gate for conversation-supplied MCP server URLs."""
+
+    def test_well_formed_urls_are_accepted(self):
+        """Plain, ported, IPv6-literal, localhost, and non-ASCII URLs all
+        pass — including localhost/private hosts, deliberately: local and
+        private-network MCP servers are first-class deployments, and WHICH
+        servers a conversation may use is the injecting client's trust
+        decision, not a shape check's."""
+        for url in (
+            "https://mcp.example.com/mcp",
+            "http://localhost:8000/mcp",
+            "https://[::1]:8443/mcp",
+            "https://example.com/mçp",
+        ):
+            self.assertTrue(McpHeaderHygiene.usable_server_url(url), url)
+
+    def test_non_strings_and_other_schemes_are_rejected(self):
+        """Only http(s) strings can be MCP server references."""
+        for url in (None, 42, b"https://x/mcp", "ftp://host/mcp", "/internal_admin_network", "file:///etc/passwd"):
+            self.assertFalse(McpHeaderHygiene.usable_server_url(url), repr(url))
+
+    def test_control_characters_and_whitespace_are_rejected(self):
+        """An accepted URL is written verbatim to log lines; a raw newline
+        (or any control char, space, or DEL) would let a client forge log
+        entries."""
+        for url in (
+            "https://example.com/mcp\nFORGED LOG LINE",
+            "https://example.com/m cp",
+            "https://example.com/\tmcp",
+            "https://example.com/mcp\x7f",
+        ):
+            self.assertFalse(McpHeaderHygiene.usable_server_url(url), repr(url))
+
+    def test_userinfo_and_hostless_urls_are_rejected(self):
+        """Credentials do not belong in a URL that gets logged and
+        persisted (auth travels in the headers), and a URL with no host —
+        including an unparseable IPv6 bracket — is not a server."""
+        for url in (
+            "https://user:pass@example.com/mcp",
+            "https://token@example.com/mcp",
+            "http://",
+            "http:///mcp",
+            "https://[::1",
+        ):
+            self.assertFalse(McpHeaderHygiene.usable_server_url(url), repr(url))
+
+
 class TestUsableHeaderNames(TestCase):
     """The single owner of which client-supplied header names count."""
 

--- a/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
+++ b/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
@@ -160,6 +160,18 @@ class TestRedactValues(TestCase):
         self.assertNotIn("FAKE-SECRET-xyz", redacted)
         self.assertIn("***", redacted)
 
+    def test_a_value_that_cannot_utf8_encode_still_redacts_without_raising(self):
+        """A client-controlled value can hold a lone surrogate, which
+        str.encode() rejects. Redaction runs inside the fetch's except
+        handler — raising there would fail the whole gathered listing — so
+        it must skip the impossible bytes form and still mask the str
+        forms."""
+        value = "Bearer FAKE-SECRET-\ud800"
+        text = f"raw={value} str={value!r}"
+        redacted = McpHeaderHygiene.redact_values(text, {"Authorization": value})
+        self.assertNotIn("FAKE-SECRET", redacted)
+        self.assertIn("***", redacted)
+
     def test_none_headers_pass_through(self):
         """The file-configured path (headers=None) leaves the text untouched."""
         self.assertEqual(McpHeaderHygiene.redact_values("401 Unauthorized", None), "401 Unauthorized")

--- a/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
+++ b/tests/coded_tools/agent_network_editor/test_mcp_header_hygiene.py
@@ -160,6 +160,24 @@ class TestRedactValues(TestCase):
         self.assertNotIn("FAKE-SECRET-xyz", redacted)
         self.assertIn("***", redacted)
 
+    def test_h11_messages_are_masked_even_without_header_values(self):
+        """File-configured headers live inside the MCP adapter (headers is
+        None on that path), so their values cannot be exact-masked — the one
+        known value-bearing message shape is masked by pattern instead,
+        while the rest of the message survives for diagnosis."""
+        text = "ValueError: Illegal header value b'Bearer FILE-SECRET\\n'; KeyError: 'k'"
+        redacted = McpHeaderHygiene.redact_values(text, None)
+        self.assertNotIn("FILE-SECRET", redacted)
+        self.assertIn("Illegal header value ***", redacted)
+        self.assertIn("KeyError: 'k'", redacted)
+
+    def test_an_illegal_name_message_is_masked_too(self):
+        """h11 renders an offending header NAME the same way, and junk in
+        the name slot could be a misplaced secret."""
+        redacted = McpHeaderHygiene.redact_values("Illegal header name b'NAME-SECRET\\rx'", None)
+        self.assertNotIn("NAME-SECRET", redacted)
+        self.assertIn("***", redacted)
+
     def test_a_value_that_cannot_utf8_encode_still_redacts_without_raising(self):
         """A client-controlled value can hold a lone surrogate, which
         str.encode() rejects. Redaction runs inside the fetch's except

--- a/tests/middleware/agent_network_designer/persistence/test_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_agent_network_assembler.py
@@ -23,10 +23,11 @@ FILE_AUTH_URL = "https://file-auth.example.com/mcp"
 UNUSED_URL = "https://unused.example.com/mcp"
 
 # The client-token servers, as the persistence middleware derives them from
-# the conversation's sly_data http_headers (minus file-configured servers).
+# the conversation's sly_data http_headers (minus file-configured servers):
+# each URL maps to the header names it supplied (names only, never values).
 # FILE_AUTH_URL is deliberately absent: mcp_info.hocon servers are a
 # server-side concern and never appear in generated schemas.
-CLIENT_TOKEN_MCP_URLS: list[str] = [OAUTH_URL, UNUSED_URL]
+CLIENT_TOKEN_MCP_HEADERS: dict[str, list[str]] = {OAUTH_URL: ["Authorization"], UNUSED_URL: ["Authorization"]}
 
 NETWORK_DEF: dict = {
     "front_man": {"description": "top", "instructions": "Coordinate.", "tools": ["helper", OAUTH_URL]},
@@ -45,7 +46,7 @@ class TestBuildMcpSlyDataSchema:
     def test_no_client_urls_means_no_schema(self):
         """None and empty both mean 'no client-token servers' — emit nothing."""
         assert AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, None) is None
-        assert AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, []) is None
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, {}) is None
 
     def test_a_network_using_no_client_token_servers_gets_no_schema(self):
         """Agent names and subnetwork refs in tools lists must not trigger a schema."""
@@ -53,11 +54,11 @@ class TestBuildMcpSlyDataSchema:
             "front_man": {"instructions": "Coordinate.", "tools": ["helper", "/sub_network"]},
             "helper": {"instructions": "Help."},
         }
-        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, CLIENT_TOKEN_MCP_URLS) is None
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, CLIENT_TOKEN_MCP_HEADERS) is None
 
     def test_shape_matches_the_nsflow_contract(self):
         """properties.http_headers.{properties,required} is what nsflow reads."""
-        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, CLIENT_TOKEN_MCP_URLS)
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, CLIENT_TOKEN_MCP_HEADERS)
 
         assert schema["type"] == "object"
         assert schema["required"] == ["http_headers"]
@@ -72,7 +73,7 @@ class TestBuildMcpSlyDataSchema:
 
     def test_only_client_token_servers_are_declared_and_required(self):
         """File-configured servers are omitted; every declared URL gates chat."""
-        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, CLIENT_TOKEN_MCP_URLS)
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, CLIENT_TOKEN_MCP_HEADERS)
         http_headers = schema["properties"]["http_headers"]
         assert FILE_AUTH_URL not in http_headers["properties"]
         assert http_headers["required"] == [OAUTH_URL]
@@ -80,11 +81,11 @@ class TestBuildMcpSlyDataSchema:
     def test_a_network_using_only_file_servers_gets_no_schema(self):
         """File-configured servers need no client input, so no schema is emitted."""
         network_def = {"front_man": {"instructions": "Go.", "tools": [FILE_AUTH_URL]}}
-        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, CLIENT_TOKEN_MCP_URLS) is None
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, CLIENT_TOKEN_MCP_HEADERS) is None
 
     def test_unused_servers_are_not_declared(self):
         """Only URLs the network references appear in the schema."""
-        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, CLIENT_TOKEN_MCP_URLS)
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, CLIENT_TOKEN_MCP_HEADERS)
         assert UNUSED_URL not in schema["properties"]["http_headers"]["properties"]
 
     def test_duplicate_and_malformed_tools_entries_are_tolerated(self):
@@ -97,6 +98,26 @@ class TestBuildMcpSlyDataSchema:
             # iterating its characters.
             "strtools": {"instructions": "Odd.", "tools": "not-a-list"},
         }
-        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, CLIENT_TOKEN_MCP_URLS)
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, CLIENT_TOKEN_MCP_HEADERS)
         assert list(schema["properties"]["http_headers"]["properties"]) == [OAUTH_URL]
         assert schema["properties"]["http_headers"]["required"] == [OAUTH_URL]
+
+    def test_declared_headers_match_the_supplied_header_names(self):
+        """A server authenticated with a non-Authorization header is described
+        with THAT header, not a hardcoded Authorization."""
+        network_def = {"front_man": {"instructions": "Go.", "tools": [OAUTH_URL]}}
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, {OAUTH_URL: ["X-Api-Key"]})
+        url_schema = schema["properties"]["http_headers"]["properties"][OAUTH_URL]
+        assert list(url_schema["properties"]) == ["X-Api-Key"]
+        assert url_schema["required"] == ["X-Api-Key"]
+        assert "Authorization" not in url_schema["properties"]
+
+    def test_multiple_supplied_headers_are_all_declared(self):
+        """Every header name the conversation supplied is declared and required."""
+        network_def = {"front_man": {"instructions": "Go.", "tools": [OAUTH_URL]}}
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(
+            network_def, {OAUTH_URL: ["Authorization", "X-Tenant"]}
+        )
+        url_schema = schema["properties"]["http_headers"]["properties"][OAUTH_URL]
+        assert list(url_schema["properties"]) == ["Authorization", "X-Tenant"]
+        assert url_schema["required"] == ["Authorization", "X-Tenant"]

--- a/tests/middleware/agent_network_designer/persistence/test_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_agent_network_assembler.py
@@ -22,9 +22,11 @@ OAUTH_URL = "https://oauth.example.com/mcp"
 FILE_AUTH_URL = "https://file-auth.example.com/mcp"
 UNUSED_URL = "https://unused.example.com/mcp"
 
-# needs_client_token per server, as GetMcpTool.get_mcp_servers_auth_info returns
-# it: True iff the server is known only from nsflow's OAuth token store.
-MCP_SERVERS_AUTH: dict[str, bool] = {OAUTH_URL: True, FILE_AUTH_URL: False, UNUSED_URL: True}
+# The client-token servers, as the persistence middleware derives them from
+# the conversation's sly_data http_headers (minus file-configured servers).
+# FILE_AUTH_URL is deliberately absent: mcp_info.hocon servers are a
+# server-side concern and never appear in generated schemas.
+CLIENT_TOKEN_MCP_URLS: list[str] = [OAUTH_URL, UNUSED_URL]
 
 NETWORK_DEF: dict = {
     "front_man": {"description": "top", "instructions": "Coordinate.", "tools": ["helper", OAUTH_URL]},
@@ -40,58 +42,61 @@ NETWORK_DEF: dict = {
 class TestBuildMcpSlyDataSchema:
     """The schema builder both assemblers share."""
 
-    def test_no_auth_info_means_no_schema(self):
-        """None and {} both mean 'nothing known about MCP servers' — emit nothing."""
+    def test_no_client_urls_means_no_schema(self):
+        """None and empty both mean 'no client-token servers' — emit nothing."""
         assert AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, None) is None
-        assert AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, {}) is None
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, []) is None
 
-    def test_a_network_using_no_mcp_servers_gets_no_schema(self):
+    def test_a_network_using_no_client_token_servers_gets_no_schema(self):
         """Agent names and subnetwork refs in tools lists must not trigger a schema."""
         network_def = {
             "front_man": {"instructions": "Coordinate.", "tools": ["helper", "/sub_network"]},
             "helper": {"instructions": "Help."},
         }
-        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, MCP_SERVERS_AUTH) is None
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, CLIENT_TOKEN_MCP_URLS) is None
 
     def test_shape_matches_the_nsflow_contract(self):
         """properties.http_headers.{properties,required} is what nsflow reads."""
-        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, MCP_SERVERS_AUTH)
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, CLIENT_TOKEN_MCP_URLS)
 
         assert schema["type"] == "object"
         assert schema["required"] == ["http_headers"]
         http_headers = schema["properties"]["http_headers"]
         assert http_headers["type"] == "object"
-        # Only the client-token (token-store) url is declared...
+        # Only the used client-token url is declared...
         assert list(http_headers["properties"]) == [OAUTH_URL]
         # ...and each declared url expects an Authorization header.
         for url_schema in http_headers["properties"].values():
             assert url_schema["required"] == ["Authorization"]
             assert url_schema["properties"]["Authorization"]["type"] == "string"
 
-    def test_only_token_store_servers_are_declared_and_required(self):
-        """mcp_info.hocon servers are omitted; every declared URL gates chat."""
-        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, MCP_SERVERS_AUTH)
+    def test_only_client_token_servers_are_declared_and_required(self):
+        """File-configured servers are omitted; every declared URL gates chat."""
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, CLIENT_TOKEN_MCP_URLS)
         http_headers = schema["properties"]["http_headers"]
         assert FILE_AUTH_URL not in http_headers["properties"]
         assert http_headers["required"] == [OAUTH_URL]
 
-    def test_a_network_using_only_info_file_servers_gets_no_schema(self):
+    def test_a_network_using_only_file_servers_gets_no_schema(self):
         """File-configured servers need no client input, so no schema is emitted."""
         network_def = {"front_man": {"instructions": "Go.", "tools": [FILE_AUTH_URL]}}
-        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, MCP_SERVERS_AUTH) is None
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, CLIENT_TOKEN_MCP_URLS) is None
 
     def test_unused_servers_are_not_declared(self):
         """Only URLs the network references appear in the schema."""
-        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, MCP_SERVERS_AUTH)
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, CLIENT_TOKEN_MCP_URLS)
         assert UNUSED_URL not in schema["properties"]["http_headers"]["properties"]
 
     def test_duplicate_and_malformed_tools_entries_are_tolerated(self):
-        """A URL used twice is declared once; non-str/None entries are skipped."""
+        """A URL used twice is declared once; malformed shapes are skipped."""
         network_def = {
             "front_man": {"instructions": "Go.", "tools": [OAUTH_URL, "helper", None, 42]},
             "helper": {"instructions": "Help.", "tools": [OAUTH_URL]},
             "broken": "not-a-dict",
+            # coerce_tools reads a str-valued tools field as [] instead of
+            # iterating its characters.
+            "strtools": {"instructions": "Odd.", "tools": "not-a-list"},
         }
-        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, MCP_SERVERS_AUTH)
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, CLIENT_TOKEN_MCP_URLS)
         assert list(schema["properties"]["http_headers"]["properties"]) == [OAUTH_URL]
         assert schema["properties"]["http_headers"]["required"] == [OAUTH_URL]

--- a/tests/middleware/agent_network_designer/persistence/test_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_agent_network_assembler.py
@@ -1,0 +1,95 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for the shared MCP sly_data_schema builder on AgentNetworkAssembler."""
+
+from middleware.agent_network_designer.persistence.agent_network_assembler import AgentNetworkAssembler
+
+OAUTH_URL = "https://oauth.example.com/mcp"
+FILE_AUTH_URL = "https://file-auth.example.com/mcp"
+UNUSED_URL = "https://unused.example.com/mcp"
+
+# needs_client_token per server, as GetMcpTool.get_mcp_servers_auth_info returns it.
+MCP_SERVERS_AUTH: dict[str, bool] = {OAUTH_URL: True, FILE_AUTH_URL: False, UNUSED_URL: True}
+
+NETWORK_DEF: dict = {
+    "front_man": {"description": "top", "instructions": "Coordinate.", "tools": ["helper", OAUTH_URL]},
+    "helper": {
+        "description": "helps",
+        "instructions": "Help.",
+        "tools": [FILE_AUTH_URL, "/sub_network", "ddgs_search"],
+    },
+    "ddgs_search": {},
+}
+
+
+class TestBuildMcpSlyDataSchema:
+    """The schema builder both assemblers share."""
+
+    def test_no_auth_info_means_no_schema(self):
+        """None and {} both mean 'nothing known about MCP servers' — emit nothing."""
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, None) is None
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, {}) is None
+
+    def test_a_network_using_no_mcp_servers_gets_no_schema(self):
+        """Agent names and subnetwork refs in tools lists must not trigger a schema."""
+        network_def = {
+            "front_man": {"instructions": "Coordinate.", "tools": ["helper", "/sub_network"]},
+            "helper": {"instructions": "Help."},
+        }
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, MCP_SERVERS_AUTH) is None
+
+    def test_shape_matches_the_nsflow_contract(self):
+        """properties.http_headers.{properties,required} is what nsflow reads."""
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, MCP_SERVERS_AUTH)
+
+        assert schema["type"] == "object"
+        assert schema["required"] == ["http_headers"]
+        http_headers = schema["properties"]["http_headers"]
+        assert http_headers["type"] == "object"
+        # Every USED url is declared (opportunistic injection)...
+        assert sorted(http_headers["properties"]) == sorted([OAUTH_URL, FILE_AUTH_URL])
+        # ...and each declared url expects an Authorization header.
+        for url_schema in http_headers["properties"].values():
+            assert url_schema["required"] == ["Authorization"]
+            assert url_schema["properties"]["Authorization"]["type"] == "string"
+
+    def test_required_is_the_headerless_subset_of_used_urls(self):
+        """Only servers needing a client token gate chat; file-auth ones do not."""
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, MCP_SERVERS_AUTH)
+        assert schema["properties"]["http_headers"]["required"] == [OAUTH_URL]
+
+    def test_required_is_emitted_even_when_empty(self):
+        """Omitting `required` makes nsflow gate every declared URL; [] must be explicit."""
+        network_def = {"front_man": {"instructions": "Go.", "tools": [FILE_AUTH_URL]}}
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, MCP_SERVERS_AUTH)
+        assert schema["properties"]["http_headers"]["required"] == []
+
+    def test_unused_servers_are_not_declared(self):
+        """Only URLs the network references appear in the schema."""
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, MCP_SERVERS_AUTH)
+        assert UNUSED_URL not in schema["properties"]["http_headers"]["properties"]
+
+    def test_duplicate_and_malformed_tools_entries_are_tolerated(self):
+        """A URL used twice is declared once; non-str/None entries are skipped."""
+        network_def = {
+            "front_man": {"instructions": "Go.", "tools": [OAUTH_URL, "helper", None, 42]},
+            "helper": {"instructions": "Help.", "tools": [OAUTH_URL]},
+            "broken": "not-a-dict",
+        }
+        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, MCP_SERVERS_AUTH)
+        assert list(schema["properties"]["http_headers"]["properties"]) == [OAUTH_URL]
+        assert schema["properties"]["http_headers"]["required"] == [OAUTH_URL]

--- a/tests/middleware/agent_network_designer/persistence/test_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_agent_network_assembler.py
@@ -22,7 +22,8 @@ OAUTH_URL = "https://oauth.example.com/mcp"
 FILE_AUTH_URL = "https://file-auth.example.com/mcp"
 UNUSED_URL = "https://unused.example.com/mcp"
 
-# needs_client_token per server, as GetMcpTool.get_mcp_servers_auth_info returns it.
+# needs_client_token per server, as GetMcpTool.get_mcp_servers_auth_info returns
+# it: True iff the server is known only from nsflow's OAuth token store.
 MCP_SERVERS_AUTH: dict[str, bool] = {OAUTH_URL: True, FILE_AUTH_URL: False, UNUSED_URL: True}
 
 NETWORK_DEF: dict = {
@@ -60,23 +61,24 @@ class TestBuildMcpSlyDataSchema:
         assert schema["required"] == ["http_headers"]
         http_headers = schema["properties"]["http_headers"]
         assert http_headers["type"] == "object"
-        # Every USED url is declared (opportunistic injection)...
-        assert sorted(http_headers["properties"]) == sorted([OAUTH_URL, FILE_AUTH_URL])
+        # Only the client-token (token-store) url is declared...
+        assert list(http_headers["properties"]) == [OAUTH_URL]
         # ...and each declared url expects an Authorization header.
         for url_schema in http_headers["properties"].values():
             assert url_schema["required"] == ["Authorization"]
             assert url_schema["properties"]["Authorization"]["type"] == "string"
 
-    def test_required_is_the_headerless_subset_of_used_urls(self):
-        """Only servers needing a client token gate chat; file-auth ones do not."""
+    def test_only_token_store_servers_are_declared_and_required(self):
+        """mcp_info.hocon servers are omitted; every declared URL gates chat."""
         schema = AgentNetworkAssembler.build_mcp_sly_data_schema(NETWORK_DEF, MCP_SERVERS_AUTH)
-        assert schema["properties"]["http_headers"]["required"] == [OAUTH_URL]
+        http_headers = schema["properties"]["http_headers"]
+        assert FILE_AUTH_URL not in http_headers["properties"]
+        assert http_headers["required"] == [OAUTH_URL]
 
-    def test_required_is_emitted_even_when_empty(self):
-        """Omitting `required` makes nsflow gate every declared URL; [] must be explicit."""
+    def test_a_network_using_only_info_file_servers_gets_no_schema(self):
+        """File-configured servers need no client input, so no schema is emitted."""
         network_def = {"front_man": {"instructions": "Go.", "tools": [FILE_AUTH_URL]}}
-        schema = AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, MCP_SERVERS_AUTH)
-        assert schema["properties"]["http_headers"]["required"] == []
+        assert AgentNetworkAssembler.build_mcp_sly_data_schema(network_def, MCP_SERVERS_AUTH) is None
 
     def test_unused_servers_are_not_declared(self):
         """Only URLs the network references appear in the schema."""

--- a/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
@@ -1,0 +1,78 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for DeployableAgentNetworkAssembler's sly_data_schema emission."""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("middleware.agent_network_designer.persistence.deployable_agent_network_assembler")
+
+# The import must stay below importorskip so environments whose neuro-san
+# predates the assembler's imports skip cleanly.
+# pylint: disable=wrong-import-position
+from middleware.agent_network_designer.persistence.deployable_agent_network_assembler import (  # noqa: E402
+    DeployableAgentNetworkAssembler,
+)
+
+OAUTH_URL = "https://oauth.example.com/mcp"
+FILE_AUTH_URL = "https://file-auth.example.com/mcp"
+
+MCP_SERVERS_AUTH: dict[str, bool] = {OAUTH_URL: True, FILE_AUTH_URL: False}
+
+NETWORK_DEF: dict = {
+    "front_man": {"description": "top", "instructions": "Coordinate.", "tools": ["helper", OAUTH_URL]},
+    "helper": {"description": "helps", "instructions": "Help.", "tools": [FILE_AUTH_URL]},
+}
+
+
+def assemble(mcp_servers_auth: dict[str, bool] | None) -> dict:
+    """Assemble the test network into a deployable config dict (real templates)."""
+    assembler = DeployableAgentNetworkAssembler(demo_mode=False)
+    return asyncio.run(
+        assembler.assemble_agent_network(NETWORK_DEF, "front_man", "test_net", ["query one"], mcp_servers_auth)
+    )
+
+
+class TestDeployableAssemblerSlyDataSchema:
+    """The deployable config dict declares the network's MCP header needs."""
+
+    def test_front_man_declares_the_schema(self):
+        """The top agent's function block carries the nsflow contract."""
+        agent_network = assemble(MCP_SERVERS_AUTH)
+
+        front_man = agent_network["tools"][0]
+        assert front_man["name"] == "front_man"
+        http_headers = front_man["function"]["sly_data_schema"]["properties"]["http_headers"]
+        assert sorted(http_headers["properties"]) == sorted([OAUTH_URL, FILE_AUTH_URL])
+        assert http_headers["required"] == [OAUTH_URL]
+        # The description injection it sits next to still happened.
+        assert front_man["function"]["description"] == "top"
+
+    def test_non_top_agents_carry_no_schema(self):
+        """Only the front man talks to clients; helpers must not declare one."""
+        agent_network = assemble(MCP_SERVERS_AUTH)
+        for agent in agent_network["tools"][1:]:
+            function = agent.get("function")
+            if isinstance(function, dict):
+                assert "sly_data_schema" not in function
+
+    def test_no_mcp_means_no_schema(self):
+        """Without MCP servers the function block stays as the template made it."""
+        for auth_info in (None, {}):
+            agent_network = assemble(auth_info)
+            assert "sly_data_schema" not in agent_network["tools"][0]["function"]

--- a/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
@@ -58,7 +58,7 @@ class TestDeployableAssemblerSlyDataSchema:
         front_man = agent_network["tools"][0]
         assert front_man["name"] == "front_man"
         http_headers = front_man["function"]["sly_data_schema"]["properties"]["http_headers"]
-        assert sorted(http_headers["properties"]) == sorted([OAUTH_URL, FILE_AUTH_URL])
+        assert list(http_headers["properties"]) == [OAUTH_URL]
         assert http_headers["required"] == [OAUTH_URL]
         # The description injection it sits next to still happened.
         assert front_man["function"]["description"] == "top"

--- a/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
@@ -36,9 +36,10 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 OAUTH_URL = "https://oauth.example.com/mcp"
 FILE_AUTH_URL = "https://file-auth.example.com/mcp"
 
-# Client-token servers (from the conversation's sly_data http_headers);
-# FILE_AUTH_URL is a file-configured server and deliberately not in it.
-CLIENT_TOKEN_MCP_URLS: list[str] = [OAUTH_URL]
+# Client-token servers (from the conversation's sly_data http_headers), each
+# mapped to the header names it supplied; FILE_AUTH_URL is a file-configured
+# server and deliberately not in it.
+CLIENT_TOKEN_MCP_HEADERS: dict[str, list[str]] = {OAUTH_URL: ["Authorization"]}
 
 NETWORK_DEF: dict = {
     "front_man": {"description": "top", "instructions": "Coordinate.", "tools": ["helper", OAUTH_URL]},
@@ -46,7 +47,7 @@ NETWORK_DEF: dict = {
 }
 
 
-def assemble(client_token_mcp_urls: list[str] | None) -> dict:
+def assemble(client_token_mcp_headers: dict[str, list[str]] | None) -> dict:
     """
     Assemble the test network into a deployable config dict (real templates).
 
@@ -61,7 +62,7 @@ def assemble(client_token_mcp_urls: list[str] | None) -> dict:
     try:
         return asyncio.run(
             assembler.assemble_agent_network(
-                NETWORK_DEF, "front_man", "test_net", ["query one"], client_token_mcp_urls
+                NETWORK_DEF, "front_man", "test_net", ["query one"], client_token_mcp_headers
             )
         )
     finally:
@@ -73,7 +74,7 @@ class TestDeployableAssemblerSlyDataSchema:
 
     def test_front_man_declares_the_schema(self):
         """The top agent's function block carries the nsflow contract."""
-        agent_network = assemble(CLIENT_TOKEN_MCP_URLS)
+        agent_network = assemble(CLIENT_TOKEN_MCP_HEADERS)
 
         front_man = agent_network["tools"][0]
         assert front_man["name"] == "front_man"
@@ -85,7 +86,7 @@ class TestDeployableAssemblerSlyDataSchema:
 
     def test_non_top_agents_carry_no_schema(self):
         """Only the front man talks to clients; helpers must not declare one."""
-        agent_network = assemble(CLIENT_TOKEN_MCP_URLS)
+        agent_network = assemble(CLIENT_TOKEN_MCP_HEADERS)
         for agent in agent_network["tools"][1:]:
             function = agent.get("function")
             if isinstance(function, dict):
@@ -93,6 +94,6 @@ class TestDeployableAssemblerSlyDataSchema:
 
     def test_no_client_urls_means_no_schema(self):
         """Without client-token servers the function block stays as templated."""
-        for client_urls in (None, []):
-            agent_network = assemble(client_urls)
+        for client_headers in (None, {}):
+            agent_network = assemble(client_headers)
             assert "sly_data_schema" not in agent_network["tools"][0]["function"]

--- a/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
@@ -17,6 +17,8 @@
 """Tests for DeployableAgentNetworkAssembler's sly_data_schema emission."""
 
 import asyncio
+import os
+from pathlib import Path
 
 import pytest
 
@@ -29,10 +31,14 @@ from middleware.agent_network_designer.persistence.deployable_agent_network_asse
     DeployableAgentNetworkAssembler,
 )
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
 OAUTH_URL = "https://oauth.example.com/mcp"
 FILE_AUTH_URL = "https://file-auth.example.com/mcp"
 
-MCP_SERVERS_AUTH: dict[str, bool] = {OAUTH_URL: True, FILE_AUTH_URL: False}
+# Client-token servers (from the conversation's sly_data http_headers);
+# FILE_AUTH_URL is a file-configured server and deliberately not in it.
+CLIENT_TOKEN_MCP_URLS: list[str] = [OAUTH_URL]
 
 NETWORK_DEF: dict = {
     "front_man": {"description": "top", "instructions": "Coordinate.", "tools": ["helper", OAUTH_URL]},
@@ -40,12 +46,26 @@ NETWORK_DEF: dict = {
 }
 
 
-def assemble(mcp_servers_auth: dict[str, bool] | None) -> dict:
-    """Assemble the test network into a deployable config dict (real templates)."""
+def assemble(client_token_mcp_urls: list[str] | None) -> dict:
+    """
+    Assemble the test network into a deployable config dict (real templates).
+
+    Runs from the repo root: the wrapper template's include resolves
+    CWD-relatively, so without the chdir these tests error out under any
+    runner whose working directory is not the repo root (IDE test runners,
+    CI steps with a different workdir).
+    """
     assembler = DeployableAgentNetworkAssembler(demo_mode=False)
-    return asyncio.run(
-        assembler.assemble_agent_network(NETWORK_DEF, "front_man", "test_net", ["query one"], mcp_servers_auth)
-    )
+    cwd = os.getcwd()
+    os.chdir(REPO_ROOT)
+    try:
+        return asyncio.run(
+            assembler.assemble_agent_network(
+                NETWORK_DEF, "front_man", "test_net", ["query one"], client_token_mcp_urls
+            )
+        )
+    finally:
+        os.chdir(cwd)
 
 
 class TestDeployableAssemblerSlyDataSchema:
@@ -53,7 +73,7 @@ class TestDeployableAssemblerSlyDataSchema:
 
     def test_front_man_declares_the_schema(self):
         """The top agent's function block carries the nsflow contract."""
-        agent_network = assemble(MCP_SERVERS_AUTH)
+        agent_network = assemble(CLIENT_TOKEN_MCP_URLS)
 
         front_man = agent_network["tools"][0]
         assert front_man["name"] == "front_man"
@@ -65,14 +85,14 @@ class TestDeployableAssemblerSlyDataSchema:
 
     def test_non_top_agents_carry_no_schema(self):
         """Only the front man talks to clients; helpers must not declare one."""
-        agent_network = assemble(MCP_SERVERS_AUTH)
+        agent_network = assemble(CLIENT_TOKEN_MCP_URLS)
         for agent in agent_network["tools"][1:]:
             function = agent.get("function")
             if isinstance(function, dict):
                 assert "sly_data_schema" not in function
 
-    def test_no_mcp_means_no_schema(self):
-        """Without MCP servers the function block stays as the template made it."""
-        for auth_info in (None, {}):
-            agent_network = assemble(auth_info)
+    def test_no_client_urls_means_no_schema(self):
+        """Without client-token servers the function block stays as templated."""
+        for client_urls in (None, []):
+            agent_network = assemble(client_urls)
             assert "sly_data_schema" not in agent_network["tools"][0]["function"]

--- a/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
@@ -109,7 +109,10 @@ class TestHoconAssemblerSlyDataSchema:
     def test_a_non_ascii_url_key_round_trips_verbatim(self):
         """ensure_ascii=False keeps a non-ASCII URL key matching the tools list;
         an escaped key would read back as literal text pyhocon never decodes."""
-        unicode_url = "https://exämple.com/mcp"
+        # The non-ASCII character must live in the path, not the host: CI
+        # link-checks string literals (lychee) and skips example.com hosts,
+        # but a non-ASCII host punycodes to a real, checkable domain.
+        unicode_url = "https://example.com/mçp"
         network_def = {"front_man": {"description": "top", "instructions": "Go.", "tools": [unicode_url]}}
         assembler = HoconAgentNetworkAssembler(demo_mode=False)
         text = asyncio.run(
@@ -120,7 +123,7 @@ class TestHoconAssemblerSlyDataSchema:
 
         # The raw character survives in the emitted text, not a \uXXXX escape...
         assert unicode_url in text
-        assert "ex\\u00e4mple" not in text
+        assert "m\\u00e7p" not in text
 
         # ...and parses back to the same key the tools list uses.
         http_headers = parse(text)["tools"][0]["function"]["sly_data_schema"]["properties"]["http_headers"]

--- a/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
@@ -76,9 +76,9 @@ class TestHoconAssemblerSlyDataSchema:
         front_man = config["tools"][0]
         assert front_man["name"] == "front_man"
         http_headers = front_man["function"]["sly_data_schema"]["properties"]["http_headers"]
-        # Both used URLs are declared; only the token-needing one is required.
+        # Only the client-token URL is declared, and it is required.
         url_properties = {unquote(url): value for url, value in http_headers["properties"].items()}
-        assert sorted(url_properties) == sorted([OAUTH_URL, FILE_AUTH_URL])
+        assert list(url_properties) == [OAUTH_URL]
         assert list(http_headers["required"]) == [OAUTH_URL]
         assert list(url_properties[OAUTH_URL]["required"]) == ["Authorization"]
         # The description substitution still landed alongside the schema.

--- a/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
@@ -30,9 +30,10 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 OAUTH_URL = "https://oauth.example.com/mcp"
 FILE_AUTH_URL = "https://file-auth.example.com/mcp"
 
-# Client-token servers (from the conversation's sly_data http_headers);
-# FILE_AUTH_URL is a file-configured server and deliberately not in it.
-CLIENT_TOKEN_MCP_URLS: list[str] = [OAUTH_URL]
+# Client-token servers (from the conversation's sly_data http_headers), each
+# mapped to the header names it supplied; FILE_AUTH_URL is a file-configured
+# server and deliberately not in it.
+CLIENT_TOKEN_MCP_HEADERS: dict[str, list[str]] = {OAUTH_URL: ["Authorization"]}
 
 NETWORK_DEF: dict = {
     "front_man": {"description": "top", "instructions": "Coordinate.", "tools": ["helper", OAUTH_URL]},
@@ -40,11 +41,11 @@ NETWORK_DEF: dict = {
 }
 
 
-def assemble(client_token_mcp_urls: list[str] | None) -> str:
+def assemble(client_token_mcp_headers: dict[str, list[str]] | None) -> str:
     """Assemble the test network into HOCON text."""
     assembler = HoconAgentNetworkAssembler(demo_mode=False)
     return asyncio.run(
-        assembler.assemble_agent_network(NETWORK_DEF, "front_man", "test_net", ["query one"], client_token_mcp_urls)
+        assembler.assemble_agent_network(NETWORK_DEF, "front_man", "test_net", ["query one"], client_token_mcp_headers)
     )
 
 
@@ -73,7 +74,7 @@ class TestHoconAssemblerSlyDataSchema:
 
     def test_front_man_declares_the_schema_and_it_parses(self):
         """The emitted text stays valid HOCON and carries the nsflow contract."""
-        config = parse(assemble(CLIENT_TOKEN_MCP_URLS))
+        config = parse(assemble(CLIENT_TOKEN_MCP_HEADERS))
 
         front_man = config["tools"][0]
         assert front_man["name"] == "front_man"
@@ -88,14 +89,14 @@ class TestHoconAssemblerSlyDataSchema:
 
     def test_non_top_agents_carry_no_schema(self):
         """Only the front man talks to clients; helpers must not declare one."""
-        config = parse(assemble(CLIENT_TOKEN_MCP_URLS))
+        config = parse(assemble(CLIENT_TOKEN_MCP_HEADERS))
         for agent in config["tools"][1:]:
             assert "sly_data_schema" not in agent.get("function", {})
 
     def test_no_mcp_means_no_schema_and_unchanged_output(self):
         """Without MCP the text is byte-identical to the pre-schema behavior."""
         without_client_urls = assemble(None)
-        with_no_client_urls = assemble([])
+        with_no_client_urls = assemble({})
 
         assert "sly_data_schema" not in without_client_urls
         # The two renders differ only in the date_created stamp.
@@ -104,3 +105,24 @@ class TestHoconAssemblerSlyDataSchema:
 
         config = parse(without_client_urls)
         assert "sly_data_schema" not in config["tools"][0]["function"]
+
+    def test_a_non_ascii_url_key_round_trips_verbatim(self):
+        """ensure_ascii=False keeps a non-ASCII URL key matching the tools list;
+        an escaped key would read back as literal text pyhocon never decodes."""
+        unicode_url = "https://exämple.com/mcp"
+        network_def = {"front_man": {"description": "top", "instructions": "Go.", "tools": [unicode_url]}}
+        assembler = HoconAgentNetworkAssembler(demo_mode=False)
+        text = asyncio.run(
+            assembler.assemble_agent_network(
+                network_def, "front_man", "test_net", ["q"], {unicode_url: ["Authorization"]}
+            )
+        )
+
+        # The raw character survives in the emitted text, not a \uXXXX escape...
+        assert unicode_url in text
+        assert "ex\\u00e4mple" not in text
+
+        # ...and parses back to the same key the tools list uses.
+        http_headers = parse(text)["tools"][0]["function"]["sly_data_schema"]["properties"]["http_headers"]
+        assert [unquote(url) for url in http_headers["properties"]] == [unicode_url]
+        assert list(http_headers["required"]) == [unicode_url]

--- a/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
@@ -30,7 +30,9 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 OAUTH_URL = "https://oauth.example.com/mcp"
 FILE_AUTH_URL = "https://file-auth.example.com/mcp"
 
-MCP_SERVERS_AUTH: dict[str, bool] = {OAUTH_URL: True, FILE_AUTH_URL: False}
+# Client-token servers (from the conversation's sly_data http_headers);
+# FILE_AUTH_URL is a file-configured server and deliberately not in it.
+CLIENT_TOKEN_MCP_URLS: list[str] = [OAUTH_URL]
 
 NETWORK_DEF: dict = {
     "front_man": {"description": "top", "instructions": "Coordinate.", "tools": ["helper", OAUTH_URL]},
@@ -38,11 +40,11 @@ NETWORK_DEF: dict = {
 }
 
 
-def assemble(mcp_servers_auth: dict[str, bool] | None) -> str:
+def assemble(client_token_mcp_urls: list[str] | None) -> str:
     """Assemble the test network into HOCON text."""
     assembler = HoconAgentNetworkAssembler(demo_mode=False)
     return asyncio.run(
-        assembler.assemble_agent_network(NETWORK_DEF, "front_man", "test_net", ["query one"], mcp_servers_auth)
+        assembler.assemble_agent_network(NETWORK_DEF, "front_man", "test_net", ["query one"], client_token_mcp_urls)
     )
 
 
@@ -71,7 +73,7 @@ class TestHoconAssemblerSlyDataSchema:
 
     def test_front_man_declares_the_schema_and_it_parses(self):
         """The emitted text stays valid HOCON and carries the nsflow contract."""
-        config = parse(assemble(MCP_SERVERS_AUTH))
+        config = parse(assemble(CLIENT_TOKEN_MCP_URLS))
 
         front_man = config["tools"][0]
         assert front_man["name"] == "front_man"
@@ -86,19 +88,19 @@ class TestHoconAssemblerSlyDataSchema:
 
     def test_non_top_agents_carry_no_schema(self):
         """Only the front man talks to clients; helpers must not declare one."""
-        config = parse(assemble(MCP_SERVERS_AUTH))
+        config = parse(assemble(CLIENT_TOKEN_MCP_URLS))
         for agent in config["tools"][1:]:
             assert "sly_data_schema" not in agent.get("function", {})
 
     def test_no_mcp_means_no_schema_and_unchanged_output(self):
         """Without MCP the text is byte-identical to the pre-schema behavior."""
-        without_auth_info = assemble(None)
-        with_no_known_servers = assemble({})
+        without_client_urls = assemble(None)
+        with_no_client_urls = assemble([])
 
-        assert "sly_data_schema" not in without_auth_info
+        assert "sly_data_schema" not in without_client_urls
         # The two renders differ only in the date_created stamp.
         strip_date = re.compile(r'"date_created": "[^"]*"')
-        assert strip_date.sub("", without_auth_info) == strip_date.sub("", with_no_known_servers)
+        assert strip_date.sub("", without_client_urls) == strip_date.sub("", with_no_client_urls)
 
-        config = parse(without_auth_info)
+        config = parse(without_client_urls)
         assert "sly_data_schema" not in config["tools"][0]["function"]

--- a/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
@@ -1,0 +1,104 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for HoconAgentNetworkAssembler's sly_data_schema emission."""
+
+import asyncio
+import os
+import re
+from pathlib import Path
+
+from pyhocon import ConfigFactory
+
+from middleware.agent_network_designer.persistence.hocon_agent_network_assembler import HoconAgentNetworkAssembler
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+OAUTH_URL = "https://oauth.example.com/mcp"
+FILE_AUTH_URL = "https://file-auth.example.com/mcp"
+
+MCP_SERVERS_AUTH: dict[str, bool] = {OAUTH_URL: True, FILE_AUTH_URL: False}
+
+NETWORK_DEF: dict = {
+    "front_man": {"description": "top", "instructions": "Coordinate.", "tools": ["helper", OAUTH_URL]},
+    "helper": {"description": "helps", "instructions": "Help.", "tools": [FILE_AUTH_URL]},
+}
+
+
+def assemble(mcp_servers_auth: dict[str, bool] | None) -> str:
+    """Assemble the test network into HOCON text."""
+    assembler = HoconAgentNetworkAssembler(demo_mode=False)
+    return asyncio.run(
+        assembler.assemble_agent_network(NETWORK_DEF, "front_man", "test_net", ["query one"], mcp_servers_auth)
+    )
+
+
+def parse(hocon_text: str) -> dict:
+    """Parse assembled HOCON from the repo root so its includes resolve."""
+    cwd = os.getcwd()
+    os.chdir(REPO_ROOT)
+    try:
+        return ConfigFactory.parse_string(hocon_text)
+    finally:
+        os.chdir(cwd)
+
+
+def unquote(key: str) -> str:
+    """
+    Strip the quotes pyhocon keeps embedded in quoted keys that contain dots
+    (URL keys come back as '"https://..."'). Clients normalize the same way —
+    see nsflow's _clean_schema_url — and the neuro-san restorer shows the
+    identical artifact for the hand-written you_search.hocon.
+    """
+    return key.strip('"')
+
+
+class TestHoconAssemblerSlyDataSchema:
+    """The generated HOCON text declares the network's MCP header needs."""
+
+    def test_front_man_declares_the_schema_and_it_parses(self):
+        """The emitted text stays valid HOCON and carries the nsflow contract."""
+        config = parse(assemble(MCP_SERVERS_AUTH))
+
+        front_man = config["tools"][0]
+        assert front_man["name"] == "front_man"
+        http_headers = front_man["function"]["sly_data_schema"]["properties"]["http_headers"]
+        # Both used URLs are declared; only the token-needing one is required.
+        url_properties = {unquote(url): value for url, value in http_headers["properties"].items()}
+        assert sorted(url_properties) == sorted([OAUTH_URL, FILE_AUTH_URL])
+        assert list(http_headers["required"]) == [OAUTH_URL]
+        assert list(url_properties[OAUTH_URL]["required"]) == ["Authorization"]
+        # The description substitution still landed alongside the schema.
+        assert "top" in front_man["function"]["description"]
+
+    def test_non_top_agents_carry_no_schema(self):
+        """Only the front man talks to clients; helpers must not declare one."""
+        config = parse(assemble(MCP_SERVERS_AUTH))
+        for agent in config["tools"][1:]:
+            assert "sly_data_schema" not in agent.get("function", {})
+
+    def test_no_mcp_means_no_schema_and_unchanged_output(self):
+        """Without MCP the text is byte-identical to the pre-schema behavior."""
+        without_auth_info = assemble(None)
+        with_no_known_servers = assemble({})
+
+        assert "sly_data_schema" not in without_auth_info
+        # The two renders differ only in the date_created stamp.
+        strip_date = re.compile(r'"date_created": "[^"]*"')
+        assert strip_date.sub("", without_auth_info) == strip_date.sub("", with_no_known_servers)
+
+        config = parse(without_auth_info)
+        assert "sly_data_schema" not in config["tools"][0]["function"]


### PR DESCRIPTION
## Description

Lets the Agent Network Designer work with OAuth-authenticated MCP servers that a user connects through nsflow, end to end: listing their tools during design, and generating networks that declare the auth they need at runtime.

Fixes #1317

Counterpart to nsflow PR cognizant-ai-lab/nsflow#254, which injects each connected server's token into the designer conversation's sly_data on every chat turn as `sly_data["http_headers"][<server_url>] = {"Authorization": "Bearer …"}`.

This introduces two classes of MCP servers, handled differently on purpose:

| | File-configured (`registries/mcp_info.hocon`) | Client-token (`sly_data["http_headers"]`) |
|---|---|---|
| Scope | server-wide | per-conversation |
| Tool listings | cached process-wide (TTL) | fetched per call, never cached process-wide |
| In generated `sly_data_schema` | not declared | declared and required |

Main changes:

- `get_mcp_tool` lists tools from client-token servers using the conversation's headers, concurrently and per call. Those listings are merged into a local result only — nothing user-specific enters the process-wide caches, so concurrent users cannot see each other's authenticated listings (guarded by a regression test). A URL present in both classes is treated as file-configured.
- Generated networks (HOCON and deployable dict) emit a `sly_data_schema` on the front man declaring exactly the header names the conversation supplied per client-token URL, with every declared URL required — same shape as `registries/tools/you_search.hocon` — so runtime clients know what auth input the network needs.
- `registries/agent_network_designer.hocon` forwards `http_headers` to the downstream subnetworks (`allow.to_downstream.sly_data`); the upstream and tracing allowlists do not include it, so tokens cannot echo back to clients or traces.
- Structure validation accepts networks that reference connected-only servers.
- The client-input policy lives in `McpHeaderHygiene` (`mcp_header_hygiene.py`, public statics with their own unit-test module): which sly_data keys can name an MCP server, which header names/values are usable, header sanitization before the fetch, fetch-error rendering, and log redaction — one policy read by URL classification, the fetch path, and the persisted schema. `McpServersLoad` (`mcp_servers_load.py`) carries the `mcp_info.hocon` load result (`urls` + `loaded_ok`).

Hardening (from review):

- No token material in logs: header values are sanitized before use and redacted from transport error messages in two layers — exact-value masking (plain, str-repr, and bytes-repr forms; lone-surrogate-safe) plus unconditional pattern masking of h11's value-bearing message shape (`Illegal header name/value b'...'`), which also covers file-configured tokens whose values live inside the MCP adapter. Fetch failures log only the end error message, never anyio's TaskGroup wrapper text.
- `http_headers` entries are validated before being trusted: a key counts as a client-token server only if it is a well-formed `http(s)://` URL (no control characters or whitespace that could forge log lines, no userinfo, a real host — an accepted key becomes a fetch target, a verbatim log line, and a persisted schema key) carrying at least one usable header (legal RFC 9110 field name, non-blank string value).
- A broken `mcp_info.hocon` no longer misclassifies file servers as client-token in persisted networks — the persist path fails safe and omits the client-token schema block (with a warning) rather than baking a wrong auth contract into the artifact.

## Impact

- Without `http_headers` in sly_data (e.g. non-nsflow clients), behavior is unchanged: file-configured servers only, no schema block emitted.
- Designer conversations in nsflow now see tools from the user's connected OAuth MCP servers, and the generated networks carry the machine-readable auth contract nsflow's runtime reads.
- URL identity is exact-string throughout (nsflow stored URL, tools list, schema, runtime lookup); no normalization, deliberately.

## Type of Change

- [x] New feature

## Checklist

- [x] Tested locally (editor + designer suites: 108 passed; ruff format/check clean; pylint 10/10)
- [x] Added/updated tests (schema declaration incl. custom/multi headers and non-ASCII URLs, URL and header-input validation, log redaction incl. h11 message masking and lone surrogates, cross-conversation isolation regression, broken-config classification)
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (none added)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

