### PR TITLE
#1303: Replace LangChain Google Serper wrapper

### DIFF
--- a/neuro_san_studio/coded_tools/google_serper.py
+++ b/neuro_san_studio/coded_tools/google_serper.py
@@ -14,11 +14,15 @@
 #
 # END COPYRIGHT
 
+import logging
+import os
 from typing import Any
 from typing import Dict
 from typing import Union
 
-from langchain_community.utilities import GoogleSerperAPIWrapper
+from aiohttp import ClientError
+from aiohttp import ClientSession
+from aiohttp import ClientTimeout
 from neuro_san.interfaces.coded_tool import CodedTool
 
 # Default parameters for google serper
@@ -26,6 +30,11 @@ K = 10  # number of search results
 GL = "us"  # country
 HL = "en"  # langauge
 TYPE = "search"  # search type
+SERPER_API_URL = "https://google.serper.dev"
+SERPER_TIMEOUT = 30.0
+SEARCH_TYPES = {"images", "news", "places", "search"}
+
+logger = logging.getLogger(__name__)
 
 
 class GoogleSerper(CodedTool):
@@ -84,6 +93,10 @@ class GoogleSerper(CodedTool):
         if query == "":
             return "Error: No query provided."
 
+        serper_api_key = os.getenv("SERPER_API_KEY")
+        if not serper_api_key:
+            return "Error: SERPER_API_KEY is not set."
+
         # Parameters for google serper
 
         # Country code to localize search results (e.g., "us" for United States)
@@ -91,17 +104,36 @@ class GoogleSerper(CodedTool):
         # Language code for the search interface (e.g., "en" for English)
         hl: str = args.get("hl", HL)
         # Number of top search results to retrieve
-        k: int = args.get("k", K)
+        try:
+            k: int = int(args.get("k", K))
+        except (TypeError, ValueError):
+            return f"Error: 'k' must be an integer, got: {args.get('k')!r}."
         # Type of search (e.g., "news", "places", "images", or "search" for general)
         search_type: str = args.get("type", TYPE)
+        if search_type not in SEARCH_TYPES:
+            return f"Error: Unsupported search type: {search_type}."
         # Search filter string (e.g., "qdr:d" for past day results); optional and can be used for time filtering
         # Default is None.
         tbs: str = args.get("tbs")
 
-        # Create search with the above parameters
-        search = GoogleSerperAPIWrapper(gl=gl, hl=hl, k=k, type=search_type, tbs=tbs)
+        headers = {
+            "X-API-KEY": serper_api_key,
+            "Content-Type": "application/json",
+        }
+        params = {
+            "q": query,
+            "gl": gl,
+            "hl": hl,
+            "num": k,
+        }
+        if tbs is not None:
+            params["tbs"] = tbs
 
-        # Perform search asynchronously
-        results = await search.aresults(query)
-
-        return results
+        try:
+            async with ClientSession(timeout=ClientTimeout(total=SERPER_TIMEOUT)) as session:
+                async with session.post(f"{SERPER_API_URL}/{search_type}", headers=headers, params=params) as response:
+                    response.raise_for_status()
+                    return await response.json()
+        except (ClientError, TimeoutError) as error:
+            logger.error("Serper request failed: %s", error)
+            return f"Error: Serper request failed: {error}"

--- a/neuro_san_studio/toolbox/toolbox_info.hocon
+++ b/neuro_san_studio/toolbox/toolbox_info.hocon
@@ -756,7 +756,7 @@ Options are `ascending` and `descending`. Default to `descending`.
                     "description": "Type of search: 'search' (general web), 'news', 'images', or 'places'. Default: 'search'"
                 },
                 "k": {
-                    "type": "object",
+                    "type": "integer",
                     "description": "Number of search results to retrieve. Default: 10"
                 },
                 "gl": {

--- a/tests/neuro_san_studio/coded_tools/test_google_serper.py
+++ b/tests/neuro_san_studio/coded_tools/test_google_serper.py
@@ -1,0 +1,148 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from aiohttp import ClientError
+
+from neuro_san_studio.coded_tools.google_serper import GoogleSerper
+
+MODULE = "neuro_san_studio.coded_tools.google_serper"
+
+
+def _client_session(response):
+    """Create a mocked aiohttp session returning the supplied response."""
+    session = MagicMock()
+
+    @asynccontextmanager
+    async def response_context():
+        yield response
+
+    session.post.return_value = response_context()
+
+    @asynccontextmanager
+    async def session_context():
+        yield session
+
+    return session_context(), session
+
+
+def _invoke(args, response=None):
+    """Invoke GoogleSerper with a mocked HTTP response."""
+    response = response or MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = AsyncMock(return_value={"organic": [{"title": "Result"}]})
+
+    session_context, session = _client_session(response)
+    with patch.dict("os.environ", {"SERPER_API_KEY": "secret"}, clear=True):
+        with patch(f"{MODULE}.ClientSession", return_value=session_context) as client_session:
+            result = asyncio.run(GoogleSerper().async_invoke(args, {}))
+
+    return result, response, client_session, session
+
+
+class TestGoogleSerper:
+    """Behavioral tests for the direct Google Serper API client."""
+
+    def test_defaults_match_previous_wrapper_contract(self):
+        """Default arguments are translated to the Serper request parameters."""
+        result, response, client_session, session = _invoke({"query": "python"})
+
+        assert result == {"organic": [{"title": "Result"}]}
+        response.raise_for_status.assert_called_once_with()
+        client_session.assert_called_once()
+        session.post.assert_called_once_with(
+            "https://google.serper.dev/search",
+            headers={"X-API-KEY": "secret", "Content-Type": "application/json"},
+            params={"q": "python", "gl": "us", "hl": "en", "num": 10},
+        )
+
+    def test_custom_arguments_are_forwarded(self):
+        """All existing optional tool arguments remain supported."""
+        result, _, _, session = _invoke(
+            {"query": "actualités", "type": "news", "k": "5", "gl": "fr", "hl": "fr", "tbs": "qdr:d"}
+        )
+
+        assert result == {"organic": [{"title": "Result"}]}
+        session.post.assert_called_once_with(
+            "https://google.serper.dev/news",
+            headers={"X-API-KEY": "secret", "Content-Type": "application/json"},
+            params={"q": "actualités", "gl": "fr", "hl": "fr", "num": 5, "tbs": "qdr:d"},
+        )
+
+    def test_missing_query_returns_error_without_request(self):
+        """A missing query retains the existing public error response."""
+        with patch(f"{MODULE}.ClientSession") as client_session:
+            result = asyncio.run(GoogleSerper().async_invoke({}, {}))
+
+        assert result == "Error: No query provided."
+        client_session.assert_not_called()
+
+    def test_missing_api_key_returns_error_without_request(self):
+        """A missing API key is reported before opening an HTTP session."""
+        with patch.dict("os.environ", {}, clear=True):
+            with patch(f"{MODULE}.ClientSession") as client_session:
+                result = asyncio.run(GoogleSerper().async_invoke({"query": "python"}, {}))
+
+        assert result == "Error: SERPER_API_KEY is not set."
+        client_session.assert_not_called()
+
+    def test_unsupported_search_type_returns_error_without_request(self):
+        """Only search types accepted by the previous wrapper are allowed."""
+        with patch.dict("os.environ", {"SERPER_API_KEY": "secret"}, clear=True):
+            with patch(f"{MODULE}.ClientSession") as client_session:
+                result = asyncio.run(GoogleSerper().async_invoke({"query": "python", "type": "videos"}, {}))
+
+        assert result == "Error: Unsupported search type: videos."
+        client_session.assert_not_called()
+
+    @pytest.mark.parametrize("invalid_k", [None, "many"])
+    def test_invalid_result_count_returns_error_without_request(self, invalid_k):
+        """Invalid result counts follow the coded tool error contract."""
+        with patch.dict("os.environ", {"SERPER_API_KEY": "secret"}, clear=True):
+            with patch(f"{MODULE}.ClientSession") as client_session:
+                result = asyncio.run(GoogleSerper().async_invoke({"query": "python", "k": invalid_k}, {}))
+
+        assert result == f"Error: 'k' must be an integer, got: {invalid_k!r}."
+        client_session.assert_not_called()
+
+    def test_http_errors_return_error_string(self):
+        """HTTP failures follow the coded tool error contract."""
+        error = ClientError("request failed")
+        response = MagicMock()
+        response.raise_for_status.side_effect = error
+        response.json = AsyncMock()
+        session_context, _ = _client_session(response)
+
+        with patch.dict("os.environ", {"SERPER_API_KEY": "secret"}, clear=True):
+            with patch(f"{MODULE}.ClientSession", return_value=session_context):
+                result = asyncio.run(GoogleSerper().async_invoke({"query": "python"}, {}))
+
+        assert result == "Error: Serper request failed: request failed"
+        response.json.assert_not_awaited()
+
+    def test_timeout_returns_error_string(self):
+        """Request timeouts follow the coded tool error contract."""
+        with patch.dict("os.environ", {"SERPER_API_KEY": "secret"}, clear=True):
+            with patch(f"{MODULE}.ClientSession", side_effect=TimeoutError("timed out")):
+                result = asyncio.run(GoogleSerper().async_invoke({"query": "python"}, {}))
+
+        assert result == "Error: Serper request failed: timed out"


### PR DESCRIPTION
## Description

Replaces the deprecated `langchain_community.utilities.GoogleSerperAPIWrapper` with a direct asynchronous request to the Serper API using `aiohttp`.

The existing public tool arguments and raw response format are preserved. The change also adds API-key and search-type validation, a request timeout, HTTP error handling, and corrects the `k` parameter schema from `object` to `integer`.

Fixes #1303

## Impact

The Google Serper tool no longer depends on `langchain-community`.

Existing users can continue using the same `query`, `type`, `k`, `gl`, `hl`, and `tbs` arguments. `SERPER_API_KEY` remains the required environment variable.

The project-level `langchain-community` dependency remains because it is still used by another coded tool.

## Screenshots / Logs / Examples (optional)

Not applicable.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
