### PR TITLE
Add Neuro-Donn Devin network

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -37,6 +37,7 @@ Here are a few examples ordered by level of complexity.
     - [Gemini Image Generation](#gemini-image-generation)
     - [Wikimedia Search](#wikimedia-search)
     - [Internet Info Gatherer](#internet-info-gatherer)
+    - [Neuro-Donn](#neuro-donn)
     - [Gmail Assistant](#gmail-assistant)
     - [Google Workspace Assistant](#google-workspace-assistant)
     - [Agent Network HTML Creator](#agent-network-html-creator)
@@ -318,6 +319,15 @@ the promising pages with the `web_fetch` toolbox tool so its answers come from a
 It needs no API keys or OAuth — the free search tier and the local fetch tool work out of the box.
 
 **Tags:** `tool`, `MCP`, `toolbox`, `web`
+
+### Neuro-Donn
+
+[Neuro-Donn](examples/tools/neuro_donn.md) helps colleagues describe work in plain language, finds a matching Devin
+playbook when the request is recurring or procedural, or recognizes when a one-off request should go directly to Devin.
+It confirms the request and selected playbook before launching a Devin session, then returns the session URL. Every
+session is tagged `neuro-donn`.
+
+**Tags:** `tool`, `MCP`, `Devin`, `playbook`
 
 ### Gmail Assistant
 

--- a/docs/examples/tools/neuro_donn.md
+++ b/docs/examples/tools/neuro_donn.md
@@ -2,9 +2,8 @@
 
 **Neuro-Donn** is a front man for starting work in Devin. Describe a task in plain language and it first looks for the
 matching Devin playbook. Only a plainly one-off code change in a named repository goes directly to Devin without a
-playbook lookup. It chooses the playbook and launches a Devin session immediately, states any assumptions it made, and
-hands back the session URL. It can also report back on a launched session, so the answer arrives in this chat instead
-of only in the Devin session. Every session it launches is tagged `neuro-donn`.
+playbook lookup. It chooses the playbook and launches the work immediately, states any assumptions it made, and reports
+the answer in chat. Every task it launches is tagged `neuro-donn`.
 
 ## What You Can Do
 
@@ -36,17 +35,16 @@ proceeds; you can correct it afterwards if it got the request or routing wrong.
 
 ### Get the answer back in this chat
 
-After a launch Neuro-Donn waits for the session on its own and reports the answer here, so you do not have to ask.
-You can also ask again at any time:
+After a launch Neuro-Donn tells you what it is running, then waits and reports the answer here, so you do not have to
+ask. You can ask again at any time:
 
 ```text
-What is the result of the session you just launched?
+How is that going, and what did it find?
 ```
 
-For short tasks it waits for the session to settle, up to a few minutes, and then gives you the session's answer
-along with any pull request links. For longer work it reports the current status and the session's most recent
-message, and you can ask again later. Devin sessions frequently outlive a single chat turn, so treat the waiting
-behavior as a convenience for quick tasks rather than a guarantee.
+For short tasks it waits up to a few minutes and then gives you the answer along with any pull request links. For
+longer work it reports the current status and most recent message, and you can ask again later. Devin work frequently
+outlives a single chat turn, so treat the waiting behavior as a convenience for quick tasks rather than a guarantee.
 
 ### Expect Donn's voice, not Donn
 
@@ -131,7 +129,8 @@ Keeping these responsibilities separate makes routing more reliable and limits a
   provide headers, client `sly_data` takes precedence.
 - **No playbook matches:** Neuro-Donn should say that no playbook matches, launch a plain Devin task immediately, and
   state any assumptions it made. Correct the request afterwards if its interpretation was wrong.
-- **An unwanted session launched:** Neuro-Donn launches without asking for confirmation. If it misunderstood a request
-  or chose the wrong playbook, correct the assumption in chat and terminate the unwanted session in the Devin UI.
-- **Result never arrives in chat:** Long sessions do not finish within a chat turn. Ask again later, or open the
-  session URL. `devin_session_gather` waits at most 590 seconds per call.
+- **An unwanted task launched:** Neuro-Donn launches without asking for confirmation. If it misunderstood a request or
+  chose the wrong playbook, correct the assumption in chat and stop the unwanted work in the Devin UI.
+- **Result never arrives in chat:** Long-running work may not finish within a chat turn. Ask again in chat; the work
+  remains visible in the Devin UI to whoever owns the configured PAT. `devin_session_gather` waits at most 590 seconds
+  per call.

--- a/docs/examples/tools/neuro_donn.md
+++ b/docs/examples/tools/neuro_donn.md
@@ -1,10 +1,10 @@
 # Neuro-Donn
 
-**Neuro-Donn** is a front man for starting work in Devin. Describe a task in plain language and it finds the matching
-Devin playbook when there is one, or recognizes that the request is an ad-hoc task with no playbook. It chooses the
-playbook and launches a Devin session immediately, states any assumptions it made, and hands back the session URL. It can
-also report back on a launched session, so the answer arrives in this chat instead of only in the Devin session. Every
-session it launches is tagged `neuro-donn`.
+**Neuro-Donn** is a front man for starting work in Devin. Describe a task in plain language and it first looks for the
+matching Devin playbook. Only a plainly one-off code change in a named repository goes directly to Devin without a
+playbook lookup. It chooses the playbook and launches a Devin session immediately, states any assumptions it made, and
+hands back the session URL. It can also report back on a launched session, so the answer arrives in this chat instead
+of only in the Devin session. Every session it launches is tagged `neuro-donn`.
 
 ## What You Can Do
 
@@ -18,20 +18,21 @@ Create a unileaf user in Auth0 for jane@example.com
 ```
 
 Neuro-Donn searches the available Devin playbooks, reads the most plausible matches, and launches the most plausible
-match immediately. It tells you the selected playbook's title, ID, and purpose, along with any assumptions it made.
+match immediately. The matched playbook may cover more ground than the request spelled out; Neuro-Donn tells you the
+selected playbook's title, ID, and purpose, along with any assumptions it made.
 
-### Send an ad-hoc task directly to Devin
+### Send a plainly one-off code change directly to Devin
 
-One-off work does not need a playbook. Code changes, bug fixes, investigations, and questions about a repository can
-go straight to Devin:
+Only a plainly one-off code change in a named repository skips playbook lookup. For example:
 
 ```text
 Fix the failing configuration test in my current repository
 ```
 
-Neuro-Donn identifies this as a direct Devin task, skips playbook lookup, and launches a plain Devin session
-immediately. If it is unsure whether a request is recurring or one-off, it makes a reasonable assumption, states it,
-and proceeds; you can correct it afterwards if it got the request or routing wrong.
+Neuro-Donn identifies this as a direct Devin task and launches a plain Devin session immediately. Investigations,
+questions about a repository, and other requests that are not plainly one-off code changes go through playbook lookup
+first. If it is unsure whether a request is recurring or one-off, it makes a reasonable assumption, states it, and
+proceeds; you can correct it afterwards if it got the request or routing wrong.
 
 ### Get the answer back in this chat
 
@@ -109,8 +110,8 @@ Sessions are attributed to the owner of the PAT configured on the server, not to
 
 Neuro-Donn has four agents:
 
-- **Front man: `neuro_donn`** — classifies the request, coordinates playbook selection when useful, launches the work
-  without confirmation, and states any assumptions it made.
+- **Front man: `neuro_donn`** — checks for a playbook by default, uses direct Devin only for plainly one-off code
+  changes in a named repository, launches the work without confirmation, and states any assumptions it made.
 - **Playbook finder: `playbook_finder`** — calls Devin's `devin_playbook_manage` MCP tool to list available
   playbooks, inspect plausible candidates, and return the best match.
 - **Task launcher: `task_launcher`** — calls Devin's `devin_session_create` MCP tool with the request, optional

--- a/docs/examples/tools/neuro_donn.md
+++ b/docs/examples/tools/neuro_donn.md
@@ -1,8 +1,8 @@
 # Neuro-Donn
 
 **Neuro-Donn** is a front man for starting work in Devin. Describe a task in plain language and it finds the matching
-Devin playbook when there is one, or recognizes that the request is an ad-hoc task with no playbook. It restates the
-request, asks for confirmation, launches a Devin session after you confirm, and hands back the session URL. It can
+Devin playbook when there is one, or recognizes that the request is an ad-hoc task with no playbook. It chooses the
+playbook and launches a Devin session immediately, states any assumptions it made, and hands back the session URL. It can
 also report back on a launched session, so the answer arrives in this chat instead of only in the Devin session. Every
 session it launches is tagged `neuro-donn`.
 
@@ -17,8 +17,8 @@ or a routine repository chore. For example:
 Create a unileaf user in Auth0 for jane@example.com
 ```
 
-Neuro-Donn searches the available Devin playbooks, reads the most plausible matches, and tells you the selected
-playbook's title, ID, and purpose. It asks you to confirm the request and playbook before launching Devin.
+Neuro-Donn searches the available Devin playbooks, reads the most plausible matches, and launches the most plausible
+match immediately. It tells you the selected playbook's title, ID, and purpose, along with any assumptions it made.
 
 ### Send an ad-hoc task directly to Devin
 
@@ -29,9 +29,9 @@ go straight to Devin:
 Fix the failing configuration test in my current repository
 ```
 
-Neuro-Donn identifies this as a direct Devin task, skips playbook lookup, asks you to confirm the request, and then
-launches a plain Devin session. If it is unsure whether a request is recurring or one-off, it can look for a playbook
-before asking for confirmation.
+Neuro-Donn identifies this as a direct Devin task, skips playbook lookup, and launches a plain Devin session
+immediately. If it is unsure whether a request is recurring or one-off, it makes a reasonable assumption, states it,
+and proceeds; you can correct it afterwards if it got the request or routing wrong.
 
 ### Get the answer back in this chat
 
@@ -109,12 +109,12 @@ Sessions are attributed to the owner of the PAT configured on the server, not to
 
 Neuro-Donn has four agents:
 
-- **Front man: `neuro_donn`** — classifies the request, coordinates playbook selection when useful, requires
-  confirmation, and launches the work.
+- **Front man: `neuro_donn`** — classifies the request, coordinates playbook selection when useful, launches the work
+  without confirmation, and states any assumptions it made.
 - **Playbook finder: `playbook_finder`** — calls Devin's `devin_playbook_manage` MCP tool to list available
   playbooks, inspect plausible candidates, and return the best match.
-- **Task launcher: `task_launcher`** — calls Devin's `devin_session_create` MCP tool with the confirmed request,
-  optional playbook ID, and the `neuro-donn` tag.
+- **Task launcher: `task_launcher`** — calls Devin's `devin_session_create` MCP tool with the request, optional
+  playbook ID, and the `neuro-donn` tag.
 - **Result fetcher: `result_fetcher`** — calls Devin's `devin_session_gather` MCP tool to wait for a session to settle
   and `devin_session_interact` to read its status and messages, then returns the session's latest answer.
 
@@ -128,9 +128,9 @@ Keeping these responsibilities separate makes routing more reliable and limits a
 - **Authentication errors or missing tools:** Check that the Devin PAT is valid, both required headers are present,
   and the MCP URL in `MCP_SERVERS_INFO_FILE` exactly matches `https://mcp.devin.ai/mcp`. If both the client and server
   provide headers, client `sly_data` takes precedence.
-- **No playbook matches:** Neuro-Donn should say that no playbook matches and offer a direct Devin task. Confirm the
-  request to launch a plain session.
-- **Nothing launches after describing a task:** Confirmation is intentional. No Devin session is created until you
-  restate the request and answer the confirmation question affirmatively.
+- **No playbook matches:** Neuro-Donn should say that no playbook matches, launch a plain Devin task immediately, and
+  state any assumptions it made. Correct the request afterwards if its interpretation was wrong.
+- **An unwanted session launched:** Neuro-Donn launches without asking for confirmation. If it misunderstood a request
+  or chose the wrong playbook, correct the assumption in chat and terminate the unwanted session in the Devin UI.
 - **Result never arrives in chat:** Long sessions do not finish within a chat turn. Ask again later, or open the
   session URL. `devin_session_gather` waits at most 590 seconds per call.

--- a/docs/examples/tools/neuro_donn.md
+++ b/docs/examples/tools/neuro_donn.md
@@ -35,7 +35,8 @@ before asking for confirmation.
 
 ### Get the answer back in this chat
 
-After a launch, ask for the result and Neuro-Donn reports it here:
+After a launch Neuro-Donn waits for the session on its own and reports the answer here, so you do not have to ask.
+You can also ask again at any time:
 
 ```text
 What is the result of the session you just launched?

--- a/docs/examples/tools/neuro_donn.md
+++ b/docs/examples/tools/neuro_donn.md
@@ -1,0 +1,111 @@
+# Neuro-Donn
+
+**Neuro-Donn** is a front man for starting work in Devin. Describe a task in plain language and it finds the matching
+Devin playbook when there is one, or recognizes that the request is an ad-hoc task with no playbook. It restates the
+request, asks for confirmation, launches a Devin session after you confirm, and hands back the session URL. Every
+session it launches is tagged `neuro-donn`.
+
+## What You Can Do
+
+### Start a playbook-matched task
+
+Use Neuro-Donn for recurring or procedural work, such as a report, an account or environment change, a release check,
+or a routine repository chore. For example:
+
+```text
+Create a unileaf user in Auth0 for jane@example.com
+```
+
+Neuro-Donn searches the available Devin playbooks, reads the most plausible matches, and tells you the selected
+playbook's title, ID, and purpose. It asks you to confirm the request and playbook before launching Devin.
+
+### Send an ad-hoc task directly to Devin
+
+One-off work does not need a playbook. Code changes, bug fixes, investigations, and questions about a repository can
+go straight to Devin:
+
+```text
+Fix the failing configuration test in my current repository
+```
+
+Neuro-Donn identifies this as a direct Devin task, skips playbook lookup, asks you to confirm the request, and then
+launches a plain Devin session. If it is unsure whether a request is recurring or one-off, it can look for a playbook
+before asking for confirmation.
+
+## File
+
+[neuro_donn.hocon](../../../registries/tools/neuro_donn.hocon)
+
+## Prerequisites
+
+This network ships disabled because it requires Devin credentials. Before using it, supply the credentials described
+below and flip `"tools/neuro_donn.hocon"` to `true` in
+[registries/tools/manifest.hocon](../../../registries/tools/manifest.hocon).
+
+Devin authentication is required. Configure access to the Devin MCP server at
+`https://mcp.devin.ai/mcp` using one of these two paths:
+
+- A client can provide `sly_data.http_headers` for the MCP URL.
+- The server can use a HOCON file named by the `MCP_SERVERS_INFO_FILE` environment variable.
+
+Both paths must provide these headers:
+
+- `Authorization: Bearer <Devin PAT>`
+- `X-Org-Id: <org id>`
+
+For example, an `MCP_SERVERS_INFO_FILE` can contain:
+
+```hocon
+{
+    "https://mcp.devin.ai/mcp": {
+        "http_headers": {
+            "Authorization": "Bearer <Devin PAT>",
+            "X-Org-Id": "<org id>",
+        },
+    },
+}
+```
+
+The server URL in this file must match the URL in the agent network configuration. Never put a real PAT in source
+control or documentation.
+
+When a client supplies headers through `sly_data`, the equivalent shape is:
+
+```json
+{
+    "http_headers": {
+        "https://mcp.devin.ai/mcp": {
+            "Authorization": "Bearer <Devin PAT>",
+            "X-Org-Id": "<org id>"
+        }
+    }
+}
+```
+
+Sessions are attributed to the owner of the PAT configured on the server, not to the user who requested the work.
+
+## Architecture Overview
+
+Neuro-Donn has three agents:
+
+- **Front man: `neuro_donn`** — classifies the request, coordinates playbook selection when useful, requires
+  confirmation, and launches the work.
+- **Playbook finder: `playbook_finder`** — calls Devin's `devin_playbook_manage` MCP tool to list available
+  playbooks, inspect plausible candidates, and return the best match.
+- **Task launcher: `task_launcher`** — calls Devin's `devin_session_create` MCP tool with the confirmed request,
+  optional playbook ID, and the `neuro-donn` tag.
+
+Devin's MCP server exposes many tools, so each downstream agent receives a filtered MCP tool list. The playbook finder
+can only call `devin_playbook_manage`; it structurally cannot create sessions. The task launcher can only call
+`devin_session_create`. Keeping these responsibilities separate makes routing more reliable and limits accidental
+tool use.
+
+## Debugging Hints
+
+- **Authentication errors or missing tools:** Check that the Devin PAT is valid, both required headers are present,
+  and the MCP URL in `MCP_SERVERS_INFO_FILE` exactly matches `https://mcp.devin.ai/mcp`. If both the client and server
+  provide headers, client `sly_data` takes precedence.
+- **No playbook matches:** Neuro-Donn should say that no playbook matches and offer a direct Devin task. Confirm the
+  request to launch a plain session.
+- **Nothing launches after describing a task:** Confirmation is intentional. No Devin session is created until you
+  restate the request and answer the confirmation question affirmatively.

--- a/docs/examples/tools/neuro_donn.md
+++ b/docs/examples/tools/neuro_donn.md
@@ -47,6 +47,12 @@ along with any pull request links. For longer work it reports the current status
 message, and you can ask again later. Devin sessions frequently outlive a single chat turn, so treat the waiting
 behavior as a convenience for quick tasks rather than a guarantee.
 
+### Expect Donn's voice, not Donn
+
+Neuro-Donn answers in the terse, decision-first style Donn uses in his pull requests and reviews: short replies, a
+pointed question when something does not add up, and a plain statement when it is unsure or when something belongs in
+follow-up work. It is a stand-in and says so; it never claims to be Donn.
+
 ## File
 
 [neuro_donn.hocon](../../../registries/tools/neuro_donn.hocon)

--- a/docs/examples/tools/neuro_donn.md
+++ b/docs/examples/tools/neuro_donn.md
@@ -2,7 +2,8 @@
 
 **Neuro-Donn** is a front man for starting work in Devin. Describe a task in plain language and it finds the matching
 Devin playbook when there is one, or recognizes that the request is an ad-hoc task with no playbook. It restates the
-request, asks for confirmation, launches a Devin session after you confirm, and hands back the session URL. Every
+request, asks for confirmation, launches a Devin session after you confirm, and hands back the session URL. It can
+also report back on a launched session, so the answer arrives in this chat instead of only in the Devin session. Every
 session it launches is tagged `neuro-donn`.
 
 ## What You Can Do
@@ -31,6 +32,19 @@ Fix the failing configuration test in my current repository
 Neuro-Donn identifies this as a direct Devin task, skips playbook lookup, asks you to confirm the request, and then
 launches a plain Devin session. If it is unsure whether a request is recurring or one-off, it can look for a playbook
 before asking for confirmation.
+
+### Get the answer back in this chat
+
+After a launch, ask for the result and Neuro-Donn reports it here:
+
+```text
+What is the result of the session you just launched?
+```
+
+For short tasks it waits for the session to settle, up to a few minutes, and then gives you the session's answer
+along with any pull request links. For longer work it reports the current status and the session's most recent
+message, and you can ask again later. Devin sessions frequently outlive a single chat turn, so treat the waiting
+behavior as a convenience for quick tasks rather than a guarantee.
 
 ## File
 
@@ -86,7 +100,7 @@ Sessions are attributed to the owner of the PAT configured on the server, not to
 
 ## Architecture Overview
 
-Neuro-Donn has three agents:
+Neuro-Donn has four agents:
 
 - **Front man: `neuro_donn`** — classifies the request, coordinates playbook selection when useful, requires
   confirmation, and launches the work.
@@ -94,11 +108,13 @@ Neuro-Donn has three agents:
   playbooks, inspect plausible candidates, and return the best match.
 - **Task launcher: `task_launcher`** — calls Devin's `devin_session_create` MCP tool with the confirmed request,
   optional playbook ID, and the `neuro-donn` tag.
+- **Result fetcher: `result_fetcher`** — calls Devin's `devin_session_gather` MCP tool to wait for a session to settle
+  and `devin_session_interact` to read its status and messages, then returns the session's latest answer.
 
 Devin's MCP server exposes many tools, so each downstream agent receives a filtered MCP tool list. The playbook finder
 can only call `devin_playbook_manage`; it structurally cannot create sessions. The task launcher can only call
-`devin_session_create`. Keeping these responsibilities separate makes routing more reliable and limits accidental
-tool use.
+`devin_session_create`. The result fetcher is read-only by instruction and never messages or terminates a session.
+Keeping these responsibilities separate makes routing more reliable and limits accidental tool use.
 
 ## Debugging Hints
 
@@ -109,3 +125,5 @@ tool use.
   request to launch a plain session.
 - **Nothing launches after describing a task:** Confirmation is intentional. No Devin session is created until you
   restate the request and answer the confirmation question affirmatively.
+- **Result never arrives in chat:** Long sessions do not finish within a chat turn. Ask again later, or open the
+  session URL. `devin_session_gather` waits at most 590 seconds per call.

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -122,6 +122,7 @@
     # python bmi_server.py
     "tools/mcp_bmi_streamable_http.hocon": false,
 
+    "tools/neuro_donn.hocon": true,
     "tools/now_agents.hocon": true,
 
     # Requirement to use this openai based agent network:

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -122,7 +122,10 @@
     # python bmi_server.py
     "tools/mcp_bmi_streamable_http.hocon": false,
 
-    "tools/neuro_donn.hocon": true,
+    # Not credential-free: supply Devin auth for the MCP URL, either as sly_data.http_headers
+    # from the client or via MCP_SERVERS_INFO_FILE carrying Authorization: Bearer <Devin PAT>
+    # and X-Org-Id: <org id>. Without them the two MCP agents fail.
+    "tools/neuro_donn.hocon": false,
     "tools/now_agents.hocon": true,
 
     # Requirement to use this openai based agent network:

--- a/registries/tools/neuro_donn.hocon
+++ b/registries/tools/neuro_donn.hocon
@@ -1,0 +1,116 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+{
+    include "config/llm_config.hocon",
+
+    "metadata": {
+        "description": "Neuro-Donn finds the right Devin playbook and starts the requested work.",
+        "tags": ["mcp", "devin", "demo"],
+        "sample_queries": [
+            "Create a unileaf user in Auth0 for jane@example.com",
+            "Give me a PR status report for neuro-san-deploy",
+            "Bump build-common to the latest release in neuro-san-deploy",
+            "Review PR 123 with Code_Fink",
+        ]
+    },
+
+    "tools": [
+        {
+            "name": "neuro_donn",
+            "function": {
+                "description": "Help the user find and launch the right Devin playbook."
+            },
+            "instructions": """
+You are Neuro-Donn, your Donn-on-demand.
+You help colleagues get work started by finding the right Devin playbook and launching a Devin session.
+Ask a clarifying question when the user's request is vague.
+For every actionable request, use playbook_finder to identify the best matching playbook.
+Always tell the user which playbook you chose, including its title and playbook ID, and briefly explain what it does.
+Before launching any Devin session, ask the user to confirm that the selected playbook and request are correct.
+Only after the user confirms should you use task_launcher.
+If no playbook matches, say so clearly and ask the user to confirm launching a plain Devin session with their request.
+After launch, share the session ID and URL returned by task_launcher.
+            """,
+            "tools": ["playbook_finder", "task_launcher"]
+        },
+        {
+            "name": "playbook_finder",
+            "function": {
+                "description": "Find the Devin playbook that best matches the user's request.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "request": {
+                            "type": "string",
+                            "description": "The user's request to match against Devin playbooks."
+                        }
+                    },
+                    "required": ["request"]
+                }
+            },
+            "instructions": """
+Call devin_playbook_manage with action list to retrieve the available Devin playbooks.
+Review the list and identify one to three plausible candidates for the user's request.
+Call devin_playbook_manage with action get and each candidate's playbook_id to read their content.
+Return the best match as its playbook title, playbook_id, and one line describing what it does.
+If none of the available playbooks matches the request, explicitly report that no playbook matches.
+            """,
+            "tools": [
+                {
+                    "url": "https://mcp.devin.ai/mcp",
+                    "tools": ["devin_playbook_manage"]
+                }
+            ]
+        },
+        {
+            "name": "task_launcher",
+            "function": {
+                "description": "Launch a Devin session for the user's confirmed request.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "description": "The user's request to send to Devin."
+                        },
+                        "playbook_id": {
+                            "type": "string",
+                            "description": "The selected Devin playbook ID, if one matched."
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "An optional title for the Devin session."
+                        }
+                    },
+                    "required": ["prompt"]
+                }
+            },
+            "instructions": """
+Call devin_session_create with the prompt and any supplied playbook_id and title.
+Always pass tags ["neuro-donn"].
+If no playbook matched, still launch a plain session using the user's request as the prompt.
+Return the resulting session ID and its URL in the form https://app.devin.ai/sessions/<id>.
+            """,
+            "tools": [
+                {
+                    "url": "https://mcp.devin.ai/mcp",
+                    "tools": ["devin_session_create"]
+                }
+            ]
+        }
+    ]
+}

--- a/registries/tools/neuro_donn.hocon
+++ b/registries/tools/neuro_donn.hocon
@@ -18,13 +18,14 @@
     include "config/llm_config.hocon",
 
     "metadata": {
-        "description": "Neuro-Donn finds the right Devin playbook and starts the requested work.",
+        "description": "Neuro-Donn finds the right Devin playbook, starts the requested work, and reports the result.",
         "tags": ["mcp", "devin", "demo"],
         "sample_queries": [
             "Create a unileaf user in Auth0 for jane@example.com",
             "Give me a PR status report for neuro-san-deploy",
             "Bump build-common to the latest release in neuro-san-deploy",
             "Review PR 123 with Code_Fink",
+            "What is the result of the session you just launched?",
         ]
     },
 
@@ -32,7 +33,7 @@
         {
             "name": "neuro_donn",
             "function": {
-                "description": "Find the right Devin playbook for the user's request, or send it to Devin directly, and launch the work."
+                "description": "Find the right Devin playbook for the user's request, or send it to Devin directly, launch the work, and report the result."
             },
             "instructions": """
 You are Neuro-Donn, your Donn-on-demand.
@@ -44,9 +45,13 @@ When a playbook matches, always tell the user which one you chose, including its
 When no playbook matches or none is needed, say so plainly and treat the request as a direct Devin task.
 Before launching any Devin session, restate the request and, if there is one, the selected playbook, and ask the user to confirm.
 Only after the user confirms should you use task_launcher, passing the playbook ID only when a playbook was selected.
-After launch, share the session ID and URL returned by task_launcher.
+After launch, share the session ID and URL returned by task_launcher, and tell the user they can ask you for the result at any time.
+Use result_fetcher whenever the user asks how a launched session is going or what its answer was, passing the session ID and the number of seconds you are willing to wait.
+Wait only for work that should finish quickly, no more than 300 seconds, and otherwise fetch the current state immediately by passing zero.
+When result_fetcher reports that the session is still working, say so, repeat what it last reported, and invite the user to ask again later.
+When result_fetcher returns a finished session, present its answer as your own final answer, including any pull request links, and keep the session URL for reference.
             """,
-            "tools": ["playbook_finder", "task_launcher"]
+            "tools": ["playbook_finder", "task_launcher", "result_fetcher"]
         },
         {
             "name": "playbook_finder",
@@ -110,6 +115,40 @@ Return the resulting session ID and its URL in the form https://app.devin.ai/ses
                 {
                     "url": "https://mcp.devin.ai/mcp",
                     "tools": ["devin_session_create"]
+                }
+            ]
+        },
+        {
+            "name": "result_fetcher",
+            "function": {
+                "description": "Report the status and latest answer of a Devin session, optionally waiting for it to settle first.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "description": "The Devin session ID to report on."
+                        },
+                        "wait_seconds": {
+                            "type": "integer",
+                            "description": "How long to wait for the session to settle before reporting. Zero reports the current state immediately."
+                        }
+                    },
+                    "required": ["session_id"]
+                }
+            },
+            "instructions": """
+When wait_seconds is given and greater than zero, first call devin_session_gather with the session ID and that many seconds, capped at 590.
+Then call devin_session_interact with action get to read the session's status, status_detail, url, and pull_requests.
+Then call devin_session_interact with action get_messages to read what the session has said, and take the most recent message from Devin as its answer so far.
+Report the status, whether the session is finished or still working, that latest answer, and any pull request links.
+When the status shows the session is waiting for the user or waiting for approval, say what it is waiting for.
+Do not send messages to the session and do not terminate, archive, or otherwise change it.
+            """,
+            "tools": [
+                {
+                    "url": "https://mcp.devin.ai/mcp",
+                    "tools": ["devin_session_gather", "devin_session_interact"]
                 }
             ]
         }

--- a/registries/tools/neuro_donn.hocon
+++ b/registries/tools/neuro_donn.hocon
@@ -41,9 +41,11 @@ You help colleagues get work started, either by finding the right Devin playbook
 Act on the request in a single turn: choose the playbook if there is one, launch the work, and report back, without asking the user to confirm anything.
 Ask a question only when the request cannot be acted on at all, and even then prefer a reasonable assumption over a question.
 When you assume something, say what you assumed so the user can correct it afterwards.
-Use playbook_finder to look for a matching playbook whenever the request sounds like a recurring or procedural task, such as a report, an account or environment change, a release check, or a routine repository chore.
-When the request is a one-off piece of work such as a code change, a bug fix, an investigation, or a question about a repository, you do not need a playbook: say that this is a direct Devin task and skip playbook_finder, or use it only if you are unsure.
-When a playbook matches, always tell the user which one you chose, including its title and playbook ID, and briefly explain what it does.
+Call playbook_finder first by default, before you decide anything else: a playbook captures how Donn actually does that work, including scope, sources, and output the user did not spell out, and looking costs one cheap call.
+Anything that asks about the state of things, or that Donn would plausibly have done before, has a playbook worth checking: reports, status summaries, deployment or version questions, account and environment changes, release checks, code reviews, and routine repository chores.
+Skip playbook_finder only when the request is plainly a one-off change to code in a named repository, such as fixing a specific bug or adding a specific feature.
+When a playbook matches, launch it and tell the user which one you chose, including its title and playbook ID, and briefly explain what it does, especially where it covers more ground than they asked for.
+Do not treat a request as a direct Devin task because it looks like an investigation or a question; that is exactly the kind of work these playbooks exist for.
 When no playbook matches or none is needed, say so plainly and treat the request as a direct Devin task.
 Use task_launcher right away, passing the playbook ID only when a playbook was selected.
 After launch, share the session ID and URL returned by task_launcher, and say that you will wait for the result.

--- a/registries/tools/neuro_donn.hocon
+++ b/registries/tools/neuro_donn.hocon
@@ -38,13 +38,14 @@
             "instructions": """
 You are Neuro-Donn, your Donn-on-demand.
 You help colleagues get work started, either by finding the right Devin playbook or by handing an ad-hoc request straight to Devin.
-Ask a clarifying question when the user's request is vague.
+Act on the request in a single turn: choose the playbook if there is one, launch the work, and report back, without asking the user to confirm anything.
+Ask a question only when the request cannot be acted on at all, and even then prefer a reasonable assumption over a question.
+When you assume something, say what you assumed so the user can correct it afterwards.
 Use playbook_finder to look for a matching playbook whenever the request sounds like a recurring or procedural task, such as a report, an account or environment change, a release check, or a routine repository chore.
 When the request is a one-off piece of work such as a code change, a bug fix, an investigation, or a question about a repository, you do not need a playbook: say that this is a direct Devin task and skip playbook_finder, or use it only if you are unsure.
 When a playbook matches, always tell the user which one you chose, including its title and playbook ID, and briefly explain what it does.
 When no playbook matches or none is needed, say so plainly and treat the request as a direct Devin task.
-Before launching any Devin session, restate the request and, if there is one, the selected playbook, and ask the user to confirm.
-Only after the user confirms should you use task_launcher, passing the playbook ID only when a playbook was selected.
+Use task_launcher right away, passing the playbook ID only when a playbook was selected.
 After launch, share the session ID and URL returned by task_launcher, and say that you will wait for the result.
 Then use result_fetcher yourself with that session ID and 300 seconds, without waiting for the user to ask.
 Use result_fetcher again, with the number of seconds you are willing to wait, whenever the user asks how a launched session is going or what its answer was.
@@ -95,7 +96,7 @@ If none of the available playbooks matches the request, explicitly report that n
         {
             "name": "task_launcher",
             "function": {
-                "description": "Launch a Devin session for the user's confirmed request.",
+                "description": "Launch a Devin session for the user's request.",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/registries/tools/neuro_donn.hocon
+++ b/registries/tools/neuro_donn.hocon
@@ -51,6 +51,15 @@ Use result_fetcher again, with the number of seconds you are willing to wait, wh
 Wait only for work that should finish quickly, no more than 300 seconds, and otherwise fetch the current state immediately by passing zero.
 When result_fetcher reports that the session is still working, say so, repeat what it last reported, and invite the user to ask again later.
 When result_fetcher returns a finished session, present its answer as your own final answer, including any pull request links, and keep the session URL for reference.
+
+Write the way Donn writes in his pull requests and code reviews.
+Be brief and plain, a couple of sentences where most assistants would write a paragraph, and skip pleasantries, praise, and restating the request back at length.
+Lead with the answer or the decision, then the reason for it, and say "let's" when proposing the next step.
+Ask a short pointed question when something does not add up, in the spirit of "why is this needed?" or "remind me, do we still use that?", rather than hedging around it.
+Say plainly when you are unsure or when something is out of scope for right now, and offer the follow-up instead of quietly expanding the work.
+Mention the practical cost when it matters, such as build time, ACUs, or someone waiting on a review.
+Stay warm and dry rather than enthusiastic: mild wit is welcome, exclamation points and emoji are not.
+Never imitate Donn's voice to claim you are Donn; you are his stand-in, and you say so if anyone asks.
             """,
             "tools": ["playbook_finder", "task_launcher", "result_fetcher"]
         },

--- a/registries/tools/neuro_donn.hocon
+++ b/registries/tools/neuro_donn.hocon
@@ -45,8 +45,9 @@ When a playbook matches, always tell the user which one you chose, including its
 When no playbook matches or none is needed, say so plainly and treat the request as a direct Devin task.
 Before launching any Devin session, restate the request and, if there is one, the selected playbook, and ask the user to confirm.
 Only after the user confirms should you use task_launcher, passing the playbook ID only when a playbook was selected.
-After launch, share the session ID and URL returned by task_launcher, and tell the user they can ask you for the result at any time.
-Use result_fetcher whenever the user asks how a launched session is going or what its answer was, passing the session ID and the number of seconds you are willing to wait.
+After launch, share the session ID and URL returned by task_launcher, and say that you will wait for the result.
+Then use result_fetcher yourself with that session ID and 300 seconds, without waiting for the user to ask.
+Use result_fetcher again, with the number of seconds you are willing to wait, whenever the user asks how a launched session is going or what its answer was.
 Wait only for work that should finish quickly, no more than 300 seconds, and otherwise fetch the current state immediately by passing zero.
 When result_fetcher reports that the session is still working, say so, repeat what it last reported, and invite the user to ask again later.
 When result_fetcher returns a finished session, present its answer as your own final answer, including any pull request links, and keep the session URL for reference.
@@ -138,6 +139,7 @@ Return the resulting session ID and its URL in the form https://app.devin.ai/ses
                 }
             },
             "instructions": """
+devin_session_gather requires the session ID to start with "devin-", so prepend that prefix when the ID you were given lacks it.
 When wait_seconds is given and greater than zero, first call devin_session_gather with the session ID and that many seconds, capped at 590.
 Then call devin_session_interact with action get to read the session's status, status_detail, url, and pull_requests.
 Then call devin_session_interact with action get_messages to read what the session has said, and take the most recent message from Devin as its answer so far.

--- a/registries/tools/neuro_donn.hocon
+++ b/registries/tools/neuro_donn.hocon
@@ -32,17 +32,18 @@
         {
             "name": "neuro_donn",
             "function": {
-                "description": "Help the user find and launch the right Devin playbook."
+                "description": "Find the right Devin playbook for the user's request, or send it to Devin directly, and launch the work."
             },
             "instructions": """
 You are Neuro-Donn, your Donn-on-demand.
-You help colleagues get work started by finding the right Devin playbook and launching a Devin session.
+You help colleagues get work started, either by finding the right Devin playbook or by handing an ad-hoc request straight to Devin.
 Ask a clarifying question when the user's request is vague.
-For every actionable request, use playbook_finder to identify the best matching playbook.
-Always tell the user which playbook you chose, including its title and playbook ID, and briefly explain what it does.
-Before launching any Devin session, ask the user to confirm that the selected playbook and request are correct.
-Only after the user confirms should you use task_launcher.
-If no playbook matches, say so clearly and ask the user to confirm launching a plain Devin session with their request.
+Use playbook_finder to look for a matching playbook whenever the request sounds like a recurring or procedural task, such as a report, an account or environment change, a release check, or a routine repository chore.
+When the request is a one-off piece of work such as a code change, a bug fix, an investigation, or a question about a repository, you do not need a playbook: say that this is a direct Devin task and skip playbook_finder, or use it only if you are unsure.
+When a playbook matches, always tell the user which one you chose, including its title and playbook ID, and briefly explain what it does.
+When no playbook matches or none is needed, say so plainly and treat the request as a direct Devin task.
+Before launching any Devin session, restate the request and, if there is one, the selected playbook, and ask the user to confirm.
+Only after the user confirms should you use task_launcher, passing the playbook ID only when a playbook was selected.
 After launch, share the session ID and URL returned by task_launcher.
             """,
             "tools": ["playbook_finder", "task_launcher"]

--- a/registries/tools/neuro_donn.hocon
+++ b/registries/tools/neuro_donn.hocon
@@ -25,7 +25,7 @@
             "Give me a PR status report for neuro-san-deploy",
             "Bump build-common to the latest release in neuro-san-deploy",
             "Review PR 123 with Code_Fink",
-            "What is the result of the session you just launched?",
+            "How is that going, and what did it find?",
         ]
     },
 
@@ -44,16 +44,20 @@ When you assume something, say what you assumed so the user can correct it after
 Call playbook_finder first by default, before you decide anything else: a playbook captures how Donn actually does that work, including scope, sources, and output the user did not spell out, and looking costs one cheap call.
 Anything that asks about the state of things, or that Donn would plausibly have done before, has a playbook worth checking: reports, status summaries, deployment or version questions, account and environment changes, release checks, code reviews, and routine repository chores.
 Skip playbook_finder only when the request is plainly a one-off change to code in a named repository, such as fixing a specific bug or adding a specific feature.
-When a playbook matches, launch it and tell the user which one you chose, including its title and playbook ID, and briefly explain what it does, especially where it covers more ground than they asked for.
+When a playbook matches, launch it and say in one line which one you chose and what it covers, especially where it covers more ground than they asked for.
 Do not treat a request as a direct Devin task because it looks like an investigation or a question; that is exactly the kind of work these playbooks exist for.
 When no playbook matches or none is needed, say so plainly and treat the request as a direct Devin task.
 Use task_launcher right away, passing the playbook ID only when a playbook was selected.
-After launch, share the session ID and URL returned by task_launcher, and say that you will wait for the result.
+Say that one line about what you are running before you go quiet waiting for the answer, so the user is not left with nothing.
 Then use result_fetcher yourself with that session ID and 300 seconds, without waiting for the user to ask.
-Use result_fetcher again, with the number of seconds you are willing to wait, whenever the user asks how a launched session is going or what its answer was.
+Use result_fetcher again, with the number of seconds you are willing to wait, whenever the user asks how the work is going or what its answer was.
 Wait only for work that should finish quickly, no more than 300 seconds, and otherwise fetch the current state immediately by passing zero.
-When result_fetcher reports that the session is still working, say so, repeat what it last reported, and invite the user to ask again later.
-When result_fetcher returns a finished session, present its answer as your own final answer, including any pull request links, and keep the session URL for reference.
+When result_fetcher reports that the work is still running, say what has happened so far and that you will have the answer shortly, and invite the user to ask again.
+When result_fetcher returns a finished session, present its answer as your own final answer, including any pull request links.
+
+The user asked a question and wants an answer, not a tour of the machinery.
+Never mention Devin session IDs or session URLs, and do not tell the user to go look at a session; you report the answer here.
+Playbook IDs are internal too: name the playbook in plain words instead.
 
 Write the way Donn writes in his pull requests and code reviews.
 Be brief and plain, a couple of sentences where most assistants would write a paragraph, and skip pleasantries, praise, and restating the request back at length.


### PR DESCRIPTION
## Description

Adds **Neuro-Donn**, a network that turns "ask Donn to do it" into "ask neuro-san to do it": describe a task
in plain language and it either finds the Devin playbook that matches or recognizes there is no playbook for
it, launches a Devin session, and reports that session's answer back in the neuro-san chat.

There is no new code and no coded tool — the downstream agents talk to Devin's hosted MCP server
(`https://mcp.devin.ai/mcp`) natively through a tool-filtered URL entry, the same native-MCP pattern as
`registries/basic/wolfram_mcp.hocon`:

```
neuro_donn (front man)
├── playbook_finder → mcp.devin.ai {devin_playbook_manage}   list, get the candidates, return the best match
├── task_launcher   → mcp.devin.ai {devin_session_create}    prompt + optional playbook_id, tags ["neuro-donn"]
└── result_fetcher  → mcp.devin.ai {devin_session_gather,    optionally wait for the session to settle, then
                                    devin_session_interact}  read its status and latest message
```

Four deliberate design points:

- **Two paths, not one.** Recurring or procedural work (a report, an account change, a release check) goes
  through `playbook_finder`. One-off work — a code change, a bug fix, an investigation — is a direct Devin
  task: the front man says so, skips the playbook hunt, and `task_launcher` omits `playbook_id`.
- **Per-agent tool filtering** (`{"url": ..., "tools": [...]}`) rather than a bare URL string. Devin's MCP
  server exposes ~25 tools; handing all of them to one agent makes routing unreliable, and it also means
  `playbook_finder` structurally cannot create sessions.
- **The front man does not gate the launch.** It picks the playbook and launches in one turn, stating any
  assumption it made instead of asking a confirmation question. Twenty questions before a session is worse
  than an occasional wrong session you correct afterwards.
- **The result comes back to the chat.** `result_fetcher` waits up to 300 seconds for work that should finish
  quickly, or reports the current state immediately for longer work, and it is read-only: it never messages,
  terminates, or archives the session. Devin sessions often outlive a chat turn, so for long work it reports
  status plus the session's most recent message and you ask again later.

Files:

- `registries/tools/neuro_donn.hocon` — the network (front man plus the three MCP-backed agents).
- `registries/tools/manifest.hocon` — registered **disabled**, with a comment saying what credentials to
  supply, like the other server-credential networks (`confluence`, `gmail`, `google_maps`).
- `docs/examples/tools/neuro_donn.md`, `docs/examples.md` — usage for all three paths, the credential and
  enablement prerequisites, architecture, and debugging hints.

## Impact

- New, self-contained network; no code changes, and no effect on existing networks or on the default server,
  since it ships disabled.
- Unlike most networks here it is **not** credential-free: the deployment must supply Devin auth for the MCP
  URL, either as `sly_data.http_headers` from the client or via a `MCP_SERVERS_INFO_FILE` HOCON on the server
  carrying `Authorization: Bearer <Devin PAT>` and `X-Org-Id: <org id>`.
- Sessions are attributed to the owner of the PAT the server is configured with, not to the requesting user.
  (The v3 REST API's `create_as_user_id` would change that, but it is not exposed as an MCP tool argument.)

## Screenshots / Logs / Examples (optional)

Verified locally against the real Devin org (manifest entry temporarily enabled for the checks, restored to
`false` before committing):

- server loads the network — 4 reachable agents, `tools/neuro_donn` in the served list
- "I need a unileaf user created in Auth0" → `playbook_finder` returned **Create unileaf user in Auth0**
  (`playbook-895be42eaab2441fa8e1d297cfdab47c`), which confirms the live MCP round trip through
  neuro-san's streamable-HTTP client with the auth headers applied
- `task_launcher` created one real session end to end:
  https://app.devin.ai/sessions/ad3719c425e143588c6e78754d45c182
- `result_fetcher` read that same session back in chat, reporting `suspended` / `inactivity`, no pull
  requests, and the session's last message ("Hello — Neuro-Donn smoke test received and working.")

## Type of Change

- [x] New agent / tool

## Checklist

- [x] Tested locally (network loads and serves; live playbook lookup, session creation, and result retrieval all exercised against the real Devin org; `pymarkdown` clean)
- [ ] Added/updated tests (config and docs only)
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (none added)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**




Link to Devin session: https://app.devin.ai/sessions/e59de3e365984c868e463aa2086eeea2
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/1354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->