### PR TITLE
Bump build-common pins to 1.0.11

### DIFF
--- a/.github/workflows/agent_network_designer.yml
+++ b/.github/workflows/agent_network_designer.yml
@@ -15,6 +15,8 @@ jobs:
     # cognizant-ai-lab/build-common 1.0.11
     uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
+      # 1.0.11
+      build-common-ref: 'a70df67b0d623e56f34159de26c38989cd315d26'
       python-version: '3.13'
       # Required by build_scripts/server_start.sh:
       #   netcat-openbsd (nc, port readiness polling)

--- a/.github/workflows/agent_network_designer.yml
+++ b/.github/workflows/agent_network_designer.yml
@@ -12,8 +12,8 @@ jobs:
   agent-network-designer-test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san-studio'
-    # cognizant-ai-lab/build-common 1.0.9
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+    # cognizant-ai-lab/build-common 1.0.11
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
       python-version: '3.13'
       # Required by build_scripts/server_start.sh:

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -22,8 +22,8 @@ jobs:
                   fetch-depth: 0
 
             - name: Run Checkmarx One scan
-              # build-common 1.0.9
-              uses: cognizant-ai-lab/build-common/actions/checkmarx-one@b14b3de23cb9aca02b2165e57542335e0c8f5304
+              # build-common 1.0.11
+              uses: cognizant-ai-lab/build-common/actions/checkmarx-one@a70df67b0d623e56f34159de26c38989cd315d26
               with:
                   base-uri: ${{ vars.CX_BASE_URI }}
                   cx-tenant: ${{ vars.CX_TENANT }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,8 @@ jobs:
     # cognizant-ai-lab/build-common 1.0.11
     uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
+      # 1.0.11
+      build-common-ref: 'a70df67b0d623e56f34159de26c38989cd315d26'
       python-version: '3.13'
       # No lint steps in the original workflow
       lint-command-override: 'true'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   test:
-    # cognizant-ai-lab/build-common 1.0.9
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+    # cognizant-ai-lab/build-common 1.0.11
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
       python-version: '3.13'
       # No lint steps in the original workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python environment
-        # 1.0.9
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@b14b3de23cb9aca02b2165e57542335e0c8f5304
+        # 1.0.11
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@a70df67b0d623e56f34159de26c38989cd315d26
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -41,8 +41,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.9
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@b14b3de23cb9aca02b2165e57542335e0c8f5304
+        # 1.0.11
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@a70df67b0d623e56f34159de26c38989cd315d26
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    # 1.0.9
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+    # 1.0.11
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
       python-version: '3.13'
       run-hadolint: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,8 @@ jobs:
     # 1.0.11
     uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
+      # 1.0.11
+      build-common-ref: 'a70df67b0d623e56f34159de26c38989cd315d26'
       python-version: '3.13'
       run-hadolint: true
       dockerfile-path: 'deploy/Dockerfile'


### PR DESCRIPTION
## Description

Refreshes the build-common pins in this repo's workflows from 1.0.9 (`b14b3de`) to the current 1.0.11 release (`a70df67`), version comments included.

Between 1.0.9 and 1.0.11 build-common only removed the two PyPI publish paths that could never work — the `publish-pypi` composite action (it nested `pypa/gh-action-pypi-publish`, a Docker action, which then misresolved its own image) and `_publish-pypi.yml` (a reusable workflow cannot satisfy PyPI Trusted Publishing) — and added the build-only `build-python-dists` action.

## Impact

None of the actions or reusable workflows referenced here (`setup-python-env`, `slack-notify`, `checkmarx-one`, `_python-quality-gate.yml`) changed between the two releases, so this is a pin refresh with no behavior change.

## Type of Change

- [x] Dependency upgrade


Link to Devin session: https://app.devin.ai/sessions/cf4d3ef8da8e4832adc46de3309a54d2
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/1352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->