### PR TITLE
Fix links to neuro-san's authorizer interfaces

### DIFF
--- a/neuro_san_studio/plugins/openfga/README.md
+++ b/neuro_san_studio/plugins/openfga/README.md
@@ -5,7 +5,7 @@ controlling authorization access for agents.
 
 ## Clarifications
 
-### Authentation != Authorization
+### Authentication != Authorization
 
 Note that _authorization_ - the ability to determine permission to access a resource (in
 Neuro SAN's case an agent network) - is not to be confused with _authentication_ -
@@ -166,7 +166,7 @@ Available agents:
 
 ## Extra Credit
 
-For any of the below extra credit exercizes, you will need the fga command line tool.
+For any of the below extra credit exercises, you will need the fga command line tool.
 
 To install the fga command line tool use the script below if you are running on linux.
 
@@ -256,10 +256,10 @@ are defined correctly.  We have included one test with this example. To run it:
 - [The Neuro SAN Dockerfile](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/deploy/Dockerfile)
   has the documentation for each of the environment variables mentioned above.
 
-- [The Neuro SAN Authorizer interface](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/authorization/interfaces/authorizer.py)
+- [The Neuro SAN Authorizer interface](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/service/authorization/interfaces/authorizer.py)
   contains documentation and examples for each of the methods of the Authorizer interface
 
-- [The OpenFGA implementation of the Authorizer interface](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/authorization/openfga/open_fga_authorizer.py)
+- [The OpenFGA implementation of the Authorizer interface](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/service/authorization/openfga/open_fga_authorizer.py)
   Seeing the details of the OpenFGA implementation can give you some ideas as to how to extend it for your own purposes.
   It's worth noting that we have used an extended version of the OpenFGA Authorizer and supplied schema
   to allow for many other objects under authorization control, including special users, and storing information


### PR DESCRIPTION
<!-- Suggested template for pull requests. -->
<!-- Feel free to remove sections that are not relevant / write your own -->

## Description

Fixes these 2 broken links:
```
[./neuro_san_studio/plugins/openfga/README.md]:
[404] https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/authorization/interfaces/authorizer.py (at 259:3) | Error (cached)
[404] https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/authorization/openfga/open_fga_authorizer.py (at 262:3) | Error (cached)
```

## Impact

Fixes CI pipelines

## Screenshots / Logs / Examples (optional)

<!-- Add screenshots, screen recordings, logs or examples if relevant -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [X] Documentation
- [ ] New agent / tool

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

<!-- For new coded tools/agent networks, ensure proper documentation and examples are included -->

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
