### PR TITLE
#1364: Support additional textual content types

### DIFF
--- a/neuro_san_studio/coded_tools/web_fetch.py
+++ b/neuro_san_studio/coded_tools/web_fetch.py
@@ -26,10 +26,16 @@ from neuro_san_studio.coded_tools.utils.safe_fetch import SafeFetch
 
 MAX_CHARS: int = 20_000
 SUPPORTED_CONTENT_TYPES: set[str] = {
-    "text/html",
-    "text/plain",
-    "application/xhtml+xml",
+    "application/atom+xml",
     "application/pdf",
+    "application/rss+xml",
+    "application/xhtml+xml",
+    "application/xml",
+    "text/csv",
+    "text/html",
+    "text/markdown",
+    "text/plain",
+    "text/xml",
 }
 
 
@@ -51,7 +57,7 @@ class WebFetch(CodedTool):
                                     or returns a redirect.
         url_not_accessible       – HTTP error or network failure while fetching the page.
         too_many_requests        – Server returned HTTP 429.
-        unsupported_content_type – Content type is not text/HTML or PDF.
+        unsupported_content_type: Content type is not an approved text, XML, feed, HTML, or PDF type.
         response_too_large       – Content-Length header or streamed body (text or PDF) exceeds the byte limit.
     """
 
@@ -105,7 +111,7 @@ class WebFetch(CodedTool):
             if not is_pdf and not self._is_supported_content_type(base_type):
                 raise ValueError(
                     f"unsupported_content_type: Content type '{content_type}' is not supported. "
-                    "Only text/HTML and PDF are accepted."
+                    "Only approved text, XML, feed, HTML, and PDF types are accepted."
                 )
 
             retrieved_at: str = datetime.now(timezone.utc).isoformat()
@@ -133,11 +139,11 @@ class WebFetch(CodedTool):
     @staticmethod
     def _is_supported_content_type(base_type: str) -> bool:
         """
-        Report whether a base media type is exactly one of the supported text/PDF types.
+        Report whether a base media type is exactly one of the supported text and PDF types.
 
         Exact membership (not substring) is required so an unsupported type that merely
-        contains a supported token — e.g. "application/x-text/plain", or a parameter
-        like "image/png; profile=text/plain" once reduced to its base — is rejected.
+        contains a supported token, such as "application/x-text/plain", or a parameter
+        like "image/png; profile=text/plain" once reduced to its base, is rejected.
 
         :param base_type: The base media type with parameters removed, lower-cased.
         :return: True if base_type is exactly one of SUPPORTED_CONTENT_TYPES.

--- a/neuro_san_studio/coded_tools/web_fetch.py
+++ b/neuro_san_studio/coded_tools/web_fetch.py
@@ -43,6 +43,8 @@ class WebFetch(CodedTool):
     """
     CodedTool implementation that fetches a URL and returns its plain-text body.
 
+    XML and feed responses are returned as extracted text; raw XML markup is not preserved.
+
     All validation and network access is delegated to the shared SSRF-hardened
     fetch path (SafeFetch): private/loopback/reserved hosts are rejected,
     DNS records are validated at connection time by GlobalOnlyResolver
@@ -57,7 +59,7 @@ class WebFetch(CodedTool):
                                     or returns a redirect.
         url_not_accessible       – HTTP error or network failure while fetching the page.
         too_many_requests        – Server returned HTTP 429.
-        unsupported_content_type: Content type is not an approved text, XML, feed, HTML, or PDF type.
+        unsupported_content_type – Content type is not an approved text, XML, feed, HTML, or PDF type.
         response_too_large       – Content-Length header or streamed body (text or PDF) exceeds the byte limit.
     """
 

--- a/tests/neuro_san_studio/coded_tools/test_web_fetch.py
+++ b/tests/neuro_san_studio/coded_tools/test_web_fetch.py
@@ -87,10 +87,12 @@ class TestWebFetch(TestCase):
 
     def test_unsupported_content_type_raises(self):
         """Tests that an unsupported content type raises ValueError with unsupported_content_type."""
-        with patch.object(SafeFetch, "get_content_type", new=AsyncMock(return_value=("image/png", None))):
-            with self.assertRaises(ValueError) as ctx:
-                asyncio.run(self.tool.async_invoke({"url": "http://example.com/img.png"}, self.sly_data))
-        self.assertIn("unsupported_content_type", str(ctx.exception))
+        for content_type in ("image/png", "image/svg+xml"):
+            with self.subTest(content_type=content_type):
+                with patch.object(SafeFetch, "get_content_type", new=AsyncMock(return_value=(content_type, None))):
+                    with self.assertRaises(ValueError) as ctx:
+                        asyncio.run(self.tool.async_invoke({"url": "http://example.com/image"}, self.sly_data))
+                self.assertIn("unsupported_content_type", str(ctx.exception))
 
     def test_uppercase_pdf_content_type_routes_to_pdf(self):
         """Tests that a mixed-case 'Application/PDF' header still routes to PDF parsing, not rejection."""
@@ -102,14 +104,28 @@ class TestWebFetch(TestCase):
         mock_pdf.assert_called_once()
         self.assertEqual(result["content"], "PDF content")
 
-    def test_mixed_case_text_content_type_supported(self):
-        """Tests that a mixed-case 'TEXT/HTML' header is accepted rather than rejected as unsupported."""
-        with (
-            patch.object(SafeFetch, "get_content_type", new=AsyncMock(return_value=("TEXT/HTML", None))),
-            patch.object(SafeFetch, "fetch_text", new=AsyncMock(return_value="hello")),
-        ):
-            result = asyncio.run(self.tool.async_invoke({"url": "http://example.com"}, self.sly_data))
-        self.assertEqual(result["content"], "hello")
+    def test_supported_text_content_types_route_to_text_fetch(self):
+        """Tests that each vetted textual media type is fetched through the text path."""
+        content_types = (
+            "TEXT/HTML",
+            "application/atom+xml",
+            "application/rss+xml",
+            "application/xml",
+            "text/csv",
+            "text/markdown",
+            "text/xml",
+        )
+
+        for content_type in content_types:
+            with self.subTest(content_type=content_type):
+                with (
+                    patch.object(SafeFetch, "get_content_type", new=AsyncMock(return_value=(content_type, None))),
+                    patch.object(SafeFetch, "fetch_text", new=AsyncMock(return_value="readable text")) as mock_text,
+                ):
+                    result = asyncio.run(self.tool.async_invoke({"url": "http://example.com/doc"}, self.sly_data))
+
+                mock_text.assert_awaited_once()
+                self.assertEqual(result["content"], "readable text")
 
     def test_supported_token_in_parameter_still_unsupported(self):
         """Tests that a supported token appearing only in a parameter does not make a type supported.


### PR DESCRIPTION
## Summary

Extend `WebFetch` to accept vetted textual MIME types while preserving its exact allow-list policy.

## Changes

- Accept `text/markdown`, `text/csv`, `text/xml`, `application/xml`, `application/rss+xml`, and `application/atom+xml`.
- Route each new type through the existing bounded text fetch path.
- Keep image and binary formats rejected, including `image/svg+xml`.
- Update the unsupported-type error to describe the expanded policy.

## Testing

- Ruff format check passed.
- Ruff lint passed.
- Pylint passed with 10.00/10.
- `test_web_fetch.py` and `test_safe_fetch.py`: 114 tests and 26 subtests passed.

## Security impact

The change keeps exact base-media-type membership. It does not introduce prefix or substring matching, so XML-labeled images and types that only contain a supported token remain blocked.

Closes #1364