### PR TITLE
#1302: Replace LangChain Wikipedia retriever

### DIFF
--- a/neuro_san_studio/coded_tools/modified_wikipedia_retriever.py
+++ b/neuro_san_studio/coded_tools/modified_wikipedia_retriever.py
@@ -1,0 +1,84 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from asyncio import to_thread
+from typing import Any
+
+from langchain_core.callbacks import AsyncCallbackManagerForRetrieverRun
+from langchain_core.callbacks import CallbackManagerForRetrieverRun
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+
+WIKIPEDIA_MAX_QUERY_LENGTH = 300
+
+
+class ModifiedWikipediaRetriever(BaseRetriever):
+    """Wikipedia retriever that depends directly on the ``wikipedia`` package."""
+
+    top_k_results: int = 3
+    lang: str = "en"
+    doc_content_chars_max: int = 4000
+
+    def _get_relevant_documents(self, query: str, *, run_manager: CallbackManagerForRetrieverRun) -> list[Document]:
+        """Retrieve Wikipedia documents synchronously."""
+        return self.load(query)
+
+    async def _aget_relevant_documents(
+        self, query: str, *, run_manager: AsyncCallbackManagerForRetrieverRun
+    ) -> list[Document]:
+        """Retrieve Wikipedia documents without blocking the event loop."""
+        return await to_thread(self.load, query)
+
+    def load(self, query: str) -> list[Document]:
+        """Search Wikipedia and load the matching article content and metadata."""
+        wikipedia = self._get_wikipedia_client()
+        wikipedia.set_lang(self.lang)
+        page_titles = wikipedia.search(
+            query[:WIKIPEDIA_MAX_QUERY_LENGTH],
+            results=self.top_k_results,
+        )
+
+        documents: list[Document] = []
+        for page_title in page_titles[: self.top_k_results]:
+            try:
+                page = wikipedia.page(title=page_title, auto_suggest=False)
+            except (wikipedia.exceptions.PageError, wikipedia.exceptions.DisambiguationError):
+                continue
+
+            documents.append(
+                Document(
+                    page_content=page.content[: self.doc_content_chars_max],
+                    metadata={
+                        "title": page_title,
+                        "summary": page.summary,
+                        "source": page.url,
+                    },
+                )
+            )
+
+        return documents
+
+    @staticmethod
+    def _get_wikipedia_client() -> Any:
+        """Import and return the optional ``wikipedia`` dependency."""
+        try:
+            import wikipedia  # pylint: disable=import-outside-toplevel
+        except ImportError as exc:
+            raise ImportError(
+                "Could not import wikipedia python package. Please install it with `pip install wikipedia`."
+            ) from exc
+
+        return wikipedia

--- a/neuro_san_studio/coded_tools/wikipedia_rag.py
+++ b/neuro_san_studio/coded_tools/wikipedia_rag.py
@@ -18,10 +18,10 @@ import logging
 from typing import Any
 from typing import Dict
 
-from langchain_community.retrievers import WikipediaRetriever
 from neuro_san.interfaces.coded_tool import CodedTool
 
 from neuro_san_studio.coded_tools.base_rag import BaseRag
+from neuro_san_studio.coded_tools.modified_wikipedia_retriever import ModifiedWikipediaRetriever
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -66,8 +66,8 @@ class WikipediaRag(CodedTool):
             logger.error("Missing required input: 'query' (retrieval question).")
             return "❌ Missing required input: 'query'."
 
-        # Initialize WikipediaRetriever with the provided arguments
-        retriever = WikipediaRetriever(
+        # Initialize ModifiedWikipediaRetriever with the provided arguments
+        retriever = ModifiedWikipediaRetriever(
             lang=str(args.get("lang", "en")),
             top_k_results=int(args.get("top_k_results", 3)),
             doc_content_chars_max=int(args.get("doc_content_chars_max", 4000)),

--- a/tests/neuro_san_studio/coded_tools/test_modified_wikipedia_retriever.py
+++ b/tests/neuro_san_studio/coded_tools/test_modified_wikipedia_retriever.py
@@ -1,0 +1,114 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from neuro_san_studio.coded_tools.modified_wikipedia_retriever import WIKIPEDIA_MAX_QUERY_LENGTH
+from neuro_san_studio.coded_tools.modified_wikipedia_retriever import ModifiedWikipediaRetriever
+
+MODULE = "neuro_san_studio.coded_tools.modified_wikipedia_retriever"
+
+
+class PageError(Exception):
+    """Fake wikipedia PageError."""
+
+
+class DisambiguationError(Exception):
+    """Fake wikipedia DisambiguationError."""
+
+
+@pytest.fixture(name="wikipedia")
+def wikipedia_fixture() -> SimpleNamespace:
+    """Create a mocked wikipedia module."""
+    return SimpleNamespace(
+        set_lang=Mock(),
+        search=Mock(return_value=["First", "Second"]),
+        page=Mock(
+            side_effect=[
+                SimpleNamespace(content="first content", summary="first summary", url="https://example.com/first"),
+                SimpleNamespace(content="second content", summary="second summary", url="https://example.com/second"),
+            ]
+        ),
+        exceptions=SimpleNamespace(PageError=PageError, DisambiguationError=DisambiguationError),
+    )
+
+
+class TestModifiedWikipediaRetriever:
+    """Behavioral tests for ModifiedWikipediaRetriever."""
+
+    def test_load_preserves_content_and_metadata(self, wikipedia: SimpleNamespace):
+        """Loaded documents match the previous retriever's result contract."""
+        retriever = ModifiedWikipediaRetriever(lang="fr", top_k_results=2, doc_content_chars_max=5)
+
+        with patch.object(retriever, "_get_wikipedia_client", return_value=wikipedia):
+            documents = retriever.load("query")
+
+        wikipedia.set_lang.assert_called_once_with("fr")
+        assert [document.page_content for document in documents] == ["first", "secon"]
+        assert documents[0].metadata == {
+            "title": "First",
+            "summary": "first summary",
+            "source": "https://example.com/first",
+        }
+
+    def test_load_truncates_query_and_limits_results(self, wikipedia: SimpleNamespace):
+        """Search input and returned pages respect the configured limits."""
+        wikipedia.search.return_value = ["First", "Second", "Third"]
+        retriever = ModifiedWikipediaRetriever(top_k_results=1)
+        query = "x" * (WIKIPEDIA_MAX_QUERY_LENGTH + 10)
+
+        with patch.object(retriever, "_get_wikipedia_client", return_value=wikipedia):
+            documents = retriever.load(query)
+
+        wikipedia.search.assert_called_once_with("x" * WIKIPEDIA_MAX_QUERY_LENGTH, results=1)
+        wikipedia.page.assert_called_once_with(title="First", auto_suggest=False)
+        assert len(documents) == 1
+
+    @pytest.mark.parametrize("error", [PageError(), DisambiguationError()])
+    def test_load_skips_unavailable_pages(self, wikipedia: SimpleNamespace, error: Exception):
+        """Missing and ambiguous pages are skipped."""
+        wikipedia.page.side_effect = [error, SimpleNamespace(content="ok", summary="summary", url="source")]
+        retriever = ModifiedWikipediaRetriever(top_k_results=2)
+
+        with patch.object(retriever, "_get_wikipedia_client", return_value=wikipedia):
+            documents = retriever.load("query")
+
+        assert len(documents) == 1
+        assert documents[0].metadata["title"] == "Second"
+
+    @pytest.mark.asyncio
+    async def test_async_retrieval_offloads_blocking_load(self):
+        """The async retriever path executes the synchronous client in a worker thread."""
+        retriever = ModifiedWikipediaRetriever()
+
+        with patch(f"{MODULE}.to_thread", new=AsyncMock(return_value=["document"])) as mock_to_thread:
+            documents = await retriever.ainvoke("query")
+
+        assert documents == ["document"]
+        mock_to_thread.assert_awaited_once_with(retriever.load, "query")
+
+    def test_missing_dependency_has_installation_guidance(self):
+        """A missing optional dependency reports the existing installation command."""
+        retriever = ModifiedWikipediaRetriever()
+
+        with patch.dict("sys.modules", {"wikipedia": None}):
+            with pytest.raises(ImportError, match="pip install wikipedia"):
+                retriever.load("query")


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Replaces the deprecated LangChain Community `WikipediaRetriever` with a self-contained retriever that uses the `wikipedia` package directly.

The replacement preserves the existing behavior:

- Configurable Wikipedia language
- Top-k result limiting
- Per-document content truncation
- Existing document metadata (`title`, `summary`, and `source`)
- Skipping missing and disambiguation pages
- Non-blocking asynchronous retrieval

Focused unit tests were added for result formatting, query truncation, result limits, unavailable pages, asynchronous execution, and missing dependency guidance.

Fixes #1302

## Impact

Wikipedia RAG no longer depends on `langchain-community` for retrieval.

Existing configurations using `lang`, `top_k_results`, and `doc_content_chars_max` remain compatible. The `wikipedia` package remains an optional prerequisite, as already documented.

The global `langchain-community` dependency is unchanged because other tools still depend on it and are covered by separate migration issues.

## Screenshots / Logs / Examples (optional)

Focused verification commands:

```bash
pytest tests/neuro_san_studio/coded_tools/test_modified_wikipedia_retriever.py
ruff check neuro_san_studio/coded_tools/wikipedia_rag.py neuro_san_studio/coded_tools/modified_wikipedia_retriever.py tests/neuro_san_studio/coded_tools/test_modified_wikipedia_retriever.py
```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [x] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
