### PR TITLE
Document AGENT_TOOL_PATH_ONLY in the sample Dockerfiles, off for now

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -417,11 +417,11 @@ ENV LEAF_LOG_SENSITIVE="false"
 # imported -- so an agent network hocon file cannot trigger import-time execution
 # of an arbitrary installed module through a CodedTool class reference.  See
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#class
-# Left off for now ("" resolves to false): some agent networks in this repo still
+# Left off for now: some agent networks in this repo still
 # use fully-qualified CodedTool class references, which the restriction refuses.
 # We will change this to "true" once this repo's class references are cleaned up
 # to the "<module>.<ClassName>" form relative to AGENT_TOOL_PATH.
-ENV AGENT_TOOL_PATH_ONLY=""
+ENV AGENT_TOOL_PATH_ONLY="false"
 
 #
 # Authorization

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -410,6 +410,19 @@ ENV AGENT_SESSION_REQUIRE_HTTPS="true"
 # Strongly consider keeping this off for production deployments.
 ENV LEAF_LOG_SENSITIVE="false"
 
+# When set to "true" (default "false"), CodedTool "class" references -- including
+# shared coded tools referenced through the toolbox -- resolve ONLY from within
+# the AGENT_TOOL_PATH hierarchy (see AGENT_TOOL_PATH above).  Fully-qualified
+# references to modules elsewhere on the PYTHONPATH are not resolved -- not even
+# imported -- so an agent network hocon file cannot trigger import-time execution
+# of an arbitrary installed module through a CodedTool class reference.  See
+# https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#class
+# Left off for now ("" resolves to false): some agent networks in this repo still
+# use fully-qualified CodedTool class references, which the restriction refuses.
+# We will change this to "true" once this repo's class references are cleaned up
+# to the "<module>.<ClassName>" form relative to AGENT_TOOL_PATH.
+ENV AGENT_TOOL_PATH_ONLY=""
+
 #
 # Authorization
 #

--- a/deploy/Dockerfile.py314t
+++ b/deploy/Dockerfile.py314t
@@ -576,11 +576,11 @@ ENV LEAF_LOG_SENSITIVE="false"
 # imported -- so an agent network hocon file cannot trigger import-time execution
 # of an arbitrary installed module through a CodedTool class reference.  See
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#class
-# Left off for now ("" resolves to false): some agent networks in this repo still
+# Left off for now: some agent networks in this repo still
 # use fully-qualified CodedTool class references, which the restriction refuses.
 # We will change this to "true" once this repo's class references are cleaned up
 # to the "<module>.<ClassName>" form relative to AGENT_TOOL_PATH.
-ENV AGENT_TOOL_PATH_ONLY=""
+ENV AGENT_TOOL_PATH_ONLY="false"
 
 #
 # Authorization

--- a/deploy/Dockerfile.py314t
+++ b/deploy/Dockerfile.py314t
@@ -569,6 +569,19 @@ ENV AGENT_SESSION_REQUIRE_HTTPS="true"
 # Strongly consider keeping this off for production deployments.
 ENV LEAF_LOG_SENSITIVE="false"
 
+# When set to "true" (default "false"), CodedTool "class" references -- including
+# shared coded tools referenced through the toolbox -- resolve ONLY from within
+# the AGENT_TOOL_PATH hierarchy (see AGENT_TOOL_PATH above).  Fully-qualified
+# references to modules elsewhere on the PYTHONPATH are not resolved -- not even
+# imported -- so an agent network hocon file cannot trigger import-time execution
+# of an arbitrary installed module through a CodedTool class reference.  See
+# https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#class
+# Left off for now ("" resolves to false): some agent networks in this repo still
+# use fully-qualified CodedTool class references, which the restriction refuses.
+# We will change this to "true" once this repo's class references are cleaned up
+# to the "<module>.<ClassName>" form relative to AGENT_TOOL_PATH.
+ENV AGENT_TOOL_PATH_ONLY=""
+
 #
 # Authorization
 #


### PR DESCRIPTION
## Description

neuro-san 0.6.94 (already the pinned version here) added the `AGENT_TOOL_PATH_ONLY` server hardening flag: when enabled, CodedTool `class` references — including shared coded tools from the toolbox — resolve only from within the `AGENT_TOOL_PATH` hierarchy, and fully-qualified references to modules elsewhere on the `PYTHONPATH` are never imported at all. This PR documents the flag in both sample Dockerfiles' Server Hardening sections, mirroring the wording in the neuro-san repo's Dockerfiles (cognizant-ai-lab/neuro-san#1251).

It is deliberately set **off** (`""`, which resolves to false — same as the library default): several agent networks in this repo still use fully-qualified CodedTool class references (e.g. `coded_tools.agent_network_editor.*`), which the restriction refuses. The comment states that we will flip it to `"true"` once those references are migrated to the `<module>.<ClassName>` form relative to `AGENT_TOOL_PATH`.

## Impact

No behavior change: the flag is explicitly off, identical to it being unset. The Dockerfiles now document the hardening option and the migration path toward enabling it, matching the neuro-san sample Dockerfiles where it ships enabled.

## Screenshots / Logs / Examples (optional)

Verified the off-spelling against leaf-common's `ConfigUtil.get_bool` (what neuro-san uses to read the flag):

```
'' -> False, 'false' -> False, '0' -> False, 'true' -> True
```

Registry survey: 15 registry files currently use multi-segment class references; the `coded_tools.*`-prefixed ones depend on fully-qualified import and are the cleanup targets before the flag can be enabled.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**