### PR TITLE
Add an internet info gatherer network pairing free you.com search with web_fetch

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -36,6 +36,7 @@ Here are a few examples ordered by level of complexity.
     - [Google Maps](#google-maps)
     - [Gemini Image Generation](#gemini-image-generation)
     - [Wikimedia Search](#wikimedia-search)
+    - [Internet Info Gatherer](#internet-info-gatherer)
     - [Gmail Assistant](#gmail-assistant)
     - [Agent Network HTML Creator](#agent-network-html-creator)
     - [Agentforce](#agentforce)
@@ -307,6 +308,15 @@ proper file extensions, supports pagination for diverse results, and employs sma
 deliver the best matching media files for user descriptions.
 
 **Tags:** `tool`, `API`, `multi-media`
+
+### Internet Info Gatherer
+
+[Internet Info Gatherer](examples/tools/internet_info_gatherer.md) is a single-agent system that answers questions
+from the live web in two steps: it searches through the you.com MCP server's free tier to find sources, then reads
+the promising pages with the `web_fetch` toolbox tool so its answers come from actual page content, with cited URLs.
+It needs no API keys or OAuth — the free search tier and the local fetch tool work out of the box.
+
+**Tags:** `tool`, `MCP`, `toolbox`, `web`
 
 ### Gmail Assistant
 

--- a/docs/examples/tools/internet_info_gatherer.md
+++ b/docs/examples/tools/internet_info_gatherer.md
@@ -1,0 +1,64 @@
+# Internet Info Gatherer
+
+The **Internet Info Gatherer** is a single-agent network that gathers information from the internet in two steps:
+it searches the web through the you.com MCP server's free tier to find sources, then reads the pages it finds with
+the `web_fetch` toolbox tool to ground its answers in actual page content, with cited URLs.
+
+The two tools deliberately complement each other: the free you.com tier exposes only the `you-search` tool — search
+result titles, URLs, and snippets, with no page content (the `you-contents` and `you-research` tools require the
+authenticated tier; see the [you_search](../../search_tools.md) network for that). `web_fetch` fills the gap by
+fetching the promising result URLs and returning their plain-text body, so the agent answers from what pages
+actually say instead of from snippets.
+
+---
+
+## File
+
+[internet_info_gatherer.hocon](../../../registries/tools/internet_info_gatherer.hocon)
+
+---
+
+## Prerequisites
+
+None — this network runs out of the box:
+
+- The you.com MCP server's free tier (`?profile=free`) needs no API key and no OAuth.
+- `web_fetch`'s packages (`aiohttp`, `beautifulsoup4`, `pypdf`) ship in `requirements.txt`.
+- `python -m neuro_san_studio run` automatically points `AGENT_TOOLBOX_INFO_FILE` at this repo's
+  [toolbox_info.hocon](../../../neuro_san_studio/toolbox/toolbox_info.hocon), where `web_fetch` is defined. If you
+  override that variable with your own toolbox file, keep a `web_fetch` entry in it.
+
+---
+
+## Architecture Overview
+
+### Frontman Agent: **info_gatherer**
+
+- The network's single LLM agent. Its instructions enforce the search-then-read loop: find sources, fetch the
+  relevant ones, answer from page content, cite URLs.
+
+### Tool: you.com MCP server (free tier)
+
+- `https://api.you.com/mcp?profile=free`, connected as a remote MCP tool over streamable HTTP.
+- Free tier exposes `you-search` only: web search results with titles, URLs, and snippets.
+
+### Tool: `web_fetch` (toolbox)
+
+- A shared toolbox coded tool (`neuro_san_studio.coded_tools.web_fetch.WebFetch`) that fetches one URL and returns
+  its plain-text body plus metadata. Handles HTML pages and PDF documents.
+- Content is truncated to `max_content_chars` (default 20000); optional `allowed_domains` / `blocked_domains`
+  parameters restrict where it may go.
+- Includes SSRF protections: private, loopback, and link-local destinations are refused.
+
+---
+
+## Debugging Hints
+
+- **Search works but answers stay shallow**: the model answered from snippets. The instructions tell it to fetch
+  before answering — if it still skips fetching, ask it explicitly to read the pages.
+- **Search results are empty or rate-limited**: the free you.com tier has usage limits. The paid tier via the
+  `you_search` network removes them.
+- **web_fetch refuses a URL**: the target resolved to a private, loopback, or link-local address (SSRF protection),
+  the URL exceeded 250 characters, or a domain filter excluded it.
+- **A fetched page comes back nearly empty**: some sites render content with JavaScript or block non-browser
+  clients; try another source from the search results.

--- a/registries/tools/internet_info_gatherer.hocon
+++ b/registries/tools/internet_info_gatherer.hocon
@@ -1,0 +1,91 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# Requirements to use this agent network:
+#   - neuro-san >= 0.6.24
+#   - Nothing else: the you.com MCP server's free tier needs no API key or OAuth, and
+#     web_fetch's packages (aiohttp, beautifulsoup4, pypdf) ship in requirements.txt.
+#
+# Why these two tools together: the free you.com tier exposes only the `you-search`
+# tool — search result snippets, no page content (the you-contents and you-research
+# tools require the authenticated tier; see the `you_search` agent network). The
+# `web_fetch` toolbox tool fills that gap: the agent searches to FIND sources, then
+# fetches the promising URLs to actually READ them.
+
+{
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Agent network with a single agent that gathers information from the internet: it searches the web through the you.com MCP server's free tier, then reads the pages it finds with the web_fetch toolbox tool to ground its answers in actual page content.",
+        "tags": ["tool", "mcp", "web"],
+        "sample_queries": [
+            "What is the latest news on AI agent frameworks? Read the top articles and summarize.",
+            "Find the official Python 3.13 release notes and list the major new features.",
+            "How do recent articles compare the licensing of open-source LLMs? Cite your sources."
+        ]
+    },
+
+    include "registries/expertise_scoping_instructions.hocon",
+    include "config/llm_config.hocon",
+
+    "tools": [
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
+        #
+        # Besides the first agent being the front man, these tool definitions
+        # do not have to be in any particular order. How they are linked and
+        # call each other is defined within their own specs.
+        # This could be a graph, potentially even with cycles.
+        {
+            "name": "info_gatherer",
+
+            "function": {
+                "description": "Assist caller with gathering information from the internet: search the web for sources, read the relevant pages, and answer with grounded, cited findings.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "user_inquiry": {
+                            "type": "string",
+                            "description": "An inquiry from a user."
+                        },
+                    },
+                    "required": ["user_inquiry"]
+                }
+            },
+
+            "instructions": """
+Gather information from the internet to respond to the inquiry:
+1. Search the web with your you.com search tool to find relevant sources. Search results carry
+   only titles, URLs, and snippets — do not answer from snippets alone when the substance matters.
+2. Fetch the most promising result URLs with your web_fetch tool and read the page content
+   (it handles HTML pages and PDFs). Fetch more sources when they disagree or a page falls short.
+3. Answer from what the pages actually say, and cite the URLs you used.
+""" ${expertise_scoping_instructions},
+            "tools": ["https://api.you.com/mcp?profile=free", "web_fetch"]
+        },
+
+        # web_fetch comes from the shared toolbox (see
+        # neuro_san_studio/toolbox/toolbox_info.hocon): it fetches one URL and returns the
+        # plain-text body with metadata, truncated to max_content_chars (default 20000).
+        {
+            "name": "web_fetch",
+            "toolbox": "web_fetch"
+        },
+    ]
+}

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -104,6 +104,11 @@
     # - Use MCP_SERVERS_INFO_FILE for authentication. See ../../neuro_san_studio/mcp/mcp_info.hocon and ../../docs/user_guide.md#authentication
     "tools/google_maps.hocon": false,
 
+    # Searches the web via the you.com MCP server's free tier (no API key or OAuth), then
+    # reads the result pages with the web_fetch toolbox tool. Works out of the box.
+    # See docs/examples/tools/internet_info_gatherer.md.
+    "tools/internet_info_gatherer.hocon": true,
+
     # Before turning on and running the following agent network, make sure that:
     # The MCP server is running.
     # The server can be found at servers/MCP/bmi_server.py and run using the following command


### PR DESCRIPTION
## Description

Adds an **Internet Info Gatherer** tool network: a single agent, `info_gatherer`, whose two tools deliberately complement each other —

- the **you.com MCP server's free tier** (`https://api.you.com/mcp?profile=free`) finds sources. The free tier exposes only the `you-search` tool: titles, URLs, and snippets, with no page content (`you-contents`/`you-research` need the authenticated tier — that's the existing `you_search` network).
- the **`web_fetch` toolbox tool** fills that gap: it fetches the promising result URLs and returns their plain-text body (HTML pages and PDFs), so the agent answers from what pages actually say, with cited URLs, instead of from snippets. The agent's instructions enforce that search → read → cite loop.

It runs out of the box: the free search tier needs no API key or OAuth, `web_fetch`'s packages (`aiohttp`, `beautifulsoup4`, `pypdf`) already ship in `requirements.txt`, and `python -m neuro_san_studio run` auto-wires this repo's `toolbox_info.hocon`, where `web_fetch` is defined (with its SSRF protections and URL/content limits).

Files:

- `registries/tools/internet_info_gatherer.hocon` — the network (front man + a `web_fetch` toolbox node, since a front man cannot carry a toolbox definition itself).
- `registries/tools/manifest.hocon` — registered as enabled (nothing to configure).
- `docs/examples/tools/internet_info_gatherer.md` — rationale for the tool pairing, prerequisites (none, with a note for deployments that override `AGENT_TOOLBOX_INFO_FILE`), architecture, and debugging hints (snippet-only answers, free-tier rate limits, `web_fetch` SSRF refusals, JS-rendered pages).
- `docs/examples.md` — new "Internet Info Gatherer" entry after Wikimedia Search, plus the TOC line.

## Impact

- New, self-contained example network; no code changes and no effect on existing networks.
- Enabled in the manifest, and usable immediately with zero credentials — a convenient default web-research network, and a working example of combining a remote MCP tool with a local toolbox tool in one agent.

## Type of Change

- [x] New agent / tool

## Checklist

- [x] Tested locally (HOCON parses through the registry loader with includes resolved; front man verified free of `class`/`toolbox` definitions; the `web_fetch` reference resolves against `neuro_san_studio/toolbox/toolbox_info.hocon`; manifest entry reads back enabled)
- [ ] Added/updated tests (config + docs only)
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (none added)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
