### PR TITLE
#1305: Replace LangChain Jira toolkit

### DIFF
--- a/neuro_san_studio/coded_tools/jira_toolkit.py
+++ b/neuro_san_studio/coded_tools/jira_toolkit.py
@@ -1,0 +1,232 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Jira and Confluence tools backed directly by atlassian-python-api."""
+
+import json
+import os
+from typing import Any
+
+from langchain_core.tools import BaseTool
+from langchain_core.tools import BaseToolkit
+from leaf_common.resolution.resolver_util import ResolverUtil
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic import model_validator
+
+CONFLUENCE_TYPE = ResolverUtil.create_type("atlassian.Confluence", raise_if_not_found=False)
+JIRA_TYPE = ResolverUtil.create_type("atlassian.Jira", raise_if_not_found=False)
+DISALLOWED_JIRA_FUNCTIONS = {"delete", "get", "post", "put", "request"}
+
+JQL_QUERY_DESCRIPTION = """
+Search for Jira issues using a JQL query string. For example:
+project = Test AND assignee = currentUser()
+"""
+GET_PROJECTS_DESCRIPTION = "Fetch all Jira projects that the authenticated user can access."
+CREATE_ISSUE_DESCRIPTION = """
+Create a Jira issue. The input is a JSON object containing the fields accepted by Jira.issue_create.
+"""
+CATCH_ALL_DESCRIPTION = """
+Call another atlassian-python-api Jira method. The input is a JSON object containing `function`, plus optional `args`
+and `kwargs`. For example: {"function": "projects"}.
+"""
+CREATE_CONFLUENCE_PAGE_DESCRIPTION = """
+Create a Confluence page. The input is a JSON object containing the arguments accepted by Confluence.create_page.
+"""
+
+
+def _parse_oauth2(value: dict[str, Any] | str | None) -> dict[str, Any] | None:
+    """Parse and validate OAuth2 configuration supplied through the environment."""
+    if not value:
+        return None
+    if isinstance(value, dict):
+        return value
+    try:
+        parsed_value = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise ValueError("JIRA_OAUTH2 must be a valid JSON object.") from error
+    if not isinstance(parsed_value, dict):
+        raise ValueError("JIRA_OAUTH2 must be a valid JSON object.")
+    return parsed_value
+
+
+class JiraAPIWrapper(BaseModel):
+    """Configure Atlassian clients and expose the operations used by the toolkit."""
+
+    jira: Any = None
+    confluence: Any = None
+    jira_username: str | None = None
+    jira_api_token: str | None = None
+    jira_oauth2: dict[str, Any] | str | None = None
+    jira_instance_url: str | None = None
+    jira_cloud: bool | str | None = None
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def configure_clients(cls, values: Any) -> Any:
+        """Load credentials and construct Jira and Confluence clients."""
+        if not isinstance(values, dict):
+            return values
+
+        values = dict(values)
+        if values.get("jira") is not None and values.get("confluence") is not None:
+            return values
+
+        username = values.get("jira_username", os.getenv("JIRA_USERNAME", ""))
+        api_token = values.get("jira_api_token", os.getenv("JIRA_API_TOKEN", ""))
+        oauth2 = values.get("jira_oauth2", os.getenv("JIRA_OAUTH2", ""))
+        instance_url = values.get("jira_instance_url", os.getenv("JIRA_INSTANCE_URL"))
+        cloud_value = values.get("jira_cloud", os.getenv("JIRA_CLOUD"))
+
+        oauth2 = _parse_oauth2(oauth2)
+
+        if api_token and oauth2:
+            raise ValueError("Provide either jira_api_token or jira_oauth2, not both.")
+        if not api_token and not oauth2:
+            raise ValueError("Set JIRA_API_TOKEN or JIRA_OAUTH2 before using jira_toolkit.")
+        if not instance_url:
+            raise ValueError("Set JIRA_INSTANCE_URL before using jira_toolkit.")
+        if cloud_value is None:
+            raise ValueError("Set JIRA_CLOUD before using jira_toolkit.")
+        cloud = cloud_value if isinstance(cloud_value, bool) else str(cloud_value).lower() == "true"
+
+        if CONFLUENCE_TYPE is None or JIRA_TYPE is None:
+            raise ImportError(
+                "Jira support requires 'atlassian-python-api'. Install it with: pip install atlassian-python-api"
+            )
+
+        common_args = {"url": instance_url, "cloud": cloud}
+        if api_token:
+            if username:
+                jira_auth_args = {"username": username, "password": api_token}
+            else:
+                jira_auth_args = {"token": api_token}
+            jira = JIRA_TYPE(**common_args, **jira_auth_args)
+            confluence = CONFLUENCE_TYPE(**common_args, **jira_auth_args)
+        else:
+            jira = JIRA_TYPE(**common_args, oauth2=oauth2)
+            confluence = CONFLUENCE_TYPE(**common_args, oauth2=oauth2)
+
+        values.update(
+            {
+                "jira": jira,
+                "confluence": confluence,
+                "jira_username": username,
+                "jira_api_token": api_token or None,
+                "jira_oauth2": oauth2 or None,
+                "jira_instance_url": instance_url,
+                "jira_cloud": cloud,
+            }
+        )
+        return values
+
+    def search(self, query: str) -> str:
+        """Search Jira and retain the established compact response format."""
+        parsed_issues = []
+        for issue in self.jira.jql(query)["issues"]:
+            fields = issue["fields"]
+            related_issues = {}
+            for related_issue in fields.get("issuelinks", []):
+                direction = "inwardIssue" if "inwardIssue" in related_issue else "outwardIssue"
+                if direction not in related_issue:
+                    continue
+                linked_issue = related_issue[direction]
+                related_issues = {
+                    "type": related_issue["type"]["inward" if direction == "inwardIssue" else "outward"],
+                    "key": linked_issue["key"],
+                    "summary": linked_issue["fields"]["summary"],
+                }
+            assignee = fields.get("assignee") or {}
+            parsed_issues.append(
+                {
+                    "key": issue["key"],
+                    "summary": fields["summary"],
+                    "created": fields["created"][:10],
+                    "assignee": assignee.get("displayName", "None"),
+                    "priority": (fields.get("priority") or {}).get("name"),
+                    "status": fields["status"]["name"],
+                    "related_issues": related_issues,
+                }
+            )
+        return f"Found {len(parsed_issues)} issues:\n{parsed_issues}"
+
+    def project(self) -> str:
+        """List Jira projects and retain the established compact response format."""
+        parsed_projects = [
+            {
+                "id": project["id"],
+                "key": project["key"],
+                "name": project["name"],
+                "type": project.get("projectTypeKey"),
+                "style": project.get("style"),
+            }
+            for project in self.jira.projects()
+        ]
+        return f"Found {len(parsed_projects)} projects:\n{parsed_projects}"
+
+    def run(self, mode: str, instructions: str) -> Any:
+        """Run one operation selected by a toolkit action."""
+        if mode == "jql":
+            return self.search(instructions)
+        if mode == "get_projects":
+            return self.project()
+
+        params = json.loads(instructions)
+        if mode == "create_issue":
+            return self.jira.issue_create(fields=dict(params))
+        if mode == "create_page":
+            return self.confluence.create_page(**dict(params))
+        if mode == "other":
+            function_name = params["function"]
+            if function_name.startswith("_") or function_name in DISALLOWED_JIRA_FUNCTIONS:
+                raise ValueError(f"Jira function not allowed: {function_name}")
+            jira_function = getattr(self.jira, function_name)
+            return jira_function(*params.get("args", []), **params.get("kwargs", {}))
+        raise ValueError(f"Unexpected Jira operation mode: {mode}")
+
+
+class JiraAction(BaseTool):
+    """One named operation exposed by JiraToolkit."""
+
+    api_wrapper: JiraAPIWrapper = Field(default_factory=JiraAPIWrapper)
+    mode: str
+
+    def _run(self, instructions: str) -> Any:  # pylint: disable=arguments-differ
+        """Delegate an invocation to the shared API wrapper."""
+        return self.api_wrapper.run(self.mode, instructions)
+
+
+class JiraToolkit(BaseToolkit):
+    """Build the agent-facing Jira tools from a shared Atlassian client."""
+
+    jira_api_wrapper: JiraAPIWrapper = Field(default_factory=JiraAPIWrapper)
+
+    def get_tools(self) -> list[BaseTool]:
+        """Return tools with names and arguments compatible with the previous toolkit."""
+        operations = (
+            ("jql_query", "jql", JQL_QUERY_DESCRIPTION),
+            ("get_projects", "get_projects", GET_PROJECTS_DESCRIPTION),
+            ("create_issue", "create_issue", CREATE_ISSUE_DESCRIPTION),
+            ("catch_all_jira_api", "other", CATCH_ALL_DESCRIPTION),
+            ("create_confluence_page", "create_page", CREATE_CONFLUENCE_PAGE_DESCRIPTION),
+        )
+        return [
+            JiraAction(name=name, description=description, mode=mode, api_wrapper=self.jira_api_wrapper)
+            for name, mode, description in operations
+        ]

--- a/neuro_san_studio/toolbox/toolbox_info.hocon
+++ b/neuro_san_studio/toolbox/toolbox_info.hocon
@@ -209,8 +209,8 @@
     # Requirements to use this tool:
     # pip install atlassian-python-api
     # Set up the following environment variable:
-    # JIRA_API_TOKEN (string), JIRA_USERNAME (string), JIRA_INSTANCE_URL (string), and JIRA_CLOUDb (boolean)
-    # See https://python.langchain.com/docs/integrations/tools/jira/
+    # JIRA_API_TOKEN (string), JIRA_USERNAME (string), JIRA_INSTANCE_URL (string), and JIRA_CLOUD (boolean)
+    # OAuth2 authentication can instead be supplied with JIRA_OAUTH2 as a JSON object.
 
     # This is a toolkit that contains the following tools for interacting with Jira.
     #
@@ -253,15 +253,15 @@
     # title","body":"This is the body. You can use <strong>HTML tags</strong>!"}} 
 
     "jira_toolkit": {
-        "class": "langchain_community.agent_toolkits.jira.toolkit.JiraToolkit",
+        "class": "neuro_san_studio.coded_tools.jira_toolkit.JiraToolkit",
         "args": {
             "jira_api_wrapper": {
-                "class": "langchain_community.utilities.jira.JiraAPIWrapper"
+                "class": "neuro_san_studio.coded_tools.jira_toolkit.JiraAPIWrapper"
             }
         },
 
         # This is where more info on the tool can be found.
-        "base_tool_info_url": "https://python.langchain.com/docs/integrations/tools/jira/",
+        "base_tool_info_url": "https://atlassian-python-api.readthedocs.io/jira.html",
 
     },
 

--- a/tests/neuro_san_studio/coded_tools/test_jira_toolkit.py
+++ b/tests/neuro_san_studio/coded_tools/test_jira_toolkit.py
@@ -1,0 +1,161 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for the project-owned Jira toolkit."""
+
+import json
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from neuro_san_studio.coded_tools.jira_toolkit import JiraAPIWrapper
+from neuro_san_studio.coded_tools.jira_toolkit import JiraToolkit
+
+BASE_URL = "https://jira.example.com"
+
+
+def _wrapper() -> JiraAPIWrapper:
+    """Create a wrapper around mocked, already-configured clients."""
+    return JiraAPIWrapper(jira=MagicMock(), confluence=MagicMock())
+
+
+def test_tool_names_and_argument_schema_match_previous_contract():
+    """Agent networks keep seeing the same five tools with an instructions argument."""
+    tools = JiraToolkit(jira_api_wrapper=_wrapper()).get_tools()
+
+    assert [tool.name for tool in tools] == [
+        "jql_query",
+        "get_projects",
+        "create_issue",
+        "catch_all_jira_api",
+        "create_confluence_page",
+    ]
+    assert all("instructions" in tool.args for tool in tools)
+
+
+def test_jql_query_retains_compact_issue_shape():
+    """JQL results retain the response fields exposed by the previous wrapper."""
+    wrapper = _wrapper()
+    wrapper.jira.jql.return_value = {
+        "issues": [
+            {
+                "key": "TEST-1",
+                "fields": {
+                    "summary": "Example",
+                    "created": "2026-08-15T10:00:00Z",
+                    "assignee": None,
+                    "priority": {"name": "Low"},
+                    "status": {"name": "Open"},
+                    "issuelinks": [],
+                },
+            }
+        ]
+    }
+
+    result = wrapper.run("jql", "project = TEST")
+
+    assert result == (
+        "Found 1 issues:\n[{'key': 'TEST-1', 'summary': 'Example', 'created': '2026-08-15', "
+        "'assignee': 'None', 'priority': 'Low', 'status': 'Open', 'related_issues': {}}]"
+    )
+    wrapper.jira.jql.assert_called_once_with("project = TEST")
+
+
+def test_create_and_catch_all_operations_forward_json_arguments():
+    """Write and catch-all tools preserve their JSON-string input contract."""
+    wrapper = _wrapper()
+    wrapper.jira.issue_create.return_value = {"key": "TEST-1"}
+    wrapper.jira.projects.return_value = [{"key": "TEST"}]
+
+    issue = wrapper.run("create_issue", json.dumps({"summary": "Example"}))
+    projects = wrapper.run("other", json.dumps({"function": "projects"}))
+
+    assert issue == {"key": "TEST-1"}
+    assert projects == [{"key": "TEST"}]
+    wrapper.jira.issue_create.assert_called_once_with(fields={"summary": "Example"})
+    wrapper.jira.projects.assert_called_once_with()
+
+
+@pytest.mark.parametrize("function_name", ["_session", "__class__", "request", "get", "post", "put", "delete"])
+def test_catch_all_rejects_private_and_raw_http_methods(function_name):
+    """Agent-controlled function names cannot access internals or raw HTTP methods."""
+    wrapper = _wrapper()
+
+    with pytest.raises(ValueError, match=f"Jira function not allowed: {function_name}"):
+        wrapper.run("other", json.dumps({"function": function_name}))
+
+
+def test_create_confluence_page_forwards_json_arguments():
+    """The Confluence action continues sharing the Jira toolkit credentials."""
+    wrapper = _wrapper()
+    wrapper.confluence.create_page.return_value = {"id": "42"}
+
+    result = wrapper.run("create_page", json.dumps({"space": "DEMO", "title": "Page", "body": "Body"}))
+
+    assert result == {"id": "42"}
+    wrapper.confluence.create_page.assert_called_once_with(space="DEMO", title="Page", body="Body")
+
+
+def test_missing_credentials_are_reported_before_importing_optional_dependency(monkeypatch):
+    """Misconfiguration produces a focused message without an unbound-client failure."""
+    for variable in ("JIRA_USERNAME", "JIRA_API_TOKEN", "JIRA_OAUTH2", "JIRA_INSTANCE_URL", "JIRA_CLOUD"):
+        monkeypatch.delenv(variable, raising=False)
+
+    with pytest.raises(ValueError, match="Set JIRA_API_TOKEN or JIRA_OAUTH2"):
+        JiraAPIWrapper()
+
+
+def test_missing_cloud_configuration_is_reported(monkeypatch):
+    """A missing JIRA_CLOUD value cannot silently select server authentication."""
+    monkeypatch.setenv("JIRA_API_TOKEN", "secret")
+    monkeypatch.setenv("JIRA_INSTANCE_URL", BASE_URL)
+    monkeypatch.delenv("JIRA_CLOUD", raising=False)
+
+    with pytest.raises(ValueError, match="Set JIRA_CLOUD"):
+        JiraAPIWrapper()
+
+
+@pytest.mark.parametrize("oauth2", ["not-json", "[]"])
+def test_invalid_oauth2_configuration_has_clear_error(monkeypatch, oauth2):
+    """Malformed or non-object OAuth2 configuration returns an instructive error."""
+    monkeypatch.setenv("JIRA_OAUTH2", oauth2)
+    monkeypatch.setenv("JIRA_INSTANCE_URL", BASE_URL)
+    monkeypatch.setenv("JIRA_CLOUD", "true")
+    monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="JIRA_OAUTH2 must be a valid JSON object"):
+        JiraAPIWrapper()
+
+
+def test_token_only_authentication_is_shared_by_jira_and_confluence(monkeypatch):
+    """PAT authentication uses the token argument for both Atlassian clients."""
+    monkeypatch.setenv("JIRA_API_TOKEN", "secret")
+    monkeypatch.setenv("JIRA_INSTANCE_URL", BASE_URL)
+    monkeypatch.setenv("JIRA_CLOUD", "false")
+    monkeypatch.delenv("JIRA_USERNAME", raising=False)
+    jira_type = MagicMock()
+    confluence_type = MagicMock()
+
+    with (
+        patch("neuro_san_studio.coded_tools.jira_toolkit.JIRA_TYPE", jira_type),
+        patch("neuro_san_studio.coded_tools.jira_toolkit.CONFLUENCE_TYPE", confluence_type),
+    ):
+        JiraAPIWrapper()
+
+    expected_args = {"url": BASE_URL, "cloud": False, "token": "secret"}
+    jira_type.assert_called_once_with(**expected_args)
+    confluence_type.assert_called_once_with(**expected_args)


### PR DESCRIPTION
## Description

Replaces the LangChain Community Jira toolkit and API wrapper with a project-owned implementation backed directly by `atlassian-python-api`.

The existing agent-facing contract remains compatible, including the following tool names and their `instructions` argument:

- `jql_query`
- `get_projects`
- `create_issue`
- `catch_all_jira_api`
- `create_confluence_page`

The toolbox configuration now references the project-owned classes and links directly to the Atlassian Python API documentation. The Jira environment-variable documentation was also corrected and clarified.

Fixes #1305

## Impact

Jira and Confluence operations provided through `jira_toolkit` no longer depend on `langchain-community`.

Existing agent networks using the toolkit should continue working without configuration changes. Both API-token and OAuth2 authentication remain supported.

## Screenshots / Logs / Examples (optional)

Not applicable.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [x] Added/updated tests
- [x] Updated relevant documentation
- [x] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
