### PR TITLE
Use reusable PyPI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish to PyPI
 
 permissions:
     contents: read
+    id-token: write
 
 on:
   release:
@@ -12,37 +13,11 @@ jobs:
     name: Build and Publish
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san-studio'
-    runs-on: ubuntu-latest
-    environment: pypi  # Match this to your configured GitHub Environment.
-    permissions:
-      id-token: write  # Mandatory for PyPI Trusted Publishing
-      contents: read   # Required for actions/checkout
-
-    steps:
-      # v6.0.2
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Setup Python environment
-        # 1.0.9
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@b14b3de23cb9aca02b2165e57542335e0c8f5304
-        with:
-          python-version: '3.10'
-          requirements-file: ''
-          requirements-build-file: ''
-          install-extras: 'build'
-
-      - name: Build wheel and sdist
-        run: python -m build
-
-      # v1.14.0
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-
-      - name: Notify Slack
-        if: ${{ !cancelled() }}
-        # 1.0.9
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@b14b3de23cb9aca02b2165e57542335e0c8f5304
-        with:
-          status: ${{ job.status }}
-          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    # build-common 1.0.9
+    uses: cognizant-ai-lab/build-common/.github/workflows/_publish-pypi.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+    with:
+      python-version: '3.10'
+      enable-slack: true
+      build-common-ref: b14b3de23cb9aca02b2165e57542335e0c8f5304
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description
Replace the duplicated release publishing steps with build-common 1.0.9's pinned `_publish-pypi.yml` reusable workflow. The caller explicitly pins the nested build-common checkout to the same immutable 1.0.9 SHA.

## Impact
Package releases continue to build with Python 3.10, publish through PyPI trusted publishing, and send Slack notifications while keeping the existing repository guard.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

Link to Devin session: https://app.devin.ai/sessions/f5f966f41bb8464bbde2ae5144dd9d48
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/1342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->