### PR TITLE
Add a Google Workspace assistant tool network over Google's hosted MCP servers

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -37,6 +37,7 @@ Here are a few examples ordered by level of complexity.
     - [Gemini Image Generation](#gemini-image-generation)
     - [Wikimedia Search](#wikimedia-search)
     - [Gmail Assistant](#gmail-assistant)
+    - [Google Workspace Assistant](#google-workspace-assistant)
     - [Agent Network HTML Creator](#agent-network-html-creator)
     - [Agentforce](#agentforce)
     - [Agentspace](#agentspace)
@@ -314,6 +315,16 @@ deliver the best matching media files for user descriptions.
 language. It can search, read, draft, and send emails by delegating tasks to specialized tools in the Gmail Toolkit.
 
 **Tags:** `tool`, `Gmail`, `API`
+
+### Google Workspace Assistant
+
+[Google Workspace Assistant](examples/tools/google_workspace.md) is a single-agent system that manages a user's Gmail,
+Calendar, Drive, Docs, and Sheets through Google's hosted Workspace MCP servers, so one request can span services —
+find a report in Drive and email a link to it, or turn a Doc's meeting notes into Calendar events. Authentication is
+per user and per conversation: an OAuth-capable client such as nsflow connects each server with the user's Google
+account and passes the bearer tokens through `sly_data`, with no server-side credentials at all.
+
+**Tags:** `tool`, `Google Workspace`, `MCP`, `OAuth`
 
 ### Agent Network HTML Creator
 

--- a/docs/examples/tools/google_workspace.md
+++ b/docs/examples/tools/google_workspace.md
@@ -1,0 +1,74 @@
+# Google Workspace Assistant
+
+The **Google Workspace Assistant** is a single-agent network that manages a user's Gmail, Calendar, Drive, Docs, and
+Sheets through Google's hosted Workspace MCP servers. Because one agent carries all five services, a single request can
+span them — for example, finding a report in Drive and emailing a link to it, or turning meeting notes from a Doc into
+Calendar events.
+
+Authentication is per user and per conversation: an OAuth-capable client (such as `nsflow`) connects each MCP server
+with the user's Google account and passes the resulting bearer tokens through `sly_data` on every message. The server
+needs no Google credentials, API keys, or extra packages.
+
+---
+
+## File
+
+[google_workspace.hocon](../../../registries/tools/google_workspace.hocon)
+
+---
+
+## Prerequisites
+
+- A Google account with access to Gmail, Calendar, Drive, Docs, and Sheets.
+- An OAuth-capable client. With `nsflow`, open the MCP settings page and connect each of the five servers with your
+  Google account. Chat with this network is gated until every server listed under
+  `sly_data_schema.http_headers.required` is connected; until then nsflow redirects you to complete the OAuth flow.
+- No server-side setup: no `credentials.json`, no environment variables, no additional `pip install`.
+
+---
+
+## Architecture Overview
+
+### Frontman Agent: **google_workspace_assistant**
+
+- The network's single agent: it talks to the client and owns all five MCP servers as tools.
+- Combines services when a request spans them, and asks for confirmation before sending email or modifying content.
+
+### Tools: Google's hosted Workspace MCP servers
+
+| Service  | MCP server URL |
+|----------|----------------|
+| Gmail    | `https://gmailmcp.googleapis.com/mcp/v1` |
+| Calendar | `https://calendarmcp.googleapis.com/mcp/v1` |
+| Drive    | `https://drivemcp.googleapis.com/mcp/v1` |
+| Docs     | `https://docsmcp.googleapis.com/mcp/v1` |
+| Sheets   | `https://sheetsmcp.googleapis.com/mcp/v1` |
+
+Each URL appears three times in the HOCON, and the three lists must stay in sync: in the agent's `tools` (making the
+server's tools callable), under `sly_data_schema.http_headers.properties` (declaring the auth input a client must
+supply), and in `sly_data_schema.http_headers.required` (gating chat until the server is connected).
+
+---
+
+## Authentication
+
+The front man's `sly_data_schema` declares, for each server URL, an `Authorization` header of the form
+`Bearer <token_value>`. Generic clients read this schema to learn what private inputs to pass outside the chat stream
+as `sly_data["http_headers"][<server_url>]["Authorization"]`; nsflow does this automatically for connected servers,
+refreshing tokens as needed — Google access tokens are short-lived, which is why the client OAuth flow is the
+practical path rather than static headers in `MCP_SERVERS_INFO_FILE` (see
+[user guide: authentication](../../user_guide.md#authentication)).
+
+To use only a subset of the services, remove the unused URLs from all three lists in the HOCON. To stop nsflow from
+forcing a connect (keeping opportunistic token injection for whatever is passed), set `http_headers.required` to `[]`.
+
+---
+
+## Debugging Hints
+
+- **Chat is blocked / keeps redirecting to home**: some URL in `http_headers.required` is not connected in nsflow yet.
+  Connect it, or trim the `required` list if you only use some of the services.
+- **A service's tools are missing from the agent's repertoire**: that server's token was absent, expired, or revoked —
+  its listing is dropped for the turn rather than failing the others. Reconnect the server in nsflow.
+- **401/403 errors on tool calls**: the Google account that connected the server lacks access to the content being
+  requested, or the OAuth grant was revoked in the Google account's security settings.

--- a/registries/manifest_multiuser_overlay.hocon
+++ b/registries/manifest_multiuser_overlay.hocon
@@ -59,6 +59,7 @@
     "tools/agentforce.hocon": false,                    # Reason #2
     "tools/openai_image_generation.hocon": false,       # Reason #1
     "tools/persistent_memory_local.hocon": false,       # Reason #1
+    "tools/google_workspace.hocon": false,              # Reason #7
     "tools/you_search.hocon": false,                    # Reason #7
 
     # Experimental and research

--- a/registries/tools/google_workspace.hocon
+++ b/registries/tools/google_workspace.hocon
@@ -1,0 +1,177 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# Requirements to use this agent network:
+#   - neuro-san >= 0.6.24
+#   - A Google account with access to Gmail, Calendar, Drive, Docs, and Sheets.
+#   - Per-user OAuth tokens for Google's hosted Workspace MCP servers. No server-side
+#     credentials or extra packages are needed: authentication is per conversation.
+#
+# Supported authentication methods:
+#   1. OAuth token exchange in the client application. An OAuth-capable client such as
+#      nsflow connects each MCP server below with the user's Google account and passes
+#      the resulting bearer tokens via the sly_data "http_headers" input, following the
+#      schema in the agent function definition below.
+#   2. MCP_SERVERS_INFO_FILE with static headers. See
+#      ../../neuro_san_studio/mcp/mcp_info.hocon and ../../docs/user_guide.md#authentication.
+#      Note that Google access tokens are short-lived, so the OAuth client flow (which
+#      refreshes tokens automatically) is the practical path.
+#
+# Note: nsflow forces an OAuth connect (blocking chat until it succeeds) for every MCP
+# server URL listed under `sly_data_schema.http_headers.required`. All five services are
+# required here because the agent's instructions span them; if you only care about a
+# subset, remove the unused URLs from this file's `tools`, `properties`, and `required`
+# lists — or set `required` to [] to keep declared tokens injected opportunistically
+# without gating chat.
+
+{
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent that manages a user's Google Workspace — Gmail, Calendar, Drive, Docs, and Sheets — through Google's hosted MCP servers, using per-user OAuth tokens.",
+        "tags": ["google", "mcp", "tool"],
+        "sample_queries": [
+            "Do I have any unread emails from this week that still need a reply?",
+            "What is on my calendar tomorrow?",
+            "Find the latest quarterly report in my Drive and summarize it.",
+            "Create a spreadsheet that tracks my project deadlines.",
+            "Draft a doc with today's meeting notes and email a link to the team."
+        ]
+    },
+
+    include "registries/expertise_scoping_instructions.hocon",
+    include "config/llm_config.hocon",
+
+    "tools": [
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        {
+            "name": "google_workspace_assistant",
+
+            "function": {
+                "description": "Assist caller with their Google Workspace: search, read, draft, and send Gmail; check and manage Calendar events; find and organize Drive files; and create or edit Docs and Sheets.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "user_inquiry": {
+                            "type": "string",
+                            "description": "An inquiry from a user."
+                        },
+                    },
+                    "required": ["user_inquiry"]
+                },
+
+                # The schema for the sly_data this network needs as input. Generic clients
+                # read it to know what private data to pass outside the chat stream; nsflow
+                # reads the URL keys and the `required` list to know which MCP servers the
+                # user must OAuth-connect before chatting, then injects each server's bearer
+                # token on every message.
+                "sly_data_schema": {
+                    "type": "object",
+                    "properties": {
+                        "http_headers": {
+                            "type": "object",
+                            "description": "HTTP headers to be sent with MCP tool requests.",
+                            "properties": {
+                                "https://gmailmcp.googleapis.com/mcp/v1": {
+                                    "type": "object",
+                                    "description": "URL for the Gmail MCP server.",
+                                    "properties": {
+                                        "Authorization": {
+                                            "type": "string",
+                                            "description": "Authorization header for Gmail access, e.g. 'Bearer <token_value>'."
+                                        }
+                                    },
+                                    "required": ["Authorization"]
+                                },
+                                "https://calendarmcp.googleapis.com/mcp/v1": {
+                                    "type": "object",
+                                    "description": "URL for the Google Calendar MCP server.",
+                                    "properties": {
+                                        "Authorization": {
+                                            "type": "string",
+                                            "description": "Authorization header for Google Calendar access, e.g. 'Bearer <token_value>'."
+                                        }
+                                    },
+                                    "required": ["Authorization"]
+                                },
+                                "https://drivemcp.googleapis.com/mcp/v1": {
+                                    "type": "object",
+                                    "description": "URL for the Google Drive MCP server.",
+                                    "properties": {
+                                        "Authorization": {
+                                            "type": "string",
+                                            "description": "Authorization header for Google Drive access, e.g. 'Bearer <token_value>'."
+                                        }
+                                    },
+                                    "required": ["Authorization"]
+                                },
+                                "https://docsmcp.googleapis.com/mcp/v1": {
+                                    "type": "object",
+                                    "description": "URL for the Google Docs MCP server.",
+                                    "properties": {
+                                        "Authorization": {
+                                            "type": "string",
+                                            "description": "Authorization header for Google Docs access, e.g. 'Bearer <token_value>'."
+                                        }
+                                    },
+                                    "required": ["Authorization"]
+                                },
+                                "https://sheetsmcp.googleapis.com/mcp/v1": {
+                                    "type": "object",
+                                    "description": "URL for the Google Sheets MCP server.",
+                                    "properties": {
+                                        "Authorization": {
+                                            "type": "string",
+                                            "description": "Authorization header for Google Sheets access, e.g. 'Bearer <token_value>'."
+                                        }
+                                    },
+                                    "required": ["Authorization"]
+                                }
+                            },
+                            # URLs listed here gate chatting: nsflow forces an OAuth connect and
+                            # redirects to home until each is connected. Set to [] to disable the
+                            # gate (declared tokens are still injected opportunistically when
+                            # passed); omit `required` entirely to gate every URL declared under
+                            # `properties`.
+                            "required": [
+                                "https://gmailmcp.googleapis.com/mcp/v1",
+                                "https://calendarmcp.googleapis.com/mcp/v1",
+                                "https://drivemcp.googleapis.com/mcp/v1",
+                                "https://docsmcp.googleapis.com/mcp/v1",
+                                "https://sheetsmcp.googleapis.com/mcp/v1"
+                            ]
+                        }
+                    },
+                    "required": ["http_headers"]
+                }
+            },
+
+            "instructions": """
+Use your Google Workspace tools — Gmail, Calendar, Drive, Docs, and Sheets — to respond to the inquiry.
+Combine services when a request spans them, e.g. attach or link a Drive file in an email, or turn meeting
+notes from a Doc into Calendar events. Confirm with the user before sending email or modifying or deleting
+their content; reading and searching need no confirmation.
+""" ${expertise_scoping_instructions},
+            "tools": [
+                "https://gmailmcp.googleapis.com/mcp/v1",
+                "https://calendarmcp.googleapis.com/mcp/v1",
+                "https://drivemcp.googleapis.com/mcp/v1",
+                "https://docsmcp.googleapis.com/mcp/v1",
+                "https://sheetsmcp.googleapis.com/mcp/v1"
+            ]
+        },
+    ]
+}

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -104,6 +104,13 @@
     # - Use MCP_SERVERS_INFO_FILE for authentication. See ../../neuro_san_studio/mcp/mcp_info.hocon and ../../docs/user_guide.md#authentication
     "tools/google_maps.hocon": false,
 
+    # Google Workspace assistant backed by Google's hosted MCP servers (Gmail, Calendar,
+    # Drive, Docs, Sheets). No server-side credentials: connect each server with your Google
+    # account in an OAuth-capable client (e.g. nsflow), which passes the bearer tokens via
+    # sly_data http_headers per the network's sly_data_schema. Chat is gated until the
+    # required servers are connected. See docs/examples/tools/google_workspace.md.
+    "tools/google_workspace.hocon": true,
+
     # Before turning on and running the following agent network, make sure that:
     # The MCP server is running.
     # The server can be found at servers/MCP/bmi_server.py and run using the following command

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -109,7 +109,7 @@
     # account in an OAuth-capable client (e.g. nsflow), which passes the bearer tokens via
     # sly_data http_headers per the network's sly_data_schema. Chat is gated until the
     # required servers are connected. See docs/examples/tools/google_workspace.md.
-    "tools/google_workspace.hocon": true,
+    "tools/google_workspace.hocon": false,
 
     # Before turning on and running the following agent network, make sure that:
     # The MCP server is running.

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -109,7 +109,7 @@
     # account in an OAuth-capable client (e.g. nsflow), which passes the bearer tokens via
     # sly_data http_headers per the network's sly_data_schema. Chat is gated until the
     # required servers are connected. See docs/examples/tools/google_workspace.md.
-    "tools/google_workspace.hocon": false,
+    "tools/google_workspace.hocon": true,
 
     # Before turning on and running the following agent network, make sure that:
     # The MCP server is running.


### PR DESCRIPTION
## Description

Adds a **Google Workspace Assistant** tool network: one agent whose five tools are Google's hosted Workspace MCP servers — Gmail, Calendar, Drive, Docs, and Sheets — so a single request can span services (find a report in Drive and email a link to it, or turn a Doc's meeting notes into Calendar events).

Authentication is per user and per conversation, with no server-side setup at all: an OAuth-capable client such as nsflow connects each MCP server with the user's Google account and passes the resulting bearer tokens through `sly_data["http_headers"]` on every message. The network follows the `you_search.hocon` pattern — its front man's `sly_data_schema` declares each server URL with a required `Authorization` header, and all five URLs sit in `http_headers.required`, so nsflow gates chat until each is connected. Header comments explain how to trim to a subset of services or relax the gate (`required: []`) for opportunistic token injection.

Files:

- `registries/tools/google_workspace.hocon` — the network (single agent `google_workspace_assistant`, five MCP server tools, full `sly_data_schema`).
- `registries/tools/manifest.hocon` — registered as enabled: there are no server-side credentials or packages to configure, and the OAuth gate handles the unconnected case (same reasoning as `you_search`).
- `docs/examples/tools/google_workspace.md` — prerequisites, architecture (service → URL table, and the rule that the `tools` / `properties` / `required` URL lists must stay in sync), how the auth flow works, debugging hints.
- `docs/examples.md` — new "Google Workspace Assistant" entry after Gmail Assistant, plus the TOC line.

The five server URLs are the same ones already exercised in this repo by the generated `personal_executive_assistant_network.hocon`.

## Impact

- New, self-contained example network; no code changes and no effect on existing networks.
- Listed in the manifest as enabled, so it appears in clients immediately; chatting with it requires connecting the five Google MCP servers in an OAuth-capable client (nsflow), and is gated until then.

## Type of Change

- [x] New agent / tool

## Checklist

- [x] Tested locally (HOCON parses through the registry loader with includes resolved; the three URL lists verified identical; manifest entry reads back enabled)
- [ ] Added/updated tests (config + docs only)
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (none added)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
