### PR TITLE
Fix FileMetadata import broken by anthropic 0.124 rename

### DIFF
--- a/neuro_san_studio/coded_tools/anthropic_code_execution.py
+++ b/neuro_san_studio/coded_tools/anthropic_code_execution.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from anthropic import Anthropic
 from anthropic._response import BinaryAPIResponse
-from anthropic.types.beta.file_metadata import FileMetadata
+from anthropic.types.beta import BetaFileMetadata
 from neuro_san.interfaces.coded_tool import CodedTool
 
 from neuro_san_studio.coded_tools.anthropic_tool import AnthropicTool
@@ -134,7 +134,7 @@ class AnthropicCodeExecution(CodedTool):
 
         for file_id in file_ids:
             # Get the file name e.g. output.png
-            file_metadata: FileMetadata = client.beta.files.retrieve_metadata(file_id)
+            file_metadata: BetaFileMetadata = client.beta.files.retrieve_metadata(file_id)
             filename: str = file_metadata.filename
 
             # Download from Anthropic container and save the file on disk

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,14 @@ langchain-openai>=1.1.9,<2.0
 langchain-anthropic>=1.4.3,<2.0
 langchain-google-genai>=4.2.2,<5.0
 
+# The Anthropic SDK is also imported directly (anthropic_code_execution,
+# anthropic_tool, check_llm_keys), so it needs its own floor: 0.124.0 renamed
+# the beta Files API type FileMetadata to BetaFileMetadata with no compat
+# alias, and no langchain-anthropic release guarantees a version that new
+# (even 1.6.0 only requires anthropic>=0.120), so bumping langchain-anthropic
+# cannot express this constraint.
+anthropic>=0.124.0,<1.0
+
 langchain-community>=0.4.2
 
 # For rich logging


### PR DESCRIPTION
## Problem

CI (`make lint-check-source`) fails on every branch with:

```
neuro_san_studio/coded_tools/anthropic_code_execution.py:25:0: E0401: Unable to import 'anthropic.types.beta.file_metadata' (import-error)
```

anthropic 0.124.0 renamed the beta Files API type `anthropic.types.beta.file_metadata.FileMetadata` to `anthropic.types.beta.BetaFileMetadata` with no compatibility alias (verified by inspecting the 0.117–0.125 wheels; the rename landed exactly in 0.124.0). The `anthropic` package is not pinned anywhere — it arrives transitively via `langchain-anthropic`, so CI resolves the latest (0.125.0) and the import breaks. Pushes to main skip the Test workflow, which is why main looks green.

## Fix

- Update the import and type annotation in `anthropic_code_execution.py` to `BetaFileMetadata`. The `client.beta.files.retrieve_metadata()` / `.download()` calls are unchanged in 0.124+, and all other direct anthropic imports in the repo (`Anthropic`, `AnthropicError`, `BinaryAPIResponse`, the error types in `check_llm_keys`) still exist in 0.125.
- Declare `anthropic>=0.124.0,<1.0` as a direct dependency in `requirements.txt`. Bumping the `langchain-anthropic` floor cannot express this constraint: even 1.6.0 only requires `anthropic>=0.120.0`, which still admits versions without the new name. Since the SDK is imported directly by several modules, a direct floor is the correct place for it. `langchain-anthropic>=1.4.3,<2.0` stays as is — 1.4.3 already accepts anthropic up to <1.0.0, so the pins compose.

## Verification

- New import verified at runtime against a clean anthropic 0.124.0 install.
- ruff format/check pass; pylint 10.00/10 on the edited file.
- No unit test imports this module (only the registry hocons reference it), so the test suite is unaffected.

Note for local environments: any env still on anthropic <0.124 needs `pip install -U 'anthropic>=0.124'` to run the code-execution tool after this lands.