### PR TITLE
Add middleware_manager subnetwork and designer middleware infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,15 @@ AGENT_NETWORK_DESIGNER_MCP_TOOLS_FETCH_TIMEOUT_SECONDS="30"
 # validation errors (e.g., a required tool was unavailable during session setup).
 # Defaults to "3" if not set.
 AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS="3"
+#
+# Path to the HOCON catalog of middleware classes that the middleware_manager subnetwork
+# is allowed to attach to agents. Each entry pairs a friendly key with the fully qualified
+# class name and an arg schema. Read by MiddlewareInfoMiddleware. Override only when
+# serving a custom middleware allow-list.
+# Defaults to "middleware/agent_network_designer/middleware_info.hocon" relative to the
+# working directory if not set, falling back to the copy installed beside the middleware
+# module (so scaffolded projects and installed wheels work without setting this).
+AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE="middleware/agent_network_designer/middleware_info.hocon"
 
 # Intranet Agents With Tools environment variables
 # For HCM API documentation refer to https://docs.oracle.com/en/cloud/saas/human-resources/25b/farws/index.html

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -24,7 +24,7 @@ https://mcp/
 https://admin.mistral.ai/
 
 # URLs whose base path is not browsable (returns 400 or 404)
-https://raw.githubusercontent.com/anthropics/skills/main/skills/internal-comms/
+https://raw.githubusercontent.com/anthropics/skills/main/skills/
 https://api.anthropic.com/
 https://api.smith.langchain.com/
 https://api.salesforce.com

--- a/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
+++ b/coded_tools/agent_network_editor/connectivity_dictionary_converter.py
@@ -26,6 +26,7 @@ from neuro_san.internals.run_context.factory.master_toolbox_factory import Maste
 from neuro_san.internals.run_context.interfaces.agent_network_inspector import AgentNetworkInspector
 from neuro_san.internals.validation.network.url_network_validator import UrlNetworkValidator
 
+from coded_tools.agent_network_editor.constants import MIDDLEWARE_KEY
 from coded_tools.agent_network_editor.designer_network_inspector import DesignerNetworkInspector
 from coded_tools.agent_network_editor.shared_process_cache import SharedProcessCache
 
@@ -99,7 +100,7 @@ class ConnectivityDictionaryConverter(DictionaryConverter):
         """
         self.include_keys = include_keys
         if include_keys is None:
-            self.include_keys = ["tools", "instructions", "description"]
+            self.include_keys = ["tools", "instructions", "description", MIDDLEWARE_KEY]
         self.toolbox_factory: ContextTypeToolboxFactory | None = toolbox_factory
 
     @classmethod

--- a/coded_tools/agent_network_editor/constants.py
+++ b/coded_tools/agent_network_editor/constants.py
@@ -14,7 +14,8 @@
 #
 # END COPYRIGHT
 
-# Common sly_data dictionary key constants used by the agent network designer.
+# Common dictionary key constants used by the agent network designer.
+# Most are sly_data keys; each comment says what dictionary the key lives in.
 
 # Agent network structure — dict mapping agent name to its definition (instructions, description, tools),
 # or the connectivity-list form used by the native Neuro-San representation.
@@ -33,3 +34,10 @@ PROGRESS_HANDLER: str = "progress_handler"
 # Defined here because SlyDataLock creates a fresh lock for any unknown name —
 # a typo'd literal would silently hand out a second, independent lock.
 PROGRESS_HANDLER_LOCK: str = "progress_handler_lock"
+
+# Key within a single agent's definition (not sly_data) holding the list of
+# middleware dicts attached to that agent. One name shared by everything that
+# touches the field — the middleware_manager tools, the definition middleware
+# that preserves it across load round-trips, and both assemblers that write it
+# back out — so the field's readers and writers cannot drift apart.
+MIDDLEWARE_KEY: str = "middleware"

--- a/coded_tools/agent_network_editor/get_mcp_tool.py
+++ b/coded_tools/agent_network_editor/get_mcp_tool.py
@@ -56,6 +56,12 @@ DEFAULT_MCP_TOOLS_TTL_SECONDS: float = 300.0
 
 logger = AndLogger(logging.getLogger(__name__))
 
+# If this tool is ever recast as a designer middleware, see the module
+# docstring of middleware/agent_network_designer/hocon_catalog_cache.py for
+# which pieces of its load/cache discipline are reusable here and which
+# policies below (McpServersInfoRestorer, missing-file-as-authoritative-empty,
+# TTL-bucketed fingerprint, the per-conversation sly_data fetch path) differ.
+
 
 class GetMcpTool(CodedTool):
     """

--- a/coded_tools/agent_network_editor/get_subnetwork.py
+++ b/coded_tools/agent_network_editor/get_subnetwork.py
@@ -37,6 +37,12 @@ DEFAULT_MANIFEST_FILE = os.path.join("registries", "manifest_and.hocon")
 
 logger = AndLogger(logging.getLogger(__name__))
 
+# If this tool is ever recast as a designer middleware, see the module
+# docstring of middleware/agent_network_designer/hocon_catalog_cache.py for
+# which pieces of its load/cache discipline are reusable here and which
+# policies below (manifest filter chain, published empties, time-bucket
+# fingerprint, the run_context-bound description fan-out) differ.
+
 
 # pylint: disable=too-many-ancestors
 class GetSubnetwork(BranchActivation, CodedTool):

--- a/coded_tools/agent_network_editor/get_toolbox.py
+++ b/coded_tools/agent_network_editor/get_toolbox.py
@@ -27,6 +27,11 @@ from coded_tools.agent_network_editor.shared_process_cache import SharedProcessC
 DEFAULT_TOOLBOX_INFO_FILE = os.path.join("neuro_san_studio", "toolbox", "agent_network_designer_toolbox_info.hocon")
 logger = AndLogger(logging.getLogger(__name__))
 
+# If this tool is ever recast as a designer middleware, see the module
+# docstring of middleware/agent_network_designer/hocon_catalog_cache.py for
+# which pieces of its load/cache discipline are reusable here and which
+# policies below (restorer, empty-means-failure, immortal cache) differ.
+
 
 class GetToolbox(CodedTool):
     """

--- a/coded_tools/agent_network_editor/globals.py
+++ b/coded_tools/agent_network_editor/globals.py
@@ -138,6 +138,17 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
     #             publishing, so recovery stays possible.
     #    Used by: GetMcpTool.async_invoke() (the coded tool the editor LLM
     #             calls).
+    #
+    # 7. Shared middleware info catalog
+    #    Holds:   the middleware allow-list catalog parsed from
+    #             AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE (default
+    #             middleware/agent_network_designer/middleware_info.hocon).
+    #    Lives:   middleware_info_middleware.MiddlewareInfoMiddleware
+    #    Expiry:  catalog path/size/modification_time change — no time bucket,
+    #             since nothing writes the file at runtime (a missing or
+    #             broken file is retried, never cached).
+    #    Used by: MiddlewareInfoMiddleware.awrap_model_call() (system-prompt
+    #             injection for the middleware_manager subnetwork).
     # -----------------------------------------------------------------------
 
     # Machine-readable registry of the entries above, as
@@ -173,6 +184,11 @@ class ProcessGlobals:  # pylint: disable=too-few-public-methods
             "coded_tools.agent_network_editor.get_mcp_tool",
             "GetMcpTool",
             "clear_shared_mcp_tool_descriptions_for_testing",
+        ),
+        (
+            "middleware.agent_network_designer.middleware_info_middleware",
+            "MiddlewareInfoMiddleware",
+            "clear_shared_info_for_testing",
         ),
     ]
 

--- a/coded_tools/agent_network_editor/shared_process_cache.py
+++ b/coded_tools/agent_network_editor/shared_process_cache.py
@@ -149,6 +149,32 @@ class SharedProcessCache(Generic[CachedValue]):
             return None
 
     @staticmethod
+    def stat_size_and_modification_time_ns(path: str) -> tuple[int, int] | None:
+        """
+        Fingerprint building block: a file's (st_size, st_mtime_ns) pair.
+
+        Folding the size in alongside the modification time closes the
+        coarse-clock hole a bare mtime probe leaves open: on filesystems whose
+        clock ticks in milliseconds (Linux) or seconds (some NFS), a
+        truncate-then-write can land both writes in one tick, so a reader that
+        raced into the window would otherwise keep serving the truncated
+        snapshot forever. Content swaps that preserve BOTH size and mtime
+        remain invisible, as with any stat-based probe.
+
+        :param path: The file to probe.
+        :return: (st_size, st_mtime_ns), or None when the file cannot be
+                stat-ed (missing file, permission problem, ...). Never raises,
+                per the fingerprint contract — and None compares like any other
+                component value, so "file missing" is itself a version that
+                goes stale the moment the file appears.
+        """
+        try:
+            file_stat = stat(path)
+            return file_stat.st_size, file_stat.st_mtime_ns
+        except OSError:
+            return None
+
+    @staticmethod
     def time_bucket(period_seconds: float) -> int:
         """
         Fingerprint building block: TTL-style expiry for sources with no

--- a/coded_tools/middleware_manager/add_middleware.py
+++ b/coded_tools/middleware_manager/add_middleware.py
@@ -93,7 +93,9 @@ class AddMiddleware(CodedTool):
                 raise ValueError(f"Middleware '{middleware_class}' is already present on agent '{agent_name}'.")
 
         new_entry: dict[str, Any] = {"class": middleware_class}
-        if middleware_args:
+        # Presence, not truthiness: an explicitly passed empty args dict is stored —
+        # the persistence layer round-trips `"args": {}` — rather than silently dropped.
+        if middleware_args is not None:
             new_entry["args"] = middleware_args
 
         existing_middleware.append(new_entry)

--- a/coded_tools/middleware_manager/add_middleware.py
+++ b/coded_tools/middleware_manager/add_middleware.py
@@ -1,0 +1,98 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import logging
+from typing import Any
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+from coded_tools.agent_network_editor.and_logger import AndLogger
+from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
+from coded_tools.agent_network_editor.constants import MIDDLEWARE_KEY
+from coded_tools.agent_network_editor.progress_handler import ProgressHandler
+from coded_tools.middleware_manager.middleware_request_guard import MiddlewareRequestGuard
+
+
+class AddMiddleware(CodedTool):
+    """
+    CodedTool implementation which adds a middleware entry to a specified agent
+    in the agent network definition stored in sly_data.
+    """
+
+    async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any] | str:
+        """
+        :param args: An argument dictionary whose keys are the parameters
+                to the coded tool and whose values are the values passed for them
+                by the calling agent.  This dictionary is to be treated as read-only.
+
+                The argument dictionary expects the following keys:
+                    "agent_name": the name of the agent to which middleware will be added.
+                    "middleware_class": the fully qualified class name of the middleware. Named this
+                        way instead of `class` because `class` is a Python reserved word and breaks
+                        pydantic tool-arg validation upstream of this method.
+                    "args" (optional): key-value arguments to pass to the middleware constructor.
+
+        :param sly_data: A dictionary whose keys are defined by the agent hierarchy,
+                but whose values are meant to be kept out of the chat stream.
+
+                Keys expected for this implementation are:
+                    "agent_network_definition": an outline of an agent network
+
+        :raises ValueError: when the input is malformed, the target agent doesn't exist or
+                is a function/toolbox node, or the requested middleware is already present.
+                The framework's `error_formatter` / `error_fragments` config catches this and
+                surfaces it back to the calling LLM as an actionable error message.
+        :return: On success, a text string confirming the middleware was added.
+        """
+        network_def, agent_name, middleware_class = MiddlewareRequestGuard.validated_target(args, sly_data)
+
+        # Middleware wraps the agent's model call, so it only makes sense on LLM agents
+        # (those with an `instructions` field). Function / toolbox nodes have no model call
+        # to wrap and the HOCON assembler's toolbox template has no slot for a middleware
+        # array — attaching middleware to them would silently disappear on persist.
+        agent_def: dict[str, Any] = network_def[agent_name]
+        if "instructions" not in agent_def:
+            raise ValueError(
+                f"Agent '{agent_name}' is a function/toolbox node (no `instructions`) and cannot have middleware."
+            )
+
+        middleware_args: dict[str, Any] | None = args.get("args")
+
+        logger = AndLogger(logging.getLogger(self.__class__.__name__))
+        logger.info(">>>>>>>>>>>>>>>>>>>Add Middleware>>>>>>>>>>>>>>>>>>")
+        logger.info("Agent Name: %s", agent_name)
+        logger.info("Middleware Class: %s", middleware_class)
+
+        existing_middleware: list[dict[str, Any]] = agent_def.get(MIDDLEWARE_KEY, [])
+
+        # Check for duplicate
+        for entry in existing_middleware:
+            if entry.get("class") == middleware_class:
+                raise ValueError(f"Middleware '{middleware_class}' is already present on agent '{agent_name}'.")
+
+        new_entry: dict[str, Any] = {"class": middleware_class}
+        if middleware_args:
+            new_entry["args"] = middleware_args
+
+        existing_middleware.append(new_entry)
+        agent_def[MIDDLEWARE_KEY] = existing_middleware
+        network_def[agent_name] = agent_def
+        sly_data[AGENT_NETWORK_DEFINITION] = network_def
+
+        await ProgressHandler.report_progress(args, sly_data, network_def)
+
+        logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
+        return f"Successfully added middleware '{middleware_class}' to agent '{agent_name}'."

--- a/coded_tools/middleware_manager/add_middleware.py
+++ b/coded_tools/middleware_manager/add_middleware.py
@@ -83,7 +83,9 @@ class AddMiddleware(CodedTool):
         logger.info("Agent Name: %s", agent_name)
         logger.info("Middleware Class: %s", middleware_class)
 
-        existing_middleware: list[dict[str, Any]] = agent_def.get(MIDDLEWARE_KEY, [])
+        existing_middleware: list[dict[str, Any]] = MiddlewareRequestGuard.validated_middleware_list(
+            agent_def, agent_name
+        )
 
         # Check for duplicate
         for entry in existing_middleware:

--- a/coded_tools/middleware_manager/add_middleware.py
+++ b/coded_tools/middleware_manager/add_middleware.py
@@ -69,7 +69,14 @@ class AddMiddleware(CodedTool):
                 f"Agent '{agent_name}' is a function/toolbox node (no `instructions`) and cannot have middleware."
             )
 
+        # A non-dict here would not fail now but on save, when the HOCON assembler
+        # iterates the entry's args.items() — reject it while the caller can react.
         middleware_args: dict[str, Any] | None = args.get("args")
+        if middleware_args is not None and not isinstance(middleware_args, dict):
+            raise ValueError(
+                f"Error: middleware args must be a dictionary of constructor arguments, "
+                f"got {type(middleware_args).__name__}."
+            )
 
         logger = AndLogger(logging.getLogger(self.__class__.__name__))
         logger.info(">>>>>>>>>>>>>>>>>>>Add Middleware>>>>>>>>>>>>>>>>>>")

--- a/coded_tools/middleware_manager/middleware_request_guard.py
+++ b/coded_tools/middleware_manager/middleware_request_guard.py
@@ -1,0 +1,62 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+
+from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
+
+
+# One shared guard method is the point; same accepted trade as AgentNameGuard.
+# pylint: disable=too-few-public-methods
+class MiddlewareRequestGuard:
+    """
+    The request-validation policy shared by the middleware_manager coded tools.
+
+    AddMiddleware and RemoveMiddleware receive the same (args, sly_data) shape and
+    must refuse the same malformed inputs in the same way, so the shared checks
+    live here once. Guards raise ValueError because the framework's
+    error_formatter / error_fragments config turns that into an actionable error
+    message for the calling LLM.
+    """
+
+    @staticmethod
+    def validated_target(args: dict[str, Any], sly_data: dict[str, Any]) -> tuple[dict[str, Any], str, str]:
+        """
+        Validate the parts of an add/remove request that both tools require.
+
+        :param args: The coded tool's args dictionary.
+        :param sly_data: The coded tool's sly_data dictionary.
+        :return: (network_def, agent_name, middleware_class) — the agent's own
+                definition is network_def[agent_name], guaranteed present.
+        :raises ValueError: when the network definition is missing from sly_data,
+                the agent name is missing or unknown, or middleware_class is
+                missing.
+        """
+        network_def: dict[str, Any] = sly_data.get(AGENT_NETWORK_DEFINITION)
+        if not network_def:
+            raise ValueError("No agent network definition found in sly data.")
+
+        agent_name: str = args.get("agent_name", "")
+        if not agent_name:
+            raise ValueError("No agent_name provided.")
+        if agent_name not in network_def:
+            raise ValueError(f"Agent '{agent_name}' not found in the agent network definition.")
+
+        middleware_class: str = args.get("middleware_class", "")
+        if not middleware_class:
+            raise ValueError("No middleware_class provided.")
+
+        return network_def, agent_name, middleware_class

--- a/coded_tools/middleware_manager/middleware_request_guard.py
+++ b/coded_tools/middleware_manager/middleware_request_guard.py
@@ -17,10 +17,9 @@
 from typing import Any
 
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
+from coded_tools.agent_network_editor.constants import MIDDLEWARE_KEY
 
 
-# One shared guard method is the point; same accepted trade as AgentNameGuard.
-# pylint: disable=too-few-public-methods
 class MiddlewareRequestGuard:
     """
     The request-validation policy shared by the middleware_manager coded tools.
@@ -43,7 +42,8 @@ class MiddlewareRequestGuard:
                 definition is network_def[agent_name], guaranteed present.
         :raises ValueError: when the network definition is missing from sly_data
                 or not a dictionary, the agent name is missing, non-string, or
-                unknown, or middleware_class is missing or non-string.
+                unknown, the agent's own definition is not a dictionary, or
+                middleware_class is missing or non-string.
         """
         # Type checks before use: a non-string agent_name would raise TypeError
         # on the `in` membership test below (lists are unhashable), escaping the
@@ -59,6 +59,11 @@ class MiddlewareRequestGuard:
             raise ValueError("No agent_name provided.")
         if agent_name not in network_def:
             raise ValueError(f"Agent '{agent_name}' not found in the agent network definition.")
+        if not isinstance(network_def[agent_name], dict):
+            raise ValueError(
+                f"Error: the definition of agent '{agent_name}' must be a dictionary, "
+                f"got {type(network_def[agent_name]).__name__}."
+            )
 
         middleware_class: Any = args.get("middleware_class", "")
         if not isinstance(middleware_class, str):
@@ -67,3 +72,27 @@ class MiddlewareRequestGuard:
             raise ValueError("No middleware_class provided.")
 
         return network_def, agent_name, middleware_class
+
+    @staticmethod
+    def validated_middleware_list(agent_def: dict[str, Any], agent_name: str) -> list[dict[str, Any]]:
+        """
+        Validate and return an agent's existing middleware list.
+
+        Both tools iterate the list calling entry.get("class"), so a malformed
+        block (a string, a dict, or non-dict entries) would raise TypeError /
+        AttributeError there and escape the ValueError contract.
+
+        :param agent_def: The agent's own definition (network_def[agent_name]).
+        :param agent_name: The agent's name, for the error message.
+        :return: The agent's middleware list ([] when absent or None).
+        :raises ValueError: when a middleware block is present but is not a
+                list of dictionaries.
+        """
+        existing_middleware: Any = agent_def.get(MIDDLEWARE_KEY) or []
+        if not isinstance(existing_middleware, list) or not all(
+            isinstance(entry, dict) for entry in existing_middleware
+        ):
+            raise ValueError(
+                f"Error: agent '{agent_name}' has a malformed middleware block — expected a list of dictionaries."
+            )
+        return existing_middleware

--- a/coded_tools/middleware_manager/middleware_request_guard.py
+++ b/coded_tools/middleware_manager/middleware_request_guard.py
@@ -41,21 +41,28 @@ class MiddlewareRequestGuard:
         :param sly_data: The coded tool's sly_data dictionary.
         :return: (network_def, agent_name, middleware_class) — the agent's own
                 definition is network_def[agent_name], guaranteed present.
-        :raises ValueError: when the network definition is missing from sly_data,
-                the agent name is missing or unknown, or middleware_class is
-                missing.
+        :raises ValueError: when the network definition is missing from sly_data
+                or not a dictionary, the agent name is missing, non-string, or
+                unknown, or middleware_class is missing or non-string.
         """
+        # Type checks before use: a non-string agent_name would raise TypeError
+        # on the `in` membership test below (lists are unhashable), escaping the
+        # ValueError contract the error_formatter relies on.
         network_def: dict[str, Any] = sly_data.get(AGENT_NETWORK_DEFINITION)
-        if not network_def:
+        if not isinstance(network_def, dict) or not network_def:
             raise ValueError("No agent network definition found in sly data.")
 
-        agent_name: str = args.get("agent_name", "")
+        agent_name: Any = args.get("agent_name", "")
+        if not isinstance(agent_name, str):
+            raise ValueError(f"Error: agent_name must be a string, got {type(agent_name).__name__}.")
         if not agent_name:
             raise ValueError("No agent_name provided.")
         if agent_name not in network_def:
             raise ValueError(f"Agent '{agent_name}' not found in the agent network definition.")
 
-        middleware_class: str = args.get("middleware_class", "")
+        middleware_class: Any = args.get("middleware_class", "")
+        if not isinstance(middleware_class, str):
+            raise ValueError(f"Error: middleware_class must be a string, got {type(middleware_class).__name__}.")
         if not middleware_class:
             raise ValueError("No middleware_class provided.")
 

--- a/coded_tools/middleware_manager/middleware_request_guard.py
+++ b/coded_tools/middleware_manager/middleware_request_guard.py
@@ -68,7 +68,9 @@ class MiddlewareRequestGuard:
         middleware_class: Any = args.get("middleware_class", "")
         if not isinstance(middleware_class, str):
             raise ValueError(f"Error: middleware_class must be a string, got {type(middleware_class).__name__}.")
-        if not middleware_class:
+        # strip(): the persistence layer refuses to preserve a whitespace-only
+        # class, so the tool must not create an entry a round trip would drop.
+        if not middleware_class.strip():
             raise ValueError("No middleware_class provided.")
 
         return network_def, agent_name, middleware_class
@@ -88,7 +90,11 @@ class MiddlewareRequestGuard:
         :raises ValueError: when a middleware block is present but is not a
                 list of dictionaries.
         """
-        existing_middleware: Any = agent_def.get(MIDDLEWARE_KEY) or []
+        # Explicit None check, not `or []`: a present-but-falsy block ({} or "")
+        # is malformed and must raise below, not be silently treated as empty.
+        existing_middleware: Any = agent_def.get(MIDDLEWARE_KEY)
+        if existing_middleware is None:
+            existing_middleware = []
         if not isinstance(existing_middleware, list) or not all(
             isinstance(entry, dict) for entry in existing_middleware
         ):

--- a/coded_tools/middleware_manager/remove_middleware.py
+++ b/coded_tools/middleware_manager/remove_middleware.py
@@ -64,7 +64,9 @@ class RemoveMiddleware(CodedTool):
         logger.info("Middleware Class: %s", middleware_class)
 
         agent_def: dict[str, Any] = network_def[agent_name]
-        existing_middleware: list[dict[str, Any]] = agent_def.get(MIDDLEWARE_KEY, [])
+        existing_middleware: list[dict[str, Any]] = MiddlewareRequestGuard.validated_middleware_list(
+            agent_def, agent_name
+        )
 
         updated_middleware = [entry for entry in existing_middleware if entry.get("class") != middleware_class]
 

--- a/coded_tools/middleware_manager/remove_middleware.py
+++ b/coded_tools/middleware_manager/remove_middleware.py
@@ -1,0 +1,81 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import logging
+from typing import Any
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+from coded_tools.agent_network_editor.and_logger import AndLogger
+from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
+from coded_tools.agent_network_editor.constants import MIDDLEWARE_KEY
+from coded_tools.agent_network_editor.progress_handler import ProgressHandler
+from coded_tools.middleware_manager.middleware_request_guard import MiddlewareRequestGuard
+
+
+class RemoveMiddleware(CodedTool):
+    """
+    CodedTool implementation which removes a middleware entry from a specified agent
+    in the agent network definition stored in sly_data.
+    """
+
+    async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> dict[str, Any] | str:
+        """
+        :param args: An argument dictionary whose keys are the parameters
+                to the coded tool and whose values are the values passed for them
+                by the calling agent.  This dictionary is to be treated as read-only.
+
+                The argument dictionary expects the following keys:
+                    "agent_name": the name of the agent from which middleware will be removed.
+                    "middleware_class": the fully qualified class name of the middleware to remove.
+                        Named this way instead of `class` because `class` is a Python reserved word
+                        and breaks pydantic tool-arg validation upstream of this method.
+
+        :param sly_data: A dictionary whose keys are defined by the agent hierarchy,
+                but whose values are meant to be kept out of the chat stream.
+
+                Keys expected for this implementation are:
+                    "agent_network_definition": an outline of an agent network
+
+        :raises ValueError: when the input is malformed, the target agent doesn't exist, or
+                the requested middleware is not present on the agent. The framework's
+                `error_formatter` / `error_fragments` config catches this and surfaces it
+                back to the calling LLM as an actionable error message.
+        :return: On success, a text string confirming the middleware was removed.
+        """
+        network_def, agent_name, middleware_class = MiddlewareRequestGuard.validated_target(args, sly_data)
+
+        logger = AndLogger(logging.getLogger(self.__class__.__name__))
+        logger.info(">>>>>>>>>>>>>>>>>>>Remove Middleware>>>>>>>>>>>>>>>>>>")
+        logger.info("Agent Name: %s", agent_name)
+        logger.info("Middleware Class: %s", middleware_class)
+
+        agent_def: dict[str, Any] = network_def[agent_name]
+        existing_middleware: list[dict[str, Any]] = agent_def.get(MIDDLEWARE_KEY, [])
+
+        updated_middleware = [entry for entry in existing_middleware if entry.get("class") != middleware_class]
+
+        if len(updated_middleware) == len(existing_middleware):
+            raise ValueError(f"Middleware '{middleware_class}' is not present on agent '{agent_name}'.")
+
+        agent_def[MIDDLEWARE_KEY] = updated_middleware
+        network_def[agent_name] = agent_def
+        sly_data[AGENT_NETWORK_DEFINITION] = network_def
+
+        await ProgressHandler.report_progress(args, sly_data, network_def)
+
+        logger.debug(">>>>>>>>>>>>>>>>>>> DONE %s !!!>>>>>>>>>>>>>>>>>>", self.__class__.__name__)
+        return f"Successfully removed middleware '{middleware_class}' from agent '{agent_name}'."

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -513,11 +513,11 @@ ENV AGENT_NETWORK_DESIGNER_SUBDIRECTORY="generated"
 
 # Manifest file(s) providing available external agents for the Agent Network Designer to choose from.
 # Defaults to "registries/manifest_and.hocon" if not set.
-ENV AGENT_NETWORK_DESIGNER_MANIFEST_FILE="registries/manifest_and.hocon"
+ENV AGENT_NETWORK_DESIGNER_MANIFEST_FILE="${APP_SOURCE}/registries/manifest_and.hocon"
 
 # Toolbox info file providing available tools for the Agent Network Designer to choose from.
 # Defaults to "neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon" if not set.
-ENV AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE="neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon"
+ENV AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE="${APP_SOURCE}/neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon"
 
 # Time in seconds that the Agent Network Designer's cached MCP tool listings are served before
 # being re-fetched from the MCP servers. Positive values are clamped to at least twice the
@@ -537,5 +537,11 @@ ENV AGENT_NETWORK_DESIGNER_MCP_TOOLS_FETCH_TIMEOUT_SECONDS="30"
 # validation errors (e.g., a required tool was unavailable during session setup).
 # Defaults to "3" if not set.
 ENV AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS="3"
+
+# Path to the HOCON catalog of middleware classes that the middleware_manager subnetwork
+# is allowed to attach to agents. Each entry pairs a friendly key with the fully qualified
+# class name and an arg schema. Read by MiddlewareInfoMiddleware. Override only when
+# serving a custom middleware allow-list.
+ENV AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE="${APP_SOURCE}/middleware/agent_network_designer/middleware_info.hocon"
 
 ENTRYPOINT ["/bin/bash", "-c", "exec ${APP_ENTRYPOINT}"]

--- a/deploy/Dockerfile.py314t
+++ b/deploy/Dockerfile.py314t
@@ -672,11 +672,11 @@ ENV AGENT_NETWORK_DESIGNER_SUBDIRECTORY="generated"
 
 # Manifest file(s) providing available external agents for the Agent Network Designer to choose from.
 # Defaults to "registries/manifest_and.hocon" if not set.
-ENV AGENT_NETWORK_DESIGNER_MANIFEST_FILE="registries/manifest_and.hocon"
+ENV AGENT_NETWORK_DESIGNER_MANIFEST_FILE="${APP_SOURCE}/registries/manifest_and.hocon"
 
 # Toolbox info file providing available tools for the Agent Network Designer to choose from.
 # Defaults to "neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon" if not set.
-ENV AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE="neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon"
+ENV AGENT_NETWORK_DESIGNER_TOOLBOX_INFO_FILE="${APP_SOURCE}/neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon"
 
 # Time in seconds that the Agent Network Designer's cached MCP tool listings are served before
 # being re-fetched from the MCP servers. Positive values are clamped to at least twice the
@@ -696,5 +696,11 @@ ENV AGENT_NETWORK_DESIGNER_MCP_TOOLS_FETCH_TIMEOUT_SECONDS="30"
 # validation errors (e.g., a required tool was unavailable during session setup).
 # Defaults to "3" if not set.
 ENV AGENT_NETWORK_DESIGNER_MAX_VALIDATION_ATTEMPTS="3"
+
+# Path to the HOCON catalog of middleware classes that the middleware_manager subnetwork
+# is allowed to attach to agents. Each entry pairs a friendly key with the fully qualified
+# class name and an arg schema. Read by MiddlewareInfoMiddleware. Override only when
+# serving a custom middleware allow-list.
+ENV AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE="${APP_SOURCE}/middleware/agent_network_designer/middleware_info.hocon"
 
 ENTRYPOINT ["/bin/bash", "-c", "exec ${APP_ENTRYPOINT}"]

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -681,9 +681,10 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         # it on load a round-trip would silently strip every previously-attached middleware.
         middleware: Any = agent.get(MIDDLEWARE_KEY)
         if middleware:
-            if not isinstance(middleware, list) or not all(isinstance(entry, dict) for entry in middleware):
+            if not self._is_preservable_middleware(middleware):
                 self.logger.warning(
-                    "WARNING: Ignoring 'middleware' on agent %s in '%s' — expected list[dict], got %r",
+                    "WARNING: Ignoring 'middleware' on agent %s in '%s' — expected a list of "
+                    '{"class": <non-empty string>, "args": <optional dict>} entries, got %r',
                     agent_name,
                     source,
                     middleware,
@@ -692,6 +693,35 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
                 agent_def[MIDDLEWARE_KEY] = middleware
 
         return agent_name, agent_def
+
+    @staticmethod
+    def _is_preservable_middleware(middleware: Any) -> bool:
+        """
+        Report whether a source agent's middleware block can be round-tripped.
+
+        Preserved middleware is re-rendered verbatim on save by
+        HoconAgentNetworkAssembler._render_middleware, which indexes
+        entry["class"] and iterates entry["args"].items() — so a block is only
+        preservable when every entry honors that shape. The caller warns about
+        and drops anything else at load time, where the source file is still
+        known, rather than letting a malformed entry crash a later save.
+
+        :param middleware: The raw middleware value from the source agent spec.
+        :return: True when middleware is a list whose entries each have a
+                non-empty string "class" and, when present, a dict "args".
+        """
+        if not isinstance(middleware, list):
+            return False
+        for entry in middleware:
+            if not isinstance(entry, dict):
+                return False
+            middleware_class: Any = entry.get("class")
+            if not isinstance(middleware_class, str) or not middleware_class.strip():
+                return False
+            entry_args: Any = entry.get("args")
+            if entry_args is not None and not isinstance(entry_args, dict):
+                return False
+        return True
 
     async def _extract_custom_instructions(self, instructions: str) -> str:
         """

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -48,6 +48,7 @@ from coded_tools.agent_network_editor.and_logger import AndLogger
 from coded_tools.agent_network_editor.connectivity_dictionary_converter import ConnectivityDictionaryConverter
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
 from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
+from coded_tools.agent_network_editor.constants import MIDDLEWARE_KEY
 from coded_tools.agent_network_editor.progress_handler import ProgressHandler
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 from middleware.agent_network_designer.persistence.file_system_agent_network_persistor import DEFAULT_REGISTRIES_DIR
@@ -634,7 +635,10 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             self.logger.warning("WARNING: Skipping agent with missing/invalid 'name' in '%s': %r", source, agent)
             return None, {}
 
-        # Only extract agents info and only "instructions" and "tools" parts
+        # Extract the agent fields the designer pipeline cares about: instructions,
+        # description, tools, and middleware. Anything else in the source agent spec
+        # (function schema, allow rules, structure_formats, etc.) is intentionally
+        # dropped — those are reconstructed by the assembler on save.
         agent_def: dict[str, Any] = {}
 
         instructions: str | None = agent.get("instructions")
@@ -671,6 +675,21 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
         tools: list[str] | None = agent.get("tools")
         if tools:
             agent_def["tools"] = tools
+
+        # Preserve middleware attached to LLM agents. The assembler writes this back out
+        # via HoconAgentNetworkAssembler._render_middleware on save, so without preserving
+        # it on load a round-trip would silently strip every previously-attached middleware.
+        middleware: Any = agent.get(MIDDLEWARE_KEY)
+        if middleware:
+            if not isinstance(middleware, list) or not all(isinstance(entry, dict) for entry in middleware):
+                self.logger.warning(
+                    "WARNING: Ignoring 'middleware' on agent %s in '%s' — expected list[dict], got %r",
+                    agent_name,
+                    source,
+                    middleware,
+                )
+            else:
+                agent_def[MIDDLEWARE_KEY] = middleware
 
         return agent_name, agent_def
 

--- a/middleware/agent_network_designer/catalog_load_error.py
+++ b/middleware/agent_network_designer/catalog_load_error.py
@@ -1,0 +1,27 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+
+class CatalogLoadError(ValueError):
+    """
+    Raised when a designer catalog (see HoconCatalogCache) cannot be resolved,
+    read, or parsed.
+
+    The message carries the resolved path and the underlying cause — server-side
+    detail. Each caller decides what (if anything) of it reaches clients: an
+    exception escaping a model call becomes the turn's client-visible answer, so
+    a security-gating caller must log this and re-raise something client-safe.
+    """

--- a/middleware/agent_network_designer/hocon_catalog_cache.py
+++ b/middleware/agent_network_designer/hocon_catalog_cache.py
@@ -1,0 +1,197 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+The one copy of the resolve/load/validate/fingerprint discipline for the
+designer's env-var-pathed HOCON catalogs (currently the middleware-info
+catalog; built to host future catalogs with the same needs).
+
+The consuming middleware keeps only its failure POLICY — the info injector
+warns and skips; a security-gating consumer would instead fail closed with a
+client-safe error — while everything catalog consumers must otherwise keep in
+lockstep lives here once:
+path resolution, empty-path and root-shape rejection, the empty-catalog
+breadcrumb, load-failure normalization, and the freshness fingerprint.
+
+The designer's other shared loads — GetToolbox, GetSubnetwork, and GetMcpTool
+in coded_tools/agent_network_editor, candidates for recasting as middlewares
+like the consumer above — sit on the same SharedProcessCache but are NOT tenants of
+this class: each deliberately differs in a policy this class fixes.
+
+* Parse: they use special-purpose restorers (ToolboxInfoRestorer, the manifest
+  filter chain, McpServersInfoRestorer) where this class does a raw HOCON read.
+* Empty results: the toolbox treats an empty mapping as a failed read and
+  raises; MCP treats a missing file as an authoritative empty and publishes
+  it; this class publishes empty with a warning breadcrumb.
+* Freshness: the toolbox cache is deliberately immortal (lockstep with the
+  shared ToolboxFactory); the manifest and MCP fingerprints carry time-bucket
+  components that this class's (path, size, mtime) probe does not.
+
+Recasting those tools as middlewares reuses the SHAPE of the consumer here
+(a class-level cache, prompt injection in awrap_model_call, an explicit
+degrade policy — see MiddlewareInfoMiddleware for the template); hosting their
+file loads in this class would mean growing the three policy knobs above.
+Their network fan-out halves (subnetwork description fetches, MCP tool
+listings) are not file catalogs at all and stay on SharedProcessCache directly.
+"""
+
+import logging
+import os
+from typing import Any
+from typing import Callable
+
+from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
+from pyparsing.exceptions import ParseException
+
+from coded_tools.agent_network_editor.and_logger import AndLogger
+from coded_tools.agent_network_editor.shared_process_cache import SharedProcessCache
+from middleware.agent_network_designer.catalog_load_error import CatalogLoadError
+
+
+# One attribute over pylint's cap of 7: six configuration knobs (each consumed
+# in a different place, so grouping any two would be an arbitrary pairing) plus
+# the logger and the wrapped cache.
+# pylint: disable-next=too-many-instance-attributes
+class HoconCatalogCache:
+    """
+    Process-wide cache of one env-var-pathed HOCON catalog.
+
+    Wraps SharedProcessCache with the discipline both designer catalog
+    middlewares need:
+
+    * Path resolution: an explicit env var always wins (including an explicitly
+      empty one, rejected below rather than silently yielding an empty catalog);
+      otherwise the working-directory repo/project layout, falling back to the
+      copy bundled beside the consuming module so scaffolded projects and
+      installed wheels work without configuration.
+    * Rejection of empty paths (restore() returns None for them BEFORE its
+      must_exist check ever runs) and of non-mapping roots (a root-level array
+      parses fine but is not a catalog) — both raise instead of publishing, so
+      recovery needs only a file fix, never a restart.
+    * A warning breadcrumb for an empty catalog: legitimate config, but
+      indistinguishable from an accidentally truncated file.
+    * Load failures normalized into CatalogLoadError; nothing is published on a
+      raise, so the next call retries.
+    * A (path, size, modification-time) fingerprint, so an edited file, a
+      changed env var, and a same-clock-tick truncate-then-write all register
+      as a miss and trigger a reload.
+    """
+
+    # pylint: disable-next=too-many-arguments
+    def __init__(
+        self,
+        *,
+        env_var: str,
+        default_file: str,
+        bundled_file: str,
+        file_purpose: str,
+        empty_effect: str,
+        transform: Callable[[dict[str, Any]], Any] | None = None,
+    ):
+        """
+        :param env_var: Name of the environment variable that overrides the path.
+        :param default_file: Working-directory-relative path used when the env
+                var is unset (the repo / `ns init` project layout).
+        :param bundled_file: The copy shipped beside the consuming module; the
+                fallback when the working directory has no layout copy.
+        :param file_purpose: AbstractAsyncConfigRestorer purpose string.
+        :param empty_effect: One clause describing what an empty catalog means,
+                spliced into the breadcrumb warning (e.g. "no middleware
+                will be offered to the LLM").
+        :param transform: Optional post-parse projection of the catalog dict
+                into the cached value (e.g. pre-rendering a prompt section), run
+                once per load instead of once per model call. Must not return
+                None — that is the cache's miss sentinel.
+        """
+        self.env_var = env_var
+        self.default_file = default_file
+        self.bundled_file = bundled_file
+        self.file_purpose = file_purpose
+        self.empty_effect = empty_effect
+        self.transform = transform
+        self.logger = AndLogger(logging.getLogger(f"{self.__class__.__name__}({env_var})"))
+        self._cache: SharedProcessCache[Any] = SharedProcessCache(
+            loader=self._load,
+            fingerprint=self._fingerprint,
+        )
+
+    def resolve_file(self) -> str:
+        """
+        :return: The catalog path per the resolution order in the class docstring.
+        """
+        env_path: str | None = os.getenv(self.env_var)
+        if env_path is not None:
+            return env_path
+        if os.path.isfile(self.default_file):
+            return self.default_file
+        return self.bundled_file
+
+    def _load(self) -> Any:
+        """
+        SharedProcessCache loader: read, parse, validate, and transform the catalog.
+
+        Runs in a worker thread (reached through aget()), so the blocking file
+        read and HOCON parse stay off the event loop.
+
+        :return: transform(catalog) when a transform was given, else the catalog
+                dict ({} for an empty file — loaders must never return None).
+        :raises CatalogLoadError: when the catalog cannot be read or parsed.
+        """
+        catalog_file: str = self.resolve_file()
+        try:
+            if not catalog_file:
+                raise ValueError(f"{self.env_var} is set to an empty string")
+            restorer = AbstractAsyncConfigRestorer(file_purpose=self.file_purpose, must_exist=True)
+            catalog: dict[str, Any] = restorer.restore(file_reference=catalog_file)
+            if catalog is not None and not isinstance(catalog, dict):
+                raise ValueError(f"catalog root must be a mapping, got {type(catalog).__name__}")
+        except (OSError, ValueError, ParseException) as error:
+            # OSError covers FileNotFoundError / PermissionError / IsADirectoryError;
+            # ValueError is raised for unsupported file extensions and is what current
+            # neuro-san re-wraps HOCON/JSON parse failures into; ParseException stays
+            # in the tuple defensively for neuro-san versions that surface its own
+            # ParseException wrapper directly.
+            raise CatalogLoadError(
+                f"Catalog for {self.env_var} could not be loaded from '{catalog_file}': {error}"
+            ) from error
+
+        if not catalog:
+            self.logger.warning("Catalog '%s' is empty: %s.", catalog_file, self.empty_effect)
+            catalog = {}
+        if self.transform is not None:
+            return self.transform(catalog)
+        return catalog
+
+    def _fingerprint(self) -> tuple[str, tuple[int, int] | None]:
+        """
+        SharedProcessCache fingerprint: the resolved path plus its (size,
+        modification time). Cheap and never raises, per the fingerprint contract.
+        """
+        catalog_file: str = self.resolve_file()
+        return catalog_file, SharedProcessCache.stat_size_and_modification_time_ns(catalog_file)
+
+    async def aget(self) -> Any:
+        """
+        :return: The cached (or freshly loaded) catalog value; see _load().
+        :raises CatalogLoadError: when the catalog cannot be read or parsed.
+        """
+        return await self._cache.aget()
+
+    def clear_for_testing(self):
+        """
+        Reset the process-wide cache. For test isolation only — production code
+        relies on the load-once-with-fingerprint semantics.
+        """
+        self._cache.clear_for_testing()

--- a/middleware/agent_network_designer/middleware_info.hocon
+++ b/middleware/agent_network_designer/middleware_info.hocon
@@ -1,0 +1,132 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# This is a middleware configuration file that defines middlewares that are available for use in agent networks designed
+# by the experimental agent harness designer.
+
+{
+    "pii_middleware": {
+        "class": "langchain.agents.middleware.PIIMiddleware",
+        "description": """
+    Detect and handle Personally Identifiable Information (PII) in conversations using configurable strategies.
+        """,
+        "args": {
+            "type": "object",
+            "properties": {
+                "pii_type": {
+                    "type": "string",
+                    "description": """Type of PII to detect. Built-in types: 'email', 'credit_card', 'ip', 'mac_address'
+                    , 'url'. Can also be a custom type name when paired with a custom detector.
+                    """
+                },
+                "strategy": {
+                    "type": "string",
+                    "enum": ["block", "redact", "mask", "hash"],
+                    "description": """
+                How to handle detected PII. 'block' raises an exception, 'redact' replaces with [REDACTED_{PII_TYPE}],
+                'mask' partially obscures (e.g. ****-****-****-1234), 'hash' substitutes a deterministic hash.
+                    """,
+                    "default": "redact"
+                },
+                "detector": {
+                    "type": "string",
+                    "description": """Custom detector as a regex pattern string. Used when pii_type is a custom name or
+                    when overriding a built-in detector.
+                    """
+                },
+                "apply_to_input": {
+                    "type": "boolean",
+                    "description": "Whether to scan user input messages before the model call.",
+                    "default": true
+                },
+                "apply_to_output": {
+                    "type": "boolean",
+                    "description": "Whether to scan AI response messages after the model call.",
+                    "default": false
+                },
+                "apply_to_tool_results": {
+                    "type": "boolean",
+                    "description": "Whether to scan tool result messages after tool execution.",
+                    "default": false
+                }
+            },
+            "required": ["pii_type"]
+        }
+    },
+
+    "agent_checklist_middleware": {
+        "class": "middleware.agent_checklist_middleware.AgentChecklistMiddleware",
+        "description": """
+    Middleware for managing an in-memory checklist during agent execution.
+    The checklist is stored as an instance variable so it persists across all model
+    calls within a single agent session. The agent can create and update the checklist
+    via registered tools, and the current checklist state is automatically injected
+    into the system prompt before each model call.
+        """,
+        "args": {
+            "type": "object",
+            "properties": {
+                "checklist_title": {
+                    "type": "string",
+                    "description": "A title for the checklist to provide context to the agent."
+                },
+            },
+            "required": ["checklist_title"]
+        }
+    },
+
+    "agent_skills_middleware": {
+        "class": "middleware.agent_skills_middleware.AgentSkillsMiddleware",
+        "description": """
+    Middleware for loading and managing agent skills per the Agent Skills specification
+    (https://agentskills.io/specification). Uses a progressive disclosure pattern: skill
+    metadata is loaded upfront, and full SKILL.md content is retrieved on demand when the
+    agent activates a skill. Supports remote URLs as skill sources.
+        """,
+        "args": {
+            "type": "object",
+            "properties": {
+                "skill_sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": """List of URLs to scan for SKILL.md files.
+                    Available URLs
+                    - https://raw.githubusercontent.com/anthropics/skills/main/skills/brand-guidelines/
+                    - https://raw.githubusercontent.com/anthropics/skills/main/skills/doc-coauthoring/
+                    - https://raw.githubusercontent.com/anthropics/skills/main/skills/internal-comms/
+                    """
+                },
+                "keep_skill_in_context": {
+                    "type": "boolean",
+                    "description": """Whether to keep full skill content in the chat context after loading.
+                    If false (default), skill content is injected directly into the model request
+                    without appearing as a tool message in the conversation history.
+                    """,
+                    "default": false
+                },
+                "http_timeout": {
+                    "type": "number",
+                    "description": "Timeout in seconds for HTTP requests when loading remote skills.",
+                    "default": 30.0
+                }
+            },
+            "required": ["skill_sources"]
+        }
+    },
+
+}

--- a/middleware/agent_network_designer/middleware_info_middleware.py
+++ b/middleware/agent_network_designer/middleware_info_middleware.py
@@ -1,0 +1,140 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from typing import override
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware.types import ContextT
+from langchain.agents.middleware.types import ModelRequest
+from langchain.agents.middleware.types import ModelResponse
+from langchain.agents.middleware.types import ResponseT
+from langchain_core.messages import BaseMessage
+from langchain_core.messages import SystemMessage
+
+from coded_tools.agent_network_editor.and_logger import AndLogger
+from middleware.agent_network_designer.catalog_load_error import CatalogLoadError
+from middleware.agent_network_designer.hocon_catalog_cache import HoconCatalogCache
+
+# Relative to the working directory, matching the repo/scaffold layout when the
+# server is started from the top of the repository or of an `ns init` project.
+DEFAULT_MIDDLEWARE_INFO_FILE: str = str(Path("middleware", "agent_network_designer", "middleware_info.hocon"))
+# The copy of the catalog that ships right next to this module — the fallback when
+# the working directory has no repo/project-layout copy (e.g. `ns run` inside a
+# scaffolded project, or an installed wheel).
+BUNDLED_MIDDLEWARE_INFO_FILE: str = str(Path(__file__).with_name("middleware_info.hocon"))
+
+
+class MiddlewareInfoMiddleware(AgentMiddleware):
+    """
+    Middleware that reads the available middleware catalog from a HOCON file and injects it
+    into the system prompt before each model call, so the LLM can reason about which
+    middleware are available without the information passing through the chat stream.
+
+    The catalog is loaded once per process through HoconCatalogCache (see ProcessGlobals
+    entry 7), which also handles path resolution (env var, working-directory layout, the
+    copy bundled beside this module) and freshness; the prompt section is rendered once
+    per load rather than once per model call.
+
+    This middleware only enriches the prompt — it is not a security gate that must
+    fail closed — so a catalog that cannot be loaded degrades to a warning and an
+    uninjected prompt rather than failing the model call.
+    """
+
+    @staticmethod
+    def _format_middleware_info_prompt(middleware_info: dict[str, Any]) -> str:
+        """
+        Format the middleware catalog as a system prompt section.
+
+        Run once per catalog load (via the cache's transform), not once per model
+        call — the catalog is immutable per fingerprint, so the rendered section is
+        a pure function of the file.
+
+        :param middleware_info: The middleware catalog dictionary
+        :return: Formatted prompt string
+        """
+        info_str: str = json.dumps(middleware_info, indent=2)
+        return f"## Available Middleware\n\n```json\n{info_str}\n```"
+
+    # Process-wide cache of (catalog, rendered prompt section) — see ProcessGlobals
+    # entry 7. Access goes through the class by name (not cls) so a hypothetical
+    # subclass shares the one cache instead of splitting it. The transform lambda
+    # runs at load time, well after this class body finishes executing, so its
+    # by-name reference to the class resolves fine.
+    _shared_info_cache: HoconCatalogCache = HoconCatalogCache(
+        env_var="AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE",
+        default_file=DEFAULT_MIDDLEWARE_INFO_FILE,
+        bundled_file=BUNDLED_MIDDLEWARE_INFO_FILE,
+        file_purpose="get_middleware_info",
+        empty_effect="no middleware will be offered to the LLM",
+        transform=lambda info: (info, MiddlewareInfoMiddleware._format_middleware_info_prompt(info)),
+    )
+
+    def __init__(self) -> None:
+        self.logger = AndLogger(logging.getLogger(self.__class__.__name__))
+
+    @classmethod
+    def clear_shared_info_for_testing(cls):
+        """
+        Reset the process-wide catalog cache. For test isolation only.
+
+        Production code must never call this: the cache is deliberately
+        load-once-per-process with fingerprint-based refresh. Tests call it (via
+        tests/conftest.py's ProcessGlobals reset) so a catalog loaded under one
+        test's AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE state cannot leak into later tests.
+        """
+        MiddlewareInfoMiddleware._shared_info_cache.clear_for_testing()
+
+    @override
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        """
+        Inject the middleware catalog into the system prompt before each model call.
+
+        :param request: Model request containing messages and state
+        :param handler: Handler to execute the model call
+        :return: Model response from handler
+        """
+        try:
+            middleware_info, info_prompt = await MiddlewareInfoMiddleware._shared_info_cache.aget()
+        except CatalogLoadError as error:
+            # This catalog only enriches the prompt, so degrade gracefully instead
+            # of failing the model call; the load is retried on the next call. The
+            # detailed message stays server-side — this warning never reaches the
+            # client.
+            self.logger.warning("Middleware info catalog could not be loaded (%s). Skipping injection.", error)
+            return await handler(request)
+
+        if middleware_info:
+            self.logger.debug(">>>>>>>>>>>>>>>>>>>Injecting Middleware Info into System Prompt>>>>>>>>>>>>>>>>>>>")
+            system_message: BaseMessage | None = request.system_message
+            if system_message is not None:
+                original_content: str = system_message.content if isinstance(system_message.content, str) else ""
+                system_message = SystemMessage(content=f"{original_content}\n\n{info_prompt}")
+            else:
+                system_message = SystemMessage(content=info_prompt)
+
+            return await handler(request.override(system_message=system_message))
+
+        return await handler(request)

--- a/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/deployable_agent_network_assembler.py
@@ -25,6 +25,7 @@ from neuro_san.internals.graph.filters.dictionary_common_defs_config_filter impo
 from neuro_san.internals.graph.filters.string_common_defs_config_filter import StringCommonDefsConfigFilter
 from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
 
+from coded_tools.agent_network_editor.constants import MIDDLEWARE_KEY
 from middleware.agent_network_designer.persistence.agent_network_assembler import AgentNetworkAssembler
 
 
@@ -154,6 +155,11 @@ class DeployableAgentNetworkAssembler(AgentNetworkAssembler):
                         agent_spec["function"]["sly_data_schema"] = sly_data_schema
                 else:
                     agent_spec["function"]["description"] = agent_description
+
+            # Carry over middleware if present in the agent definition
+            middleware: list[dict[str, Any]] | None = agent_def.get(MIDDLEWARE_KEY)
+            if middleware:
+                agent_spec[MIDDLEWARE_KEY] = middleware
 
             # Add agent to tools
             agent_network["tools"].append(agent_spec)

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -336,14 +336,17 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
             lines.append("                {")
             lines.append(f'                    "class": "{entry["class"]}",')
             args = entry.get("args")
-            if args:
+            # `is not None` rather than truthiness: a hand-authored explicit empty
+            # args dict must round-trip as `"args": {}` instead of vanishing on save.
+            if args is not None:
                 # HOCON is a superset of JSON, so json.dumps emits valid HOCON for every value
                 # type (str/int/float/bool/None/list/dict). Don't try to format these by hand —
                 # Python's str() produces Python repr (single quotes, `None`, etc.) which would
                 # break round-trip for middleware whose args contain lists or dicts.
                 args_lines: list[str] = [f'                        "{k}": {json.dumps(v)}' for k, v in args.items()]
                 lines.append('                    "args": {')
-                lines.append(",\n".join(args_lines))
+                if args_lines:
+                    lines.append(",\n".join(args_lines))
                 lines.append("                    }")
             else:
                 # Remove the trailing comma from "class" line since it's the last field

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -21,6 +21,7 @@ from collections.abc import Mapping
 from copy import copy as shallow_copy
 from typing import Any
 
+from coded_tools.agent_network_editor.constants import MIDDLEWARE_KEY
 from middleware.agent_network_designer.persistence.agent_network_assembler import AgentNetworkAssembler
 
 HOCON_HEADER_START = (
@@ -171,7 +172,7 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         for agent_name, agent in use_network_def.items():
             body.append(self._render_agent_block(agent_name, agent, top_agent_name, sly_data_schema_block))
 
-        return header + "".join(body) + "]\n}\n"
+        return header + "".join(body) + "    ]\n}\n"
 
     def _move_top_agent_first(self, network_def: dict[str, Any], top_agent_name: str) -> dict[str, Any]:
         """
@@ -283,18 +284,74 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
         tools: str = self._format_tools(raw_tools)
         description: str = (agent.get("description") or "").strip()
         instructions: str = (agent.get("instructions") or "").strip()
+        middleware_block: str = self._render_middleware(agent.get(MIDDLEWARE_KEY) or [])
 
         if agent_name == top_agent_name:
             use_description = description or "An assistant that answers inquiries from the user."
-            return TOP_AGENT_TEMPLATE % (agent_name, use_description, sly_data_schema_block, instructions, tools)
-
-        if raw_tools:
-            return REGULAR_AGENT_TEMPLATE % (agent_name, description, instructions, tools)
-
-        if instructions:
+            block: str = TOP_AGENT_TEMPLATE % (agent_name, use_description, sly_data_schema_block, instructions, tools)
+        elif raw_tools:
+            block = REGULAR_AGENT_TEMPLATE % (agent_name, description, instructions, tools)
+        elif instructions:
             demo_prefix = "${demo_mode}" if self.demo_mode else ""
-            return LEAF_NODE_AGENT_TEMPLATE % (agent_name, description, demo_prefix, instructions)
-        return TOOLBOX_AGENT_TEMPLATE % (agent_name, agent_name)
+            block = LEAF_NODE_AGENT_TEMPLATE % (agent_name, description, demo_prefix, instructions)
+        else:
+            return TOOLBOX_AGENT_TEMPLATE % (agent_name, agent_name)
+
+        if middleware_block:
+            block = self._insert_middleware(block, middleware_block)
+        return block
+
+    def _insert_middleware(self, block: str, middleware_block: str) -> str:
+        """
+        Insert a middleware block before the closing brace of an agent block.
+
+        All agent templates end with "        },\\n". This method removes that suffix,
+        ensures the last property line has a trailing comma, appends the middleware block,
+        then re-adds the closing brace.
+
+        :param block: The rendered agent block string
+        :param middleware_block: The rendered middleware block string
+        :return: The agent block with middleware inserted inside its closing brace.
+        """
+        close = "        },\n"
+        prefix = block[: -len(close)]
+        prefix = prefix.rstrip("\n")
+        if not prefix.endswith(","):
+            prefix += ","
+        return prefix + "\n" + middleware_block + close
+
+    def _render_middleware(self, middleware: list[dict[str, Any]]) -> str:
+        """
+        Render the middleware list as a HOCON array string.
+
+        :param middleware: List of middleware dicts, each with "class" and optional "args"
+
+        :return: Formatted middleware block as a string, or empty string if none.
+        """
+        if not middleware:
+            return ""
+
+        lines: list[str] = [f'            "{MIDDLEWARE_KEY}": [']
+        for i, entry in enumerate(middleware):
+            lines.append("                {")
+            lines.append(f'                    "class": "{entry["class"]}",')
+            args = entry.get("args")
+            if args:
+                # HOCON is a superset of JSON, so json.dumps emits valid HOCON for every value
+                # type (str/int/float/bool/None/list/dict). Don't try to format these by hand —
+                # Python's str() produces Python repr (single quotes, `None`, etc.) which would
+                # break round-trip for middleware whose args contain lists or dicts.
+                args_lines: list[str] = [f'                        "{k}": {json.dumps(v)}' for k, v in args.items()]
+                lines.append('                    "args": {')
+                lines.append(",\n".join(args_lines))
+                lines.append("                    }")
+            else:
+                # Remove the trailing comma from "class" line since it's the last field
+                lines[-1] = lines[-1].rstrip(",")
+            comma = "," if i < len(middleware) - 1 else ""
+            lines.append(f"                }}{comma}")
+        lines.append("            ]")
+        return "\n".join(lines) + "\n"
 
     def _format_tools(self, tools: list[str]) -> str:
         """

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -342,8 +342,14 @@ class HoconAgentNetworkAssembler(AgentNetworkAssembler):
                 # HOCON is a superset of JSON, so json.dumps emits valid HOCON for every value
                 # type (str/int/float/bool/None/list/dict). Don't try to format these by hand —
                 # Python's str() produces Python repr (single quotes, `None`, etc.) which would
-                # break round-trip for middleware whose args contain lists or dicts.
-                args_lines: list[str] = [f'                        "{k}": {json.dumps(v)}' for k, v in args.items()]
+                # break round-trip for middleware whose args contain lists or dicts. Keys go
+                # through json.dumps too (a quote/backslash in a key must be escaped, not
+                # hand-quoted), with ensure_ascii=False because pyhocon never decodes \uXXXX
+                # escapes in keys — same round-trip quirk the sly_data_schema emitter documents.
+                args_lines: list[str] = [
+                    f"                        {json.dumps(str(k), ensure_ascii=False)}: {json.dumps(v)}"
+                    for k, v in args.items()
+                ]
                 lines.append('                    "args": {')
                 if args_lines:
                     lines.append(",\n".join(args_lines))

--- a/neuro_san_studio/importer/agent_network_importer.py
+++ b/neuro_san_studio/importer/agent_network_importer.py
@@ -174,6 +174,27 @@ class AgentNetworkImporter:
         self._copy_file_or_dir(source, target, dep_path, result, force=force)
         if os.path.isfile(source):
             self._copy_parent_inits(os.path.dirname(source), roots, result, force=force)
+            self._copy_sibling_data_files(source, roots, result, force=force)
+
+    def _copy_sibling_data_files(self, source_file: str, roots: "_Roots", result: ImportResult, force: bool = False):
+        """Copy .hocon data files that live beside a copied module.
+
+        Middleware such as the designer's MiddlewareInfoMiddleware resolves its
+        catalog file relative to its own module as a fallback, so a scaffolded
+        project needs those catalogs colocated
+        exactly as the source ships them — without this, the module imports fine but
+        its data file is missing at runtime.
+        """
+        source_dir = os.path.dirname(source_file)
+        for name in sorted(os.listdir(source_dir)):
+            if not name.endswith(".hocon"):
+                continue
+            sibling = os.path.join(source_dir, name)
+            if not os.path.isfile(sibling):
+                continue
+            rel = os.path.relpath(sibling, roots.source)
+            display = os.path.join(os.path.basename(roots.target), rel)
+            self._copy_file_or_dir(sibling, os.path.join(roots.target, rel), display, result, force=force)
 
     @staticmethod
     def _copy_file_or_dir(source: str, target: str, display: str, result: ImportResult, force: bool = False) -> None:

--- a/neuro_san_studio/importer/agent_network_importer.py
+++ b/neuro_san_studio/importer/agent_network_importer.py
@@ -174,7 +174,11 @@ class AgentNetworkImporter:
         self._copy_file_or_dir(source, target, dep_path, result, force=force)
         if os.path.isfile(source):
             self._copy_parent_inits(os.path.dirname(source), roots, result, force=force)
-            self._copy_sibling_data_files(source, roots, result, force=force)
+            # Sibling catalogs are a Python-module concern (a module resolves its data
+            # file relative to itself); a non-module dependency must not drag its
+            # directory's other .hocon files along.
+            if source.endswith(".py"):
+                self._copy_sibling_data_files(source, roots, result, force=force)
 
     def _copy_sibling_data_files(self, source_file: str, roots: "_Roots", result: ImportResult, force: bool = False):
         """Copy .hocon data files that live beside a copied module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,10 @@ exclude = ["apps*", "build_scripts*", "config*", "deploy*", "docs*", "servers*",
 # Include registries, coded_tools, middleware, and skills directories
 "registries" = ["**/*.hocon"]
 "coded_tools" = ["**/*.py"]
-"middleware" = ["**/*.py"]
+# middleware ships .hocon data catalogs colocated with the modules that read them
+# (e.g. the designer's middleware_info.hocon, resolved
+# relative to their module as a fallback) — package them alongside the code.
+"middleware" = ["**/*.py", "**/*.hocon"]
 "skills" = ["**/*.md", "**/*.py"]
 
 [tool.setuptools_scm]

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -55,9 +55,17 @@
         "serve": true,
         "public": false
     },
-    "agent_network_query_generator.hocon": { 
+    "agent_network_query_generator.hocon": {
         # This is a support network for agent_network_designer
         # We want it served up, but not listed as a public agent network
+        "serve": true,
+        "public": false
+    },
+    "middleware_manager.hocon": {
+        # Support network for agent_network_designer's middleware capability.
+        # Always served so it can be exercised directly; the designer-side
+        # integration that calls it arrives separately. Not listed as a
+        # public agent network.
         "serve": true,
         "public": false
     },

--- a/registries/middleware_manager.hocon
+++ b/registries/middleware_manager.hocon
@@ -1,0 +1,189 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+{
+    # Load the shared LLM configuration from a single source of truth.
+    # This allows users to change the model in one file rather than
+    # modifying the configuration for each agent network.
+    # Note that the file path here is relative to the root level of the repo.
+    include "config/llm_config.hocon",
+    "max_steps": 40000,
+    "max_execution_seconds": 6000,
+
+    "tools": [
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
+        #
+        # Besides the first agent being the front man, these tool definitions
+        # do not have to be in any particular order. How they are linked and
+        # call each other is defined within their own specs.
+        # This could be a graph, potentially even with cycles.
+
+        {
+            "name": "middleware_manager",
+            "function": {
+                "description": "Add or remove middlewares from an agent network definition.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "agent_network_description": {
+                            "type": "string",
+                            "description": """
+                            A full description of the project, business, or company this agent network represents or
+                            a clear description of the change you want to make to the existing agent network.
+                            """
+                        },
+                    },
+                    "required": ["agent_network_description"]
+                }
+            },
+            "instructions": """
+You are responsible for adding or removing middleware from agents in an agent network.
+Only answer inquiries that are directly within your area of expertise. Do not try to help for other matters.
+Do not mention what you can NOT do. Only mention what you can do.
+
+## Context injected into your system prompt
+
+**Current Agent Network Definition** — a JSON object where each key is an agent name and each value
+is a dict with zero or more of these fields:
+- `instructions`: present when the agent is an LLM agent (not a function/coded tool).
+- `tools`: list of down-chain agent or tool names.
+- `middleware`: list of middleware objects currently attached to this agent, each with:
+  - `class`: fully qualified class name of the middleware.
+  - `args` (optional): constructor arguments passed to the middleware.
+
+**Available Middleware** — a JSON object where each key is a middleware identifier and each value contains:
+- `class`: the fully qualified class name used when attaching the middleware.
+- `description`: what the middleware does and when it is appropriate to use.
+- `args`: the schema of optional constructor arguments accepted by the middleware.
+
+## Workflow
+
+1. Read the **Current Agent Network Definition** to identify agents and their existing `middleware` lists.
+2. Read **Available Middleware** to understand what can be added and which `class` string to use.
+3. Based on the `agent_network_description`, decide which agents need middleware added or removed
+   and which middleware class applies.
+4. Call `add_middleware` or `remove_middleware` for each change. Pass the catalog's `class` string
+   as the `middleware_class` argument (the parameter is renamed to avoid colliding with Python's
+   reserved word).
+   - You may make multiple calls if the request affects several agents or middlewares.
+   - Always use the exact `class` string from **Available Middleware** as `middleware_class`.
+   - Only pass `args` to `add_middleware` if `required` field of the middleware is not empty; omit `args` otherwise.
+5. Briefly confirm to the user which middleware were added or removed and on which agents.
+
+## Rules
+
+- Only operate on agents that exist in the **Current Agent Network Definition**.
+- Only agents that have an `instructions` field can have middleware. Do not add middleware to function agents (those without an `instructions` field).
+- Only use middleware classes listed in **Available Middleware**.
+- Do not add a middleware that is already present on the agent.
+- Do not remove a middleware that is not present on the agent.
+- Not all agents need to have middleware. Only add middleware where necessary.
+""",
+            "allow": {
+                "to_upstream": {
+                    # Only the network definition flows back to the designer. The
+                    # middleware catalog (middleware_info) is served from a
+                    # process-wide cache inside MiddlewareInfoMiddleware and never
+                    # needs to travel through sly_data.
+                    "sly_data": ["agent_network_definition"]
+                }
+            },
+            "tools": [
+                "add_middleware",
+                "remove_middleware",
+            ],
+            "middleware": [
+                {
+                    "class": "middleware.agent_network_designer.middleware_info_middleware.MiddlewareInfoMiddleware"
+                },
+                {
+                    "class": "middleware.agent_network_designer.agent_network_definition_middleware.AgentNetworkDefinitionMiddleware",
+                    "args": {
+                        "sly_data": true
+                    }
+                },
+            ]
+        },
+
+        {
+          "name": "add_middleware",
+            "class": "coded_tools.middleware_manager.add_middleware.AddMiddleware",
+            "function": {
+                "description": "Adds middleware to the specified agent.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "agent_name": {
+                            "type": "string",
+                            "description": "The name of the agent to which the middleware will be added."
+                        },
+                        "middleware_class": {
+                            "type": "string",
+                            "description": """
+                            The fully qualified class name of the middleware
+                            (e.g. 'middleware.agent_checklist_middleware.AgentChecklistMiddleware').
+                            Pass the catalog's `class` value here — the parameter is named
+                            `middleware_class` because `class` is a Python reserved word and breaks
+                            pydantic tool-arg validation downstream.
+                            """
+                        },
+                        "args": {
+                            "type": "object",
+                            "description": """
+                            Key-value arguments to pass to the middleware constructor.
+                            Shape depends on the middleware class.
+                            """,
+                        }
+                    },
+                    "required": ["agent_name", "middleware_class"]
+                }
+            }
+        },
+
+        {
+            "name": "remove_middleware",
+            "class": "coded_tools.middleware_manager.remove_middleware.RemoveMiddleware",
+            "function": {
+                "description": "Removes middleware from the specified agent.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "agent_name": {
+                            "type": "string",
+                            "description": "The name of the agent from which the middleware will be removed."
+                        },
+                        "middleware_class": {
+                            "type": "string",
+                            "description": """
+                            The fully qualified class name of the middleware
+                            (e.g. 'middleware.agent_checklist_middleware.AgentChecklistMiddleware').
+                            Pass the catalog's `class` value here — the parameter is named
+                            `middleware_class` because `class` is a Python reserved word and breaks
+                            pydantic tool-arg validation downstream.
+                            """
+                        },
+                    },
+                    "required": ["agent_name", "middleware_class"]
+                }
+            }
+        },
+
+    ]
+}

--- a/tests/coded_tools/agent_network_editor/fake_process_globals_owner.py
+++ b/tests/coded_tools/agent_network_editor/fake_process_globals_owner.py
@@ -1,0 +1,38 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Shared test double for the ProcessGlobals registry tests. Stdlib-only, like
+the tests that use it."""
+
+
+class FakeProcessGlobalsOwner:  # pylint: disable=too-few-public-methods
+    """Stand-in owner class exposing a clear method like the real caches.
+
+    ProcessGlobals reaches owners through sys.modules by module path, so this
+    fake lives in a real importable module: the test importing this class is
+    exactly what makes the module "imported" from the registry's point of view.
+
+    `cleared` is a class-level record (tests clear it before use) because a
+    module-level class cannot close over a test-local list the way the nested
+    class it replaced did.
+    """
+
+    cleared: list[str] = []
+
+    @classmethod
+    def clear_fake_for_testing(cls):
+        """Record that the registry reached this clear method."""
+        cls.cleared.append("cleared")

--- a/tests/coded_tools/agent_network_editor/test_globals.py
+++ b/tests/coded_tools/agent_network_editor/test_globals.py
@@ -22,11 +22,11 @@ modules are only validated when a test run happens to have imported them.
 """
 
 import sys
-import types
 from unittest import TestCase
 from unittest.mock import patch
 
 from coded_tools.agent_network_editor.globals import ProcessGlobals
+from tests.coded_tools.agent_network_editor.fake_process_globals_owner import FakeProcessGlobalsOwner
 
 
 class TestProcessGlobals(TestCase):
@@ -34,33 +34,26 @@ class TestProcessGlobals(TestCase):
 
     def test_clear_all_clears_imported_owners_and_skips_unimported(self):
         """The registry clears imported owners and skips unimported ones."""
-        cleared: list[str] = []
+        FakeProcessGlobalsOwner.cleared.clear()
 
-        class FakeOwner:  # pylint: disable=too-few-public-methods
-            """Stand-in owner class exposing a clear method like the real caches."""
-
-            @classmethod
-            def clear_fake_for_testing(cls):
-                """Record that the registry reached this clear method."""
-                cleared.append("cleared")
-
-        fake_module = types.ModuleType("fake_process_globals_owner_module")
-        fake_module.FakeOwner = FakeOwner
+        # The fake lives in a real module which the import above has placed in
+        # sys.modules, so the registry resolves it exactly like a real owner.
         registry = [
-            ("fake_process_globals_owner_module", "FakeOwner", "clear_fake_for_testing"),
+            (FakeProcessGlobalsOwner.__module__, FakeProcessGlobalsOwner.__name__, "clear_fake_for_testing"),
             # Never imported: must be skipped silently (an unimported module
             # cannot have a populated cache), not raise.
             ("module_that_was_never_imported_for_test", "Nope", "clear_nope_for_testing"),
         ]
-        with patch.dict(sys.modules, {"fake_process_globals_owner_module": fake_module}):
-            with patch.object(ProcessGlobals, "REGISTRY", registry):
-                ProcessGlobals.clear_all_for_testing()
-        self.assertEqual(cleared, ["cleared"])
+        with patch.object(ProcessGlobals, "REGISTRY", registry):
+            ProcessGlobals.clear_all_for_testing()
+        self.assertEqual(FakeProcessGlobalsOwner.cleared, ["cleared"])
 
     def test_registry_entries_resolve_when_imported(self):
         """Registry triples must resolve against any imported owner module."""
         for module_name, class_name, clear_method_name in ProcessGlobals.REGISTRY:
-            self.assertTrue(module_name.startswith("coded_tools."))
+            # Owners live in the designer family's two packages; anything else
+            # in the registry is almost certainly a typo'd module path.
+            self.assertTrue(module_name.startswith(("coded_tools.", "middleware.")))
             # Owner modules need neuro-san, so only validate the ones this test
             # run happens to have imported; a typo'd class or method name in an
             # imported module must fail here rather than being skipped silently.

--- a/tests/middleware/agent_network_designer/fake_model_request.py
+++ b/tests/middleware/agent_network_designer/fake_model_request.py
@@ -1,0 +1,34 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Shared test double for the designer middleware tests."""
+
+from typing import Any
+
+from langchain_core.messages import SystemMessage
+
+
+class FakeModelRequest:  # pylint: disable=too-few-public-methods
+    """Just enough of langchain's ModelRequest for awrap_model_call tests: tools,
+    system_message, and an override() that returns a modified copy."""
+
+    def __init__(self, tools: list[Any] | None = None, system_message: SystemMessage | None = None):
+        self.tools = [] if tools is None else tools
+        self.system_message = system_message
+
+    def override(self, **kwargs) -> "FakeModelRequest":
+        """Mirror ModelRequest.override(): a copy with the given fields replaced."""
+        return FakeModelRequest(kwargs.get("tools", self.tools), kwargs.get("system_message", self.system_message))

--- a/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
@@ -131,14 +131,16 @@ class TestHoconAssemblerSlyDataSchema:
         assert list(http_headers["required"]) == [unicode_url]
 
 
-class TestHoconAssemblerMiddleware:  # pylint: disable=too-few-public-methods
+class TestHoconAssemblerMiddleware:
     """The generated HOCON text round-trips per-agent middleware blocks."""
 
     def test_middleware_round_trips_including_empty_args(self):
         """Per-agent middleware survives the save verbatim — including an explicit
-        empty args dict, which a truthiness check would silently drop."""
+        empty args dict, which a truthiness check would silently drop, and a
+        non-ASCII args key, which ensure_ascii=False keeps verbatim (pyhocon
+        never decodes \\uXXXX escapes in keys)."""
         middleware = [
-            {"class": "some.module.SomeMiddleware", "args": {"k": ["v1", "v2"]}},
+            {"class": "some.module.SomeMiddleware", "args": {"k": ["v1", "v2"], "café": 1}},
             {"class": "other.module.OtherMiddleware", "args": {}},
             {"class": "third.module.ThirdMiddleware"},
         ]
@@ -152,3 +154,21 @@ class TestHoconAssemblerMiddleware:  # pylint: disable=too-few-public-methods
         helper = parse(text)["tools"][1]
         assert helper["name"] == "helper"
         assert helper["middleware"] == middleware
+
+    def test_hostile_args_key_still_emits_parseable_hocon(self):
+        """A double quote in an args key is escaped via json.dumps, so the emitted
+        text stays valid HOCON. Exact round-trip is NOT asserted: pyhocon itself
+        mangles escaped quotes in keys on read-back, which is upstream of the
+        assembler — hand-quoting instead would make the whole save unparseable."""
+        network_def = {
+            "front_man": {
+                "description": "top",
+                "instructions": "Go.",
+                "middleware": [{"class": "some.module.SomeMiddleware", "args": {'he said "hi"': 1}}],
+            },
+        }
+        assembler = HoconAgentNetworkAssembler(demo_mode=False)
+        text = asyncio.run(assembler.assemble_agent_network(network_def, "front_man", "test_net", ["q"], None))
+
+        assert '\\"hi\\"' in text
+        parse(text)  # must not raise

--- a/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
@@ -14,7 +14,7 @@
 #
 # END COPYRIGHT
 
-"""Tests for HoconAgentNetworkAssembler's sly_data_schema emission."""
+"""Tests for HoconAgentNetworkAssembler's sly_data_schema and middleware emission."""
 
 import asyncio
 import os
@@ -129,3 +129,26 @@ class TestHoconAssemblerSlyDataSchema:
         http_headers = parse(text)["tools"][0]["function"]["sly_data_schema"]["properties"]["http_headers"]
         assert [unquote(url) for url in http_headers["properties"]] == [unicode_url]
         assert list(http_headers["required"]) == [unicode_url]
+
+
+class TestHoconAssemblerMiddleware:  # pylint: disable=too-few-public-methods
+    """The generated HOCON text round-trips per-agent middleware blocks."""
+
+    def test_middleware_round_trips_including_empty_args(self):
+        """Per-agent middleware survives the save verbatim — including an explicit
+        empty args dict, which a truthiness check would silently drop."""
+        middleware = [
+            {"class": "some.module.SomeMiddleware", "args": {"k": ["v1", "v2"]}},
+            {"class": "other.module.OtherMiddleware", "args": {}},
+            {"class": "third.module.ThirdMiddleware"},
+        ]
+        network_def = {
+            "front_man": {"description": "top", "instructions": "Go.", "tools": ["helper"]},
+            "helper": {"description": "helps", "instructions": "Help.", "middleware": middleware},
+        }
+        assembler = HoconAgentNetworkAssembler(demo_mode=False)
+        text = asyncio.run(assembler.assemble_agent_network(network_def, "front_man", "test_net", ["q"], None))
+
+        helper = parse(text)["tools"][1]
+        assert helper["name"] == "helper"
+        assert helper["middleware"] == middleware

--- a/tests/middleware/agent_network_designer/test_agent_network_definition_middleware.py
+++ b/tests/middleware/agent_network_designer/test_agent_network_definition_middleware.py
@@ -1,0 +1,481 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for AgentNetworkDefinitionMiddleware.
+
+The S3 reservation path is intentionally not covered here — its underlying storage
+client is synchronous and is slated for replacement, so locking down its current
+behavior with tests would just block that work.
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from langchain_core.messages import AIMessage
+from langchain_core.messages import SystemMessage
+
+from coded_tools.agent_network_editor.constants import AGENT_NETWORK_DEFINITION
+from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
+from middleware.agent_network_designer.agent_network_definition_middleware import AGENT_NETWORK_HOCON_FILE
+from middleware.agent_network_designer.agent_network_definition_middleware import SKIP_DESIGNER
+from middleware.agent_network_designer.agent_network_definition_middleware import AgentNetworkDefinitionMiddleware
+
+
+# Tests legitimately exercise private helpers (the load/parse pipeline is internal to the
+# middleware class) and the suite covers many behaviors in a single class for cohesion.
+# pylint: disable=protected-access,too-many-public-methods
+class TestAgentNetworkDefinitionMiddleware:
+    """Tests for AgentNetworkDefinitionMiddleware (non-S3 paths)."""
+
+    @staticmethod
+    def _make_mw(sly_data: dict | None = None) -> AgentNetworkDefinitionMiddleware:
+        """Build a middleware instance with a pre-seeded aaosa cache so tests don't hit disk."""
+        sly = sly_data if sly_data is not None else {}
+        # Pre-populate aaosa cache so _get_aaosa_instructions short-circuits without reading
+        # registries/aaosa.hocon. Tests that need the real loader can delete this key.
+        sly.setdefault("aaosa_instructions", "")
+        return AgentNetworkDefinitionMiddleware(sly_data=sly)
+
+    # ------------------------------------------------------------------
+    # _parse_agent: extracts instructions, description, tools, middleware
+    # ------------------------------------------------------------------
+
+    def test_parse_agent_returns_none_for_non_dict_entry(self):
+        """Non-dict entries in the `tools` list are skipped."""
+        mw = self._make_mw()
+        name, agent_def = asyncio.run(mw._parse_agent("not a dict", "src"))
+        assert name is None
+        assert agent_def == {}
+
+    def test_parse_agent_returns_none_for_missing_name(self):
+        """An agent without `name` is skipped."""
+        mw = self._make_mw()
+        name, agent_def = asyncio.run(mw._parse_agent({"instructions": "hi"}, "src"))
+        assert name is None
+        assert agent_def == {}
+
+    def test_parse_agent_returns_none_for_empty_name(self):
+        """An empty string name is treated as missing."""
+        mw = self._make_mw()
+        name, _ = asyncio.run(mw._parse_agent({"name": ""}, "src"))
+        assert name is None
+
+    def test_parse_agent_returns_none_for_non_string_instructions(self):
+        """Non-string `instructions` invalidates the whole agent."""
+        mw = self._make_mw()
+        name, _ = asyncio.run(mw._parse_agent({"name": "a", "instructions": 123}, "src"))
+        assert name is None
+
+    def test_parse_agent_returns_none_for_non_string_description(self):
+        """Non-string `function.description` invalidates the whole agent."""
+        mw = self._make_mw()
+        name, _ = asyncio.run(mw._parse_agent({"name": "a", "function": {"description": 42}}, "src"))
+        assert name is None
+
+    def test_parse_agent_extracts_tools(self):
+        """`tools` is copied through; absent middleware does not add a `middleware` key."""
+        mw = self._make_mw()
+        name, agent_def = asyncio.run(mw._parse_agent({"name": "a", "tools": ["b", "c"]}, "src"))
+        assert name == "a"
+        assert agent_def["tools"] == ["b", "c"]
+        assert "middleware" not in agent_def
+
+    def test_parse_agent_extracts_description_from_function(self):
+        """`function.description` is trimmed and stored as `description` on the agent."""
+        mw = self._make_mw()
+        _, agent_def = asyncio.run(
+            mw._parse_agent({"name": "a", "instructions": "hi.", "function": {"description": "  An agent.  "}}, "src")
+        )
+        assert agent_def["description"] == "An agent."
+
+    def test_parse_agent_initializes_blank_description_for_llm_agents(self):
+        """When instructions present, description must exist (even empty) so setters can update it."""
+        mw = self._make_mw()
+        _, agent_def = asyncio.run(mw._parse_agent({"name": "a", "instructions": "hi."}, "src"))
+        assert agent_def.get("description") == ""
+
+    def test_parse_agent_preserves_middleware_list(self):
+        """Middleware on agents must round-trip on load (regression: previously dropped)."""
+        mw = self._make_mw()
+        middleware = [
+            {"class": "langchain.agents.middleware.PIIMiddleware", "args": {"pii_type": "email"}},
+            {
+                "class": "middleware.agent_checklist_middleware.AgentChecklistMiddleware",
+                "args": {"checklist_title": "Audit"},
+            },
+        ]
+        _, agent_def = asyncio.run(
+            mw._parse_agent({"name": "a", "instructions": "hi.", "middleware": middleware}, "src")
+        )
+        assert agent_def["middleware"] == middleware
+
+    def test_parse_agent_drops_middleware_when_not_a_list(self):
+        """Non-list middleware is logged and dropped; the rest of the agent still loads."""
+        mw = self._make_mw()
+        name, agent_def = asyncio.run(
+            mw._parse_agent({"name": "a", "instructions": "hi.", "middleware": "not a list"}, "src")
+        )
+        assert name == "a"
+        assert "middleware" not in agent_def
+        assert agent_def["instructions"] == "hi."
+
+    def test_parse_agent_drops_middleware_when_entries_are_not_dicts(self):
+        """Middleware that is a list but contains non-dict entries is dropped."""
+        mw = self._make_mw()
+        _, agent_def = asyncio.run(mw._parse_agent({"name": "a", "middleware": ["not a dict"]}, "src"))
+        assert "middleware" not in agent_def
+
+    def test_parse_agent_omits_middleware_key_when_empty(self):
+        """An empty middleware list adds no `middleware` key to the agent definition."""
+        mw = self._make_mw()
+        _, agent_def = asyncio.run(mw._parse_agent({"name": "a", "middleware": []}, "src"))
+        assert "middleware" not in agent_def
+
+    # ------------------------------------------------------------------
+    # _config_to_network_def: parses HOCON config's `tools` list
+    # ------------------------------------------------------------------
+
+    def test_config_to_network_def_returns_none_when_tools_missing(self):
+        """A config without the `tools` field reports an actionable error and returns None."""
+        mw = self._make_mw()
+        result = asyncio.run(mw._config_to_network_def({}, "src"))
+        assert result is None
+        assert "No field 'tools' found" in mw.error_message
+
+    def test_config_to_network_def_returns_none_when_tools_not_a_list(self):
+        """`tools` of the wrong type reports an actionable error and returns None."""
+        mw = self._make_mw()
+        result = asyncio.run(mw._config_to_network_def({"tools": "not a list"}, "src"))
+        assert result is None
+        assert "not a list" in mw.error_message
+
+    def test_config_to_network_def_skips_unparseable_agents(self):
+        """A single bad entry does not invalidate sibling entries in the same network."""
+        mw = self._make_mw()
+        config = {
+            "tools": [
+                {"name": "ok", "instructions": "hi."},
+                "not a dict",
+                {"missing_name": True},
+            ]
+        }
+        result = asyncio.run(mw._config_to_network_def(config, "src"))
+        assert list(result.keys()) == ["ok"]
+
+    # ------------------------------------------------------------------
+    # _normalize_network_def: dict pass-through, list (connectivity) → dict
+    # ------------------------------------------------------------------
+
+    def test_normalize_dict_input_passes_through_and_caches(self):
+        """A dict input is returned as-is and stored under AGENT_NETWORK_DEFINITION in sly_data."""
+        sly = {"aaosa_instructions": ""}
+        mw = self._make_mw(sly_data=sly)
+        net = {"a": {"instructions": "hi."}}
+        result = mw._normalize_network_def(net)
+        assert result is net
+        assert sly[AGENT_NETWORK_DEFINITION] is net
+
+    def test_normalize_connectivity_list_is_converted_to_dict(self):
+        """A connectivity-format list is converted to the internal dict format and cached."""
+        sly = {"aaosa_instructions": ""}
+        mw = self._make_mw(sly_data=sly)
+        net_list = [
+            {"origin": "top", "tools": ["worker"]},
+            {"origin": "worker"},
+        ]
+        result = mw._normalize_network_def(net_list)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"top", "worker"}
+        assert sly[AGENT_NETWORK_DEFINITION] is result
+
+    # ------------------------------------------------------------------
+    # format_definition_prompt: markdown-fenced JSON block
+    # ------------------------------------------------------------------
+
+    def test_format_definition_prompt_emits_round_trippable_json(self):
+        """The injected system-prompt section is a markdown-fenced JSON block we can re-parse."""
+        mw = self._make_mw()
+        prompt = mw.format_definition_prompt({"a": {"instructions": "hi."}})
+        assert prompt.startswith("## Current Agent Network Definition")
+        body = prompt.split("```json\n", 1)[1].rsplit("\n```", 1)[0]
+        assert json.loads(body) == {"a": {"instructions": "hi."}}
+
+    # ------------------------------------------------------------------
+    # _resolve_hocon_path: input validation + cwd vs base_dir resolution
+    # ------------------------------------------------------------------
+
+    def test_resolve_hocon_path_returns_none_for_non_string(self):
+        """None input is rejected with an `expected non-empty string` error."""
+        mw = self._make_mw()
+        assert mw._resolve_hocon_path(None) is None
+        assert "expected non-empty string" in mw.error_message
+
+    def test_resolve_hocon_path_returns_none_for_whitespace_only(self):
+        """Whitespace-only input is rejected with an `expected non-empty string` error."""
+        mw = self._make_mw()
+        assert mw._resolve_hocon_path("   ") is None
+        assert "expected non-empty string" in mw.error_message
+
+    def test_resolve_hocon_path_passes_through_absolute(self):
+        """A POSIX-absolute input is returned unchanged."""
+        mw = self._make_mw()
+        assert mw._resolve_hocon_path("/abs/path/to/file.hocon") == "/abs/path/to/file.hocon"
+
+    def test_resolve_hocon_path_keeps_existing_cwd_relative_path_as_is(self):
+        """A relative path that resolves to an existing file under cwd is used as-is."""
+        mw = self._make_mw()
+        with patch.object(Path, "is_file", return_value=True):
+            result = mw._resolve_hocon_path("registries/generated/foo.hocon")
+        assert result == "registries/generated/foo.hocon"
+
+    def test_resolve_hocon_path_falls_through_to_manifest_base_dir(self):
+        """Non-existent relative input is joined to AGENT_MANIFEST_FILE's directory."""
+        mw = self._make_mw()
+        with patch.dict(os.environ, {"AGENT_MANIFEST_FILE": "registries/manifest.hocon"}):
+            result = mw._resolve_hocon_path("foo.hocon")
+        assert result == "registries/foo.hocon"
+
+    # ------------------------------------------------------------------
+    # _hocon_to_config: disk reads and error reporting
+    # ------------------------------------------------------------------
+
+    def test_hocon_to_config_reads_valid_file(self):
+        """A valid HOCON file is parsed into a dict and no error_message is set."""
+        mw = self._make_mw()
+        with tempfile.NamedTemporaryFile("w", suffix=".hocon", delete=False) as f:
+            f.write('{ "tools": [{"name": "a"}] }')
+            path = f.name
+        try:
+            config = asyncio.run(mw._hocon_to_config(path))
+            assert config["tools"][0]["name"] == "a"
+            assert mw.error_message == ""
+        finally:
+            os.unlink(path)
+
+    def test_hocon_to_config_sets_error_for_missing_file(self):
+        """A missing file path is reported via error_message and the return is None."""
+        mw = self._make_mw()
+        result = asyncio.run(mw._hocon_to_config("/definitely/not/a/file.hocon"))
+        assert result is None
+        assert "not found" in mw.error_message.lower()
+
+    # ------------------------------------------------------------------
+    # _hocon_to_definition: end-to-end load round trip
+    # ------------------------------------------------------------------
+
+    def test_hocon_to_definition_round_trip_preserves_middleware(self):
+        """End-to-end HOCON → network_def keeps every agent's middleware array intact."""
+        mw = self._make_mw()
+        hocon = (
+            "{"
+            '"tools": ['
+            '  {"name": "top", "function": {"description": "Top"},'
+            '   "instructions": "I am the top.", "tools": ["worker"],'
+            '   "middleware": [{"class": "X", "args": {"k": "v"}}]},'
+            '  {"name": "worker", "function": {"description": "Worker"},'
+            '   "instructions": "I am the worker.",'
+            '   "middleware": [{"class": "Y"}]}'
+            "]}"
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".hocon", delete=False) as f:
+            f.write(hocon)
+            path = f.name
+        try:
+            net = asyncio.run(mw._hocon_to_definition(path))
+            assert set(net.keys()) == {"top", "worker"}
+            assert net["top"]["middleware"] == [{"class": "X", "args": {"k": "v"}}]
+            assert net["worker"]["middleware"] == [{"class": "Y"}]
+            assert net["top"]["tools"] == ["worker"]
+        finally:
+            os.unlink(path)
+
+    # ------------------------------------------------------------------
+    # _resolve_network_def: source-precedence
+    # ------------------------------------------------------------------
+
+    def test_resolve_prefers_sly_data_definition_over_hocon_file(self):
+        """A definition already in sly_data wins over the configured hocon_file."""
+        existing = {"top": {"instructions": "hi."}}
+        sly = {
+            "aaosa_instructions": "",
+            AGENT_NETWORK_DEFINITION: existing,
+            AGENT_NETWORK_HOCON_FILE: "ignored.hocon",
+        }
+        mw = self._make_mw(sly_data=sly)
+        assert asyncio.run(mw._resolve_network_def()) is existing
+
+    def test_resolve_loads_from_hocon_when_no_definition_in_sly_data(self):
+        """When sly_data has no definition, the hocon file is read and the name is auto-set."""
+        sly = {"aaosa_instructions": ""}
+        mw = self._make_mw(sly_data=sly)
+        with tempfile.NamedTemporaryFile("w", suffix=".hocon", delete=False) as f:
+            f.write('{"tools": [{"name": "a", "instructions": "hi."}]}')
+            path = f.name
+        try:
+            sly[AGENT_NETWORK_HOCON_FILE] = path
+            result = asyncio.run(mw._resolve_network_def())
+            assert "a" in result
+            # The agent network name is auto-set from the file stem on hocon load.
+            assert sly[AGENT_NETWORK_NAME] == Path(path).stem
+        finally:
+            os.unlink(path)
+
+    def test_resolve_returns_none_when_no_source(self):
+        """When sly_data has no definition and no hocon_file, the resolver returns None."""
+        mw = self._make_mw()
+        assert asyncio.run(mw._resolve_network_def()) is None
+
+    # ------------------------------------------------------------------
+    # abefore_model: orchestration + error/skip-designer routing
+    # ------------------------------------------------------------------
+
+    def test_abefore_model_returns_none_when_no_definition_anywhere(self):
+        """No definition source means the agent is free to respond without injection."""
+        mw = self._make_mw()
+        result = asyncio.run(mw.abefore_model(state={}, runtime=None))
+        assert result is None
+        assert mw.network_def is None
+
+    def test_abefore_model_jumps_to_end_when_resolve_errors(self):
+        """A missing hocon file surfaces as an AIMessage and a jump_to=end."""
+        sly = {"aaosa_instructions": "", AGENT_NETWORK_HOCON_FILE: "/does/not/exist.hocon"}
+        mw = self._make_mw(sly_data=sly)
+        result = asyncio.run(mw.abefore_model(state={}, runtime=None))
+        assert result["jump_to"] == "end"
+        assert isinstance(result["messages"][0], AIMessage)
+        assert "not found" in result["messages"][0].content.lower()
+
+    def test_abefore_model_reports_missing_agent_network_name(self):
+        """A definition present without a name is a user error; report it actionably."""
+        sly = {"aaosa_instructions": "", AGENT_NETWORK_DEFINITION: {"a": {"instructions": "hi."}}}
+        mw = self._make_mw(sly_data=sly)
+        result = asyncio.run(mw.abefore_model(state={}, runtime=None))
+        assert result["jump_to"] == "end"
+        assert AGENT_NETWORK_NAME in result["messages"][0].content
+
+    def test_abefore_model_skip_designer_jumps_to_end_with_acknowledgement(self):
+        """`skip_designer=True` short-circuits the LLM and acknowledges the user-supplied network."""
+        sly = {
+            "aaosa_instructions": "",
+            AGENT_NETWORK_DEFINITION: {"a": {"instructions": "hi."}},
+            AGENT_NETWORK_NAME: "my_net",
+            SKIP_DESIGNER: True,
+        }
+        mw = self._make_mw(sly_data=sly)
+        result = asyncio.run(mw.abefore_model(state={}, runtime=None))
+        assert result["jump_to"] == "end"
+        assert "my_net" in result["messages"][0].content
+
+    def test_abefore_model_normal_path_returns_none_and_caches_definition(self):
+        """Happy path: a valid sly_data definition + name resolves, caches, and lets the agent proceed."""
+        net = {"a": {"instructions": "hi."}}
+        sly = {"aaosa_instructions": "", AGENT_NETWORK_DEFINITION: net, AGENT_NETWORK_NAME: "my_net"}
+        mw = self._make_mw(sly_data=sly)
+        result = asyncio.run(mw.abefore_model(state={}, runtime=None))
+        assert result is None
+        assert mw.network_def == net
+
+    # ------------------------------------------------------------------
+    # awrap_model_call: system-prompt injection
+    # ------------------------------------------------------------------
+
+    def test_awrap_passes_through_when_no_definition(self):
+        """With no network_def, the handler is invoked with the original request unmodified."""
+        mw = self._make_mw()
+        mw.network_def = None
+
+        request = MagicMock()
+        handler = AsyncMock(return_value="response")
+        result = asyncio.run(mw.awrap_model_call(request, handler))
+        assert result == "response"
+        handler.assert_awaited_once_with(request)
+        request.override.assert_not_called()
+
+    def test_awrap_appends_to_existing_system_message(self):
+        """An existing SystemMessage is preserved and the definition block is appended to it."""
+        mw = self._make_mw()
+        mw.network_def = {"a": {"instructions": "hi."}}
+
+        original = SystemMessage(content="ORIGINAL")
+        request = MagicMock()
+        request.system_message = original
+        new_request = MagicMock()
+        request.override.return_value = new_request
+        handler = AsyncMock(return_value="response")
+
+        result = asyncio.run(mw.awrap_model_call(request, handler))
+
+        assert result == "response"
+        request.override.assert_called_once()
+        forwarded_system = request.override.call_args.kwargs["system_message"]
+        assert "ORIGINAL" in forwarded_system.content
+        assert "Current Agent Network Definition" in forwarded_system.content
+        handler.assert_awaited_once_with(new_request)
+
+    def test_awrap_creates_system_message_when_none_present(self):
+        """When the request has no SystemMessage, a fresh one is created with just the definition."""
+        mw = self._make_mw()
+        mw.network_def = {"a": {"instructions": "hi."}}
+
+        request = MagicMock()
+        request.system_message = None
+        request.override.return_value = MagicMock()
+        handler = AsyncMock(return_value="ok")
+
+        asyncio.run(mw.awrap_model_call(request, handler))
+
+        forwarded = request.override.call_args.kwargs["system_message"]
+        assert isinstance(forwarded, SystemMessage)
+        assert "Current Agent Network Definition" in forwarded.content
+
+    # ------------------------------------------------------------------
+    # _extract_custom_instructions: strips boilerplate (prefix, aaosa, demo)
+    # ------------------------------------------------------------------
+
+    def test_extract_custom_instructions_strips_prefix(self):
+        """The standard `You are part of a <noun> of assistants...` prefix is removed."""
+        mw = self._make_mw(sly_data={"aaosa_instructions": ""})
+        full = (
+            "You are part of a team of assistants. "
+            "Only answer inquiries that are directly within your area of expertise. "
+            "Do not try to help for other matters. "
+            "Do not mention what you can NOT do. Only mention what you can do. "
+            "Custom body here."
+        )
+        result = asyncio.run(mw._extract_custom_instructions(full))
+        assert result == "Custom body here."
+
+    def test_extract_custom_instructions_strips_demo_mode(self):
+        """The demo_mode boilerplate sentence is removed."""
+        mw = self._make_mw(sly_data={"aaosa_instructions": ""})
+        demo = (
+            "You are part of a demo system, so when queried, make up a realistic response as if "
+            "you are actually grounded in real data or you are operating a real application API or microservice."
+        )
+        result = asyncio.run(mw._extract_custom_instructions(f"{demo} Real body."))
+        assert result == "Real body."
+
+    def test_extract_custom_instructions_strips_aaosa_when_cached(self):
+        """The aaosa instructions stored in sly_data are stripped from the agent's instructions."""
+        mw = self._make_mw(sly_data={"aaosa_instructions": "AAOSA TEXT"})
+        result = asyncio.run(mw._extract_custom_instructions("Body. AAOSA TEXT"))
+        assert result == "Body."

--- a/tests/middleware/agent_network_designer/test_agent_network_definition_middleware.py
+++ b/tests/middleware/agent_network_designer/test_agent_network_definition_middleware.py
@@ -144,6 +144,21 @@ class TestAgentNetworkDefinitionMiddleware:
         _, agent_def = asyncio.run(mw._parse_agent({"name": "a", "middleware": ["not a dict"]}, "src"))
         assert "middleware" not in agent_def
 
+    def test_parse_agent_drops_middleware_when_entry_lacks_class(self):
+        """Entries without a non-empty string `class` would crash the assembler on save."""
+        mw = self._make_mw()
+        for bad_entry in [{"args": {"k": "v"}}, {"class": ""}, {"class": "   "}, {"class": 42}]:
+            _, agent_def = asyncio.run(mw._parse_agent({"name": "a", "middleware": [bad_entry]}, "src"))
+            assert "middleware" not in agent_def, f"entry {bad_entry!r} should not be preserved"
+
+    def test_parse_agent_drops_middleware_when_entry_args_not_a_dict(self):
+        """Entries whose `args` is not a dict would crash the assembler's args.items() on save."""
+        mw = self._make_mw()
+        _, agent_def = asyncio.run(
+            mw._parse_agent({"name": "a", "middleware": [{"class": "X", "args": ["not", "a", "dict"]}]}, "src")
+        )
+        assert "middleware" not in agent_def
+
     def test_parse_agent_omits_middleware_key_when_empty(self):
         """An empty middleware list adds no `middleware` key to the agent definition."""
         mw = self._make_mw()

--- a/tests/middleware/agent_network_designer/test_middleware_info_middleware.py
+++ b/tests/middleware/agent_network_designer/test_middleware_info_middleware.py
@@ -1,0 +1,146 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for MiddlewareInfoMiddleware: prompt injection, graceful degradation on a
+missing/broken catalog, and process-wide caching."""
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from langchain_core.messages import SystemMessage
+from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
+
+from middleware.agent_network_designer.middleware_info_middleware import MiddlewareInfoMiddleware
+from tests.middleware.agent_network_designer.fake_model_request import FakeModelRequest
+
+
+class TestMiddlewareInfoMiddleware:
+    """Tests for MiddlewareInfoMiddleware."""
+
+    @staticmethod
+    def _install_catalog(tmp_path: Path, monkeypatch, catalog: dict[str, Any] | None = None) -> Path:
+        """Write a catalog file (JSON is valid HOCON) and point AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE at it."""
+        if catalog is None:
+            catalog = {"pii_middleware": {"class": "middleware.pii.PII", "args": {}}}
+        catalog_file = tmp_path / "middleware_info.hocon"
+        catalog_file.write_text(json.dumps(catalog), encoding="utf-8")
+        monkeypatch.setenv("AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE", str(catalog_file))
+        return catalog_file
+
+    def test_catalog_injected_into_system_prompt(self, tmp_path, monkeypatch):
+        """The catalog is appended to the system prompt as an Available Middleware section."""
+        self._install_catalog(tmp_path, monkeypatch)
+        handler = AsyncMock(return_value="model-response")
+        request = FakeModelRequest(system_message=SystemMessage(content="base"))
+
+        result = asyncio.run(MiddlewareInfoMiddleware().awrap_model_call(request, handler))
+
+        assert result == "model-response"
+        seen_content = handler.await_args.args[0].system_message.content
+        assert seen_content.startswith("base")
+        assert "## Available Middleware" in seen_content
+        assert "pii_middleware" in seen_content
+
+    def test_missing_catalog_degrades_gracefully(self, tmp_path, monkeypatch, caplog):
+        """A missing catalog warns and skips injection instead of failing the model call."""
+        monkeypatch.setenv("AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE", str(tmp_path / "nope.hocon"))
+        handler = AsyncMock(return_value="model-response")
+        request = FakeModelRequest(system_message=SystemMessage(content="base"))
+
+        with caplog.at_level("WARNING"):
+            result = asyncio.run(MiddlewareInfoMiddleware().awrap_model_call(request, handler))
+
+        assert result == "model-response"
+        assert "could not be loaded" in caplog.text
+        # The request went through unmodified.
+        assert handler.await_args.args[0].system_message.content == "base"
+
+    def test_corrupt_catalog_degrades_then_recovers_after_fix(self, tmp_path, monkeypatch, caplog):
+        """A corrupt catalog is retried, not cached: fixing the file recovers injection."""
+        catalog_file = tmp_path / "middleware_info.hocon"
+        catalog_file.write_text("{ this is : : not valid hocon }}", encoding="utf-8")
+        monkeypatch.setenv("AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE", str(catalog_file))
+        handler = AsyncMock(return_value="model-response")
+        middleware = MiddlewareInfoMiddleware()
+
+        with caplog.at_level("WARNING"):
+            asyncio.run(middleware.awrap_model_call(FakeModelRequest(), handler))
+        assert "could not be loaded" in caplog.text
+
+        catalog_file.write_text(json.dumps({"pii_middleware": {"class": "x"}}), encoding="utf-8")
+        asyncio.run(middleware.awrap_model_call(FakeModelRequest(), handler))
+        assert "## Available Middleware" in handler.await_args.args[0].system_message.content
+
+    def test_root_list_catalog_degrades_gracefully(self, tmp_path, monkeypatch, caplog):
+        """A root-level array is not a catalog: warn and skip, and never publish it
+        (so no AttributeError-per-call until an mtime change)."""
+        catalog_file = tmp_path / "middleware_info.hocon"
+        catalog_file.write_text('[{"class": "x"}]', encoding="utf-8")
+        monkeypatch.setenv("AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE", str(catalog_file))
+        handler = AsyncMock(return_value="model-response")
+        middleware = MiddlewareInfoMiddleware()
+
+        with caplog.at_level("WARNING"):
+            result = asyncio.run(middleware.awrap_model_call(FakeModelRequest(), handler))
+
+        assert result == "model-response"
+        assert "could not be loaded" in caplog.text
+        # Fixing the file recovers on the next call — nothing bad was cached.
+        catalog_file.write_text(json.dumps({"pii_middleware": {"class": "x"}}), encoding="utf-8")
+        asyncio.run(middleware.awrap_model_call(FakeModelRequest(), handler))
+        assert "## Available Middleware" in handler.await_args.args[0].system_message.content
+
+    def test_bundled_catalog_is_the_fallback_when_cwd_has_no_copy(self, tmp_path, monkeypatch):
+        """With no env var and no repo/project-layout copy in the working directory,
+        the catalog bundled next to the middleware module is used."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE", raising=False)
+        handler = AsyncMock(return_value="model-response")
+
+        result = asyncio.run(MiddlewareInfoMiddleware().awrap_model_call(FakeModelRequest(), handler))
+
+        assert result == "model-response"
+        assert "## Available Middleware" in handler.await_args.args[0].system_message.content
+
+    def test_empty_env_var_degrades_with_warning(self, monkeypatch, caplog):
+        """AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE="" warns and skips instead of silently injecting nothing."""
+        monkeypatch.setenv("AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE", "")
+        handler = AsyncMock(return_value="model-response")
+
+        with caplog.at_level("WARNING"):
+            result = asyncio.run(MiddlewareInfoMiddleware().awrap_model_call(FakeModelRequest(), handler))
+
+        assert result == "model-response"
+        assert "empty string" in caplog.text
+
+    def test_catalog_loaded_once_across_instances(self, tmp_path, monkeypatch):
+        """Two instances (two 'sessions') share one parse of the catalog file."""
+        self._install_catalog(tmp_path, monkeypatch)
+        handler = AsyncMock(return_value="model-response")
+
+        # Spy on the file parse itself: with autospec the original method still
+        # runs (captured before patching, so no recursion), and the call count
+        # tells us how many times the file was actually read.
+        real_restore = AbstractAsyncConfigRestorer.restore
+        with patch.object(AbstractAsyncConfigRestorer, "restore", autospec=True, side_effect=real_restore) as spy:
+            for _ in range(2):
+                asyncio.run(MiddlewareInfoMiddleware().awrap_model_call(FakeModelRequest(), handler))
+
+        assert spy.call_count == 1

--- a/tests/neuro_san_studio/commands/test_agent_network_importer.py
+++ b/tests/neuro_san_studio/commands/test_agent_network_importer.py
@@ -27,19 +27,19 @@ from neuro_san_studio.discovery.dependency_analyzer import AgentNetworkDependenc
 from neuro_san_studio.importer.agent_network_importer import AgentNetworkImporter
 
 
-def _read_manifest_keys(manifest_path: Path) -> set:
-    """Read a manifest.hocon (with possible includes) into a set of declared keys."""
-    prev_cwd = os.getcwd()
-    try:
-        os.chdir(manifest_path.parent.parent)
-        raw = RawManifestRestorer().restore(file_reference=str(manifest_path))
-    finally:
-        os.chdir(prev_cwd)
-    return {key.strip('"') for key in raw if isinstance(key, str)}
-
-
 class TestImportNetwork:
     """Integration tests for AgentNetworkImporter."""
+
+    @staticmethod
+    def _read_manifest_keys(manifest_path: Path) -> set:
+        """Read a manifest.hocon (with possible includes) into a set of declared keys."""
+        prev_cwd = os.getcwd()
+        try:
+            os.chdir(manifest_path.parent.parent)
+            raw = RawManifestRestorer().restore(file_reference=str(manifest_path))
+        finally:
+            os.chdir(prev_cwd)
+        return {key.strip('"') for key in raw if isinstance(key, str)}
 
     @staticmethod
     def _build_fake_source(source_dir: Path) -> None:
@@ -84,6 +84,27 @@ class TestImportNetwork:
         assert (target_dir / "middleware" / "music_nerd" / "__init__.py").is_file()
         # Shared registry includes ride along.
         assert (target_dir / "registries" / "aaosa.hocon").is_file()
+        assert not result.errors
+
+    def test_import_copies_hocon_data_files_beside_middleware(self, tmp_path: Path) -> None:
+        """Data catalogs colocated with a copied middleware module ride along.
+
+        The designer's MiddlewareInfoMiddleware resolves its catalog hocon relative
+        to its own module as a fallback, so a scaffolded project must receive it
+        exactly where the source ships it.
+        """
+        source_dir = tmp_path / "source"
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+        self._build_fake_source(source_dir)
+        (source_dir / "middleware" / "music_nerd" / "catalog.hocon").write_text('{ "entry": {} }\n')
+
+        importer = AgentNetworkImporter(str(source_dir), str(target_dir))
+        deps = AgentNetworkDependencies(middleware=["middleware/music_nerd/logger.py"])
+
+        result = importer.import_network("basic/music_nerd.hocon", deps)
+
+        assert (target_dir / "middleware" / "music_nerd" / "catalog.hocon").is_file()
         assert not result.errors
 
     def test_sub_networks_are_registered_in_manifest_entries(self, tmp_path: Path) -> None:
@@ -146,7 +167,7 @@ class TestImportNetwork:
         importer = AgentNetworkImporter(str(tmp_path / "source"), str(target_dir))
         importer.update_manifest(["basic/music_nerd.hocon", "agent_network_designer.hocon"])
 
-        merged = _read_manifest_keys(manifest_path)
+        merged = self._read_manifest_keys(manifest_path)
         assert merged == {
             "agent_network_designer.hocon",
             "basic/coffee_finder.hocon",
@@ -160,7 +181,7 @@ class TestImportNetwork:
         importer.update_manifest(["basic/music_nerd.hocon"])
 
         manifest_path = target_dir / "registries" / "manifest.hocon"
-        assert _read_manifest_keys(manifest_path) == {"basic/music_nerd.hocon"}
+        assert self._read_manifest_keys(manifest_path) == {"basic/music_nerd.hocon"}
 
     def test_update_manifest_preserves_include_directive(self, tmp_path: Path) -> None:
         """The scaffolded `include "registries/generated/manifest.hocon"` line must survive imports.
@@ -196,7 +217,7 @@ class TestImportNetwork:
         # music_nerd.hocon was already declared — never duplicated, never re-emitted.
         assert text.count('"music_nerd.hocon"') == 1
         # Both new entries got registered.
-        keys = _read_manifest_keys(manifest_path)
+        keys = self._read_manifest_keys(manifest_path)
         assert "agent_network_designer.hocon" in keys
         assert "advanced_calculator.hocon" in keys
         assert "music_nerd.hocon" in keys

--- a/tests/neuro_san_studio/commands/test_agent_network_importer.py
+++ b/tests/neuro_san_studio/commands/test_agent_network_importer.py
@@ -107,6 +107,24 @@ class TestImportNetwork:
         assert (target_dir / "middleware" / "music_nerd" / "catalog.hocon").is_file()
         assert not result.errors
 
+    def test_sibling_hocon_copy_is_scoped_to_python_modules(self, tmp_path: Path) -> None:
+        """A non-Python dependency file must not drag its directory's other .hocon files along."""
+        source_dir = tmp_path / "source"
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+        self._build_fake_source(source_dir)
+        (source_dir / "middleware" / "music_nerd" / "notes.hocon").write_text('{ "notes": {} }\n')
+        (source_dir / "middleware" / "music_nerd" / "unrelated.hocon").write_text('{ "unrelated": {} }\n')
+
+        importer = AgentNetworkImporter(str(source_dir), str(target_dir))
+        deps = AgentNetworkDependencies(middleware=["middleware/music_nerd/notes.hocon"])
+
+        result = importer.import_network("basic/music_nerd.hocon", deps)
+
+        assert (target_dir / "middleware" / "music_nerd" / "notes.hocon").is_file()
+        assert not (target_dir / "middleware" / "music_nerd" / "unrelated.hocon").exists()
+        assert not result.errors
+
     def test_sub_networks_are_registered_in_manifest_entries(self, tmp_path: Path) -> None:
         """import_network must record both the top-level network AND every sub-network for manifest registration.
 


### PR DESCRIPTION
Split out of #1191 (first of two PRs, per the review discussion there). This PR adds the middleware infrastructure so it can land and be exercised on its own; the designer-side integration that makes the Agent Network Designer use it arrives separately in #1191, which will be rebased onto this.

## What's in

### middleware_manager agent network
- `registries/middleware_manager.hocon` + manifest entry: a front man with `add_middleware` / `remove_middleware` coded tools that edit the `middleware` list of an agent in the network definition held in sly_data.
- Served so it can be exercised directly, but **not listed as a public network and nothing calls it yet** — this ships dark, off-by-default behavior is unchanged.
- Shared `MiddlewareRequestGuard` validates tool arguments (network definition present, agent name known, middleware `class` present) and raises `ValueError` per the framework's error_formatter contract.

### Designer middleware infrastructure
- `MiddlewareInfoMiddleware`: injects the middleware-info catalog into the designer family's system prompt so the LLM knows which middleware classes exist and what their `args` mean.
- `HoconCatalogCache`: env-var → cwd → bundled resolution for the catalog path, `(path, size, mtime_ns)` fingerprint refresh, `CatalogLoadError` normalization of the many hocon failure modes; built on the existing `SharedProcessCache`.
- Catalog file `middleware/agent_network_designer/middleware_info.hocon`, bundled via pyproject package-data and overridable with `AGENT_NETWORK_DESIGNER_MIDDLEWARE_INFO_FILE` (documented in `.env.example` and both Dockerfiles).

### Persistence round trip (standalone bug fix)
Hand-written `middleware` blocks were silently stripped when a network was saved or exported. The hocon/deployable assemblers and the connectivity converter now preserve them, with `MIDDLEWARE_KEY` added to the shared constants module. This part is a fix worth having regardless of the designer integration.

### Supporting changes
- `ProcessGlobals` registry entry for the new process-wide cache.
- Refactor-map pointer comments in `get_toolbox` / `get_subnetwork` / `get_mcp_tool`, which share the catalog-cache shape and are planned to become middlewares later.
- The importer now copies sibling non-manifest hocon files so exported networks keep their catalogs.

## Verification
- ruff format/check clean; pylint 10.00/10 with no emitted messages.
- `pytest -m "not integration"`: 868 passed, 4 skipped.
