### PR TITLE
Adding expertise_scoping_instructions.hocon to ns init

### DIFF
--- a/docs/cli/import.md
+++ b/docs/cli/import.md
@@ -120,7 +120,9 @@ Imported alongside each network:
 - Sub-networks (`/network_name` references) — transitively
 - MCP tool URLs (`http://` / `https://`) — referenced server config is merged into `<project>/mcp/mcp_info.hocon` (additive; existing URLs preserved)
 
-Shared registry HOCONs (`aaosa.hocon`, `aaosa_basic.hocon`, `aaosa_basic_debug.hocon`) are scaffolded by `ns init`; the importer copies them as a safety net if missing.
+Shared registry HOCONs (`aaosa.hocon`, `aaosa_basic.hocon`, `aaosa_basic_debug.hocon`,
+`expertise_scoping_instructions.hocon`) are scaffolded by `ns init`; the importer copies them as a safety net if
+missing.
 
 ## Manifest
 

--- a/neuro_san_studio/commands/init.py
+++ b/neuro_san_studio/commands/init.py
@@ -29,6 +29,7 @@ from rich.table import Table
 from timedinput import timedinput
 
 from neuro_san_studio.utils.cli_status import CliStatus
+from neuro_san_studio.utils.shared_registries import SHARED_REGISTRY_INCLUDES
 
 PROVIDERS: Dict[str, Dict[str, str]] = {
     "openai": {"label": "OpenAI", "model_name": "gpt-5.2"},
@@ -71,15 +72,10 @@ class InitCommand:  # pylint: disable=too-few-public-methods
         # first time the server reads it, even before agent_network_designer has produced
         # any files. Empty `{}` is a valid manifest — neuro-san just sees no extra networks.
         self._copy_template("generated_manifest.hocon", os.path.join("registries", "generated", "manifest.hocon"))
-        # Shared registry-level HOCONs that AAOSA-style networks include. Most networks in
-        # the basic/industry/experimental groups depend on at least one of these, so
+        # Shared registry-level HOCONs that networks include. Most networks in the
+        # basic/industry/experimental groups depend on at least one of these, so
         # scaffolding them up front means `ns import <group>` works without surprises.
-        for shared in (
-            "aaosa.hocon",
-            "aaosa_basic.hocon",
-            "aaosa_basic_debug.hocon",
-            "expertise_scoping_instructions.hocon",
-        ):
+        for shared in SHARED_REGISTRY_INCLUDES:
             self._copy_template(shared, os.path.join("registries", shared), package="registries")
         self._copy_template("mcp_info.hocon", os.path.join("mcp", "mcp_info.hocon"), package="neuro_san_studio.mcp")
         self._copy_template("plugins.hocon", os.path.join("config", "plugins.hocon"))

--- a/neuro_san_studio/commands/init.py
+++ b/neuro_san_studio/commands/init.py
@@ -74,7 +74,12 @@ class InitCommand:  # pylint: disable=too-few-public-methods
         # Shared registry-level HOCONs that AAOSA-style networks include. Most networks in
         # the basic/industry/experimental groups depend on at least one of these, so
         # scaffolding them up front means `ns import <group>` works without surprises.
-        for shared in ("aaosa.hocon", "aaosa_basic.hocon", "aaosa_basic_debug.hocon"):
+        for shared in (
+            "aaosa.hocon",
+            "aaosa_basic.hocon",
+            "aaosa_basic_debug.hocon",
+            "expertise_scoping_instructions.hocon",
+        ):
             self._copy_template(shared, os.path.join("registries", shared), package="registries")
         self._copy_template("mcp_info.hocon", os.path.join("mcp", "mcp_info.hocon"), package="neuro_san_studio.mcp")
         self._copy_template("plugins.hocon", os.path.join("config", "plugins.hocon"))

--- a/neuro_san_studio/importer/agent_network_importer.py
+++ b/neuro_san_studio/importer/agent_network_importer.py
@@ -33,6 +33,7 @@ from neuro_san.internals.graph.persistence.raw_manifest_restorer import RawManif
 
 from neuro_san_studio.discovery.dependency_analyzer import AgentNetworkDependencies
 from neuro_san_studio.mcp.mcp_info_merger import McpInfoMerger
+from neuro_san_studio.utils.shared_registries import SHARED_REGISTRY_INCLUDES
 
 # `mcp/` is whitelisted so an export-side bundle can carry the filtered mcp_info.hocon. The
 # importer extracts it into memory and merges into the receiver's file additively rather than
@@ -107,12 +108,9 @@ class AgentNetworkImporter:
     # These aren't agent networks themselves so the dependency walker doesn't see them, but
     # almost every network in the basic/industry/experimental groups includes one. Copy them
     # alongside any imported network. (llm_config is generated fresh by `ns init`, not copied.)
-    SHARED_INCLUDES = (
-        "aaosa.hocon",
-        "aaosa_basic.hocon",
-        "aaosa_basic_debug.hocon",
-        "expertise_scoping_instructions.hocon",
-    )
+    # Defined in neuro_san_studio.utils.shared_registries so `ns init` scaffolds exactly the
+    # same set — the two lists used to be maintained separately and drifted.
+    SHARED_INCLUDES = SHARED_REGISTRY_INCLUDES
 
     def _register_manifest_entry(self, result: ImportResult, registries_relative: str) -> None:
         """Append ``registries_relative`` to ``result.manifest_entries`` unless it's a shared

--- a/neuro_san_studio/importer/agent_network_importer.py
+++ b/neuro_san_studio/importer/agent_network_importer.py
@@ -107,7 +107,12 @@ class AgentNetworkImporter:
     # These aren't agent networks themselves so the dependency walker doesn't see them, but
     # almost every network in the basic/industry/experimental groups includes one. Copy them
     # alongside any imported network. (llm_config is generated fresh by `ns init`, not copied.)
-    SHARED_INCLUDES = ("aaosa.hocon", "aaosa_basic.hocon", "aaosa_basic_debug.hocon")
+    SHARED_INCLUDES = (
+        "aaosa.hocon",
+        "aaosa_basic.hocon",
+        "aaosa_basic_debug.hocon",
+        "expertise_scoping_instructions.hocon",
+    )
 
     def _register_manifest_entry(self, result: ImportResult, registries_relative: str) -> None:
         """Append ``registries_relative`` to ``result.manifest_entries`` unless it's a shared

--- a/neuro_san_studio/utils/shared_registries.py
+++ b/neuro_san_studio/utils/shared_registries.py
@@ -1,0 +1,40 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""The shared registry-level HOCONs that agent networks pull in via ``include``."""
+
+from typing import Tuple
+
+# Registry-level HOCONs that are substitution fragments, not agent networks. Networks
+# reference them with `include "registries/<name>"` and then substitute a variable they
+# define (e.g. ${aaosa_instructions}, ${expertise_scoping_instructions}), so a project
+# missing one fails to parse the moment a network that includes it is read.
+#
+# The dependency walker doesn't surface them — it looks for networks, coded tools, and
+# middleware — so both `ns init` and `ns import` copy them unconditionally. `ns import`
+# additionally uses this list to keep fragments OUT of the manifest: registering one as a
+# network crashes neuro-san at startup, because its validator iterates the file expecting
+# agent specs and a bare string value blows up `agent.get(...)`.
+#
+# Keep this as the single definition. It previously lived in two places, and the copies
+# drifted: `expertise_scoping_instructions.hocon` was added to neither, which left every
+# freshly scaffolded project unable to start.
+SHARED_REGISTRY_INCLUDES: Tuple[str, ...] = (
+    "aaosa.hocon",
+    "aaosa_basic.hocon",
+    "aaosa_basic_debug.hocon",
+    "expertise_scoping_instructions.hocon",
+)

--- a/tests/neuro_san_studio/commands/test_agent_network_importer.py
+++ b/tests/neuro_san_studio/commands/test_agent_network_importer.py
@@ -48,7 +48,7 @@ class TestImportNetwork:
         (registries / "basic").mkdir(parents=True)
         (registries / "basic" / "music_nerd.hocon").write_text('{ "tools": [] }\n')
         # Shared registry includes that the importer always copies.
-        for shared in ("aaosa.hocon", "aaosa_basic.hocon", "aaosa_basic_debug.hocon"):
+        for shared in AgentNetworkImporter.SHARED_INCLUDES:
             (registries / shared).write_text(f"# {shared}\n")
 
         coded_tools = source_dir / "coded_tools" / "music_nerd"
@@ -100,7 +100,7 @@ class TestImportNetwork:
         (registries / "agent_network_designer.hocon").write_text('{ "tools": [] }\n')
         (registries / "advanced_calculator.hocon").write_text('{ "tools": [] }\n')
         (registries / "agentforce_adapter.hocon").write_text('{ "tools": [] }\n')
-        for shared in ("aaosa.hocon", "aaosa_basic.hocon", "aaosa_basic_debug.hocon"):
+        for shared in AgentNetworkImporter.SHARED_INCLUDES:
             (registries / shared).write_text("")
 
         importer = AgentNetworkImporter(str(source_dir), str(target_dir))
@@ -463,7 +463,7 @@ class TestMcpInfoMerge:
         target_dir.mkdir()
         (source_dir / "registries" / "basic").mkdir(parents=True)
         (source_dir / "registries" / "basic" / "mcp_user.hocon").write_text('{ "tools": [] }\n')
-        for shared in ("aaosa.hocon", "aaosa_basic.hocon", "aaosa_basic_debug.hocon"):
+        for shared in AgentNetworkImporter.SHARED_INCLUDES:
             (source_dir / "registries" / shared).write_text("")
         (source_dir / "mcp").mkdir()
         (source_dir / "mcp" / "mcp_info.hocon").write_text(
@@ -582,7 +582,7 @@ class TestForceOverwrite:
         registries.mkdir(parents=True)
         (registries / "music_nerd.hocon").write_text("NEW\n")
         # SHARED_INCLUDES are always copied; create empty stand-ins so import_network doesn't warn.
-        for shared in ("aaosa.hocon", "aaosa_basic.hocon", "aaosa_basic_debug.hocon"):
+        for shared in AgentNetworkImporter.SHARED_INCLUDES:
             (source_dir / "registries" / shared).write_text("")
 
         target_dir = tmp_path / "target"

--- a/tests/neuro_san_studio/commands/test_agent_network_importer.py
+++ b/tests/neuro_san_studio/commands/test_agent_network_importer.py
@@ -112,10 +112,11 @@ class TestImportNetwork:
         assert "agent_network_designer.hocon" in result.manifest_entries
         assert "advanced_calculator.hocon" in result.manifest_entries
         assert "agentforce_adapter.hocon" in result.manifest_entries
-        # Shared includes ride along on disk (line 86) but must NOT be registered as networks.
-        assert "aaosa.hocon" not in result.manifest_entries
-        assert "aaosa_basic.hocon" not in result.manifest_entries
-        assert "aaosa_basic_debug.hocon" not in result.manifest_entries
+        # Shared includes ride along on disk but must NOT be registered as networks: they are
+        # substitution fragments, and neuro-san's validator crashes on a manifest entry whose
+        # file holds a bare string instead of agent specs.
+        for shared in AgentNetworkImporter.SHARED_INCLUDES:
+            assert shared not in result.manifest_entries
 
     def test_import_skips_existing_files(self, tmp_path: Path) -> None:
         """Pre-existing target files must not be overwritten and should be reported as skipped."""

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -170,6 +170,7 @@ class TestRunFlow:
         assert (tmp_path / "registries" / "aaosa.hocon").is_file()
         assert (tmp_path / "registries" / "aaosa_basic.hocon").is_file()
         assert (tmp_path / "registries" / "aaosa_basic_debug.hocon").is_file()
+        assert (tmp_path / "registries" / "expertise_scoping_instructions.hocon").is_file()
         assert (tmp_path / "registries" / "manifest.hocon").read_text().strip().startswith("{")
         # registries/generated/ must exist with an empty manifest so the include in the
         # main manifest resolves before agent_network_designer ever runs.
@@ -337,6 +338,22 @@ class TestRunFlow:
         self._run_init(tmp_path, monkeypatch)
         self._assert_matches_template(
             tmp_path, "aaosa_basic_debug.hocon", "registries/aaosa_basic_debug.hocon", "registries"
+        )
+
+    def test_expertise_scoping_instructions_sourced_from_registries(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        """expertise_scoping_instructions.hocon should be copied from the registries package.
+
+        The scaffolded music_nerd.hocon includes it and substitutes
+        ``${expertise_scoping_instructions}``, so a project missing this file fails to parse.
+        """
+        self._run_init(tmp_path, monkeypatch)
+        self._assert_matches_template(
+            tmp_path,
+            "expertise_scoping_instructions.hocon",
+            "registries/expertise_scoping_instructions.hocon",
+            "registries",
         )
 
     def test_manifest_sourced_from_templates(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -26,6 +26,8 @@ from pytest import MonkeyPatch
 
 from neuro_san_studio.commands import init as init_module
 from neuro_san_studio.commands.init import InitCommand
+from neuro_san_studio.importer.agent_network_importer import AgentNetworkImporter
+from neuro_san_studio.utils.shared_registries import SHARED_REGISTRY_INCLUDES
 
 
 class TestProvidersArgParsing:
@@ -167,10 +169,8 @@ class TestRunFlow:
         self._run_init(tmp_path, monkeypatch)
 
         assert (tmp_path / "registries" / "music_nerd.hocon").is_file()
-        assert (tmp_path / "registries" / "aaosa.hocon").is_file()
-        assert (tmp_path / "registries" / "aaosa_basic.hocon").is_file()
-        assert (tmp_path / "registries" / "aaosa_basic_debug.hocon").is_file()
-        assert (tmp_path / "registries" / "expertise_scoping_instructions.hocon").is_file()
+        for shared in SHARED_REGISTRY_INCLUDES:
+            assert (tmp_path / "registries" / shared).is_file()
         assert (tmp_path / "registries" / "manifest.hocon").read_text().strip().startswith("{")
         # registries/generated/ must exist with an empty manifest so the include in the
         # main manifest resolves before agent_network_designer ever runs.
@@ -394,3 +394,42 @@ class TestTemplateSync:
     def test_plugins_template_matches_config(self) -> None:
         """templates/plugins.hocon must be byte-identical to config/plugins.hocon."""
         self._assert_template_matches_source("plugins.hocon", "config/plugins.hocon")
+
+
+class TestSharedRegistryIncludes:
+    """Guard the single shared-includes list that `ns init` and `ns import` both consume."""
+
+    def test_importer_uses_the_shared_constant(self) -> None:
+        """AgentNetworkImporter must not maintain its own copy of the list.
+
+        `expertise_scoping_instructions.hocon` was missing from both lists because they were
+        edited independently. Asserting identity — not equality — keeps them one object.
+        """
+        assert AgentNetworkImporter.SHARED_INCLUDES is SHARED_REGISTRY_INCLUDES
+
+    def test_every_shared_include_exists_in_the_packaged_registries(self) -> None:
+        """Each name must resolve to a real file, or `ns init` silently scaffolds nothing.
+
+        `_copy_template` reads through importlib.resources, so a typo or a renamed fragment
+        surfaces only at scaffold time — and `ns import` degrades to a warning, not an error.
+        """
+        import importlib.resources  # pylint: disable=import-outside-toplevel
+
+        for shared in SHARED_REGISTRY_INCLUDES:
+            assert (importlib.resources.files("registries") / shared).is_file(), (
+                f"{shared} is listed in SHARED_REGISTRY_INCLUDES but is not in the registries package."
+            )
+
+    def test_no_shared_include_is_an_agent_network(self) -> None:
+        """Shared includes must be substitution fragments, never networks.
+
+        The list doubles as the manifest exclusion set, so anything with a `tools` block
+        landing here would stop being served the moment it was added.
+        """
+        import importlib.resources  # pylint: disable=import-outside-toplevel
+
+        for shared in SHARED_REGISTRY_INCLUDES:
+            text = (importlib.resources.files("registries") / shared).read_text(encoding="utf-8")
+            assert "tools" not in ConfigFactory.parse_string(text), (
+                f"{shared} looks like an agent network; excluding it from the manifest would unserve it."
+            )


### PR DESCRIPTION
## Description

fixes #1314 

`ns init` scaffolded a project that could not start. The `music_nerd.hocon` template it
writes does `include "registries/expertise_scoping_instructions.hocon"` and substitutes
`${expertise_scoping_instructions}`, but that file was missing from the list of shared
registry HOCONs the command copies. The result was a hard parse failure on the first
`ns run`:

```
pyhocon.exceptions.ConfigSubstitutionException:
  Cannot resolve variable ${expertise_scoping_instructions} (line: 61, col: 29)
```

The same list was duplicated in `AgentNetworkImporter.SHARED_INCLUDES`, so `ns import` had
the identical gap. The two copies were maintained by hand and drifted — neither had the
fragment. Rather than add the filename twice, the list is now defined once in
`neuro_san_studio/utils/shared_registries.py` as `SHARED_REGISTRY_INCLUDES`;
`InitCommand.run()` iterates it and `AgentNetworkImporter.SHARED_INCLUDES` aliases it, so
the class's public surface is unchanged and the two can no longer diverge.

`expertise_scoping_instructions.hocon` is the most-included shared fragment in the repo —
80 networks pull it in, versus 72 for `aaosa.hocon` — spanning the basic, experimental,
industry, and tools groups. It also belongs in the list for that constant's second use:
`_register_manifest_entry` relies on it to keep substitution fragments out of the
manifest, and registering one as a network crashes neuro-san at startup, because its
validator iterates the file expecting agent specs and a bare string value blows up
`agent.get(...)`.

`docs/cli/import.md` documented the same list and is updated to match.

## Impact

- `ns init` now produces a project that runs out of the box. Previously every fresh
  scaffold was dead on arrival.
- `ns import <group>` no longer lands networks with an unresolvable substitution.
- Existing projects are unaffected: `_copy_template` skips files that already exist, so
  re-running `ns init` in a project created by the old version drops in only the missing
  file.
- No behavior change for networks that don't use the fragment; no new dependencies.
- Adding or removing a shared fragment is now a one-line change in one file, and three
  new guards fail the build if that file and the packaged `registries/` disagree.

## Screenshots / Logs / Examples (optional)

Fresh scaffold before the fix (note the absent file):

```
[ok]    registries/music_nerd.hocon
[ok]    registries/aaosa.hocon
[ok]    registries/aaosa_basic.hocon
[ok]    registries/aaosa_basic_debug.hocon
...
ConfigSubstitutionException: Cannot resolve variable ${expertise_scoping_instructions}
```

After:

```
[ok]    registries/music_nerd.hocon
[ok]    registries/aaosa.hocon
[ok]    registries/aaosa_basic.hocon
[ok]    registries/aaosa_basic_debug.hocon
[ok]    registries/expertise_scoping_instructions.hocon
...
```

Parsing the scaffolded network from the project root now resolves the substitution:

```
parsed OK
'\nOnly answer inquiries that are directly within your area of expertise. Do not try to
help for other matters.\nDo not mention what you can NOT do...'
```

## Tests

- `test_run_scaffolds_all_files` asserts every `SHARED_REGISTRY_INCLUDES` entry lands on
  disk, instead of naming files individually.
- `test_expertise_scoping_instructions_sourced_from_registries` checks the scaffolded copy
  is byte-identical to the packaged source.
- The importer test that verifies shared includes are not registered as networks now loops
  over `SHARED_INCLUDES`; it previously asserted only the three `aaosa*` files, so it would
  not have caught this regression. The four setup blocks that re-listed the filenames by
  hand reference the constant too.
- New `TestSharedRegistryIncludes` guards the constant itself, since one definition
  prevents drift but not the failure modes around it:
  - `SHARED_INCLUDES is SHARED_REGISTRY_INCLUDES` — identity, so reintroducing a literal
    copy fails loudly.
  - Every listed name resolves to a real file in the `registries` package. `_copy_template`
    reads through `importlib.resources` and `ns import` downgrades a missing source to a
    warning, so a typo or a renamed fragment would otherwise reproduce this bug silently.
  - No entry parses with a `tools` block. The list doubles as the manifest *exclusion* set,
    so adding a real network to it would unserve that network — the inverse failure.

565 passed, 3 skipped. `ruff format --check` and `ruff check` clean; pylint 10.00/10 on all
changed files.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` — n/a, no new dependencies

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
