### PR TITLE
Close import dependencies over package `__init__.py` files

### DIFF
--- a/neuro_san_studio/discovery/local_import_walker.py
+++ b/neuro_san_studio/discovery/local_import_walker.py
@@ -54,20 +54,31 @@ class LocalImportWalker:
         self.roots = roots
 
     def expand(self, relative_paths: List[str]) -> List[str]:
-        """Return ``relative_paths`` plus every project-local module reachable from them.
+        """
+        Return ``relative_paths`` plus every project-local module reachable from them.
 
-        Args:
-            relative_paths: Root-prefixed paths as produced by
-                ``DependencyAnalyzer.resolve_coded_tool_path``, e.g.
-                ``"coded_tools/agent_network_editor/add_agent.py"``. Directory entries (a coded
-                tool referenced as a package) are kept as-is and scanned for imports.
+        Each member's ancestor package ``__init__.py`` files are scanned too: importing
+        ``pkg.sub.mod`` at runtime executes ``pkg/__init__.py`` and ``pkg/sub/__init__.py``
+        before ``mod.py``, so whatever those files import is just as required as ``mod``'s own
+        imports — and a re-export like ``from .helper import X`` lives nowhere else. The init
+        files themselves are deliberately NOT added to the returned closure: the importer's
+        ``_copy_parent_inits`` and the exporter's parent-init bundling already deliver them for
+        every member, so listing them here would only inflate the copy/skip accounting.
 
-        Returns:
-            The same path shape, input order first and discovered modules appended, de-duplicated.
-            Breadth-first so a network's own entry points stay ahead of their helpers.
+        :param relative_paths: Root-prefixed paths as produced by
+            ``DependencyAnalyzer.resolve_coded_tool_path``, e.g.
+            ``"coded_tools/agent_network_editor/add_agent.py"``. Directory entries (a coded
+            tool referenced as a package) are kept as-is and scanned for imports.
+        :return: The same path shape, input order first and discovered modules appended,
+            de-duplicated. Breadth-first so a network's own entry points stay ahead of their
+            helpers.
         """
         ordered: List[str] = []
         seen: Set[str] = set()
+        # Ancestor __init__.py files already scanned. Kept separate from `seen` so an init
+        # that is later reached as a real import (e.g. `import coded_tools.pkg`) still joins
+        # the closure like it always did.
+        scanned_inits: Set[str] = set()
         queue: Deque[str] = deque(relative_paths)
         while queue:
             relative_path = queue.popleft()
@@ -78,7 +89,48 @@ class LocalImportWalker:
             for discovered in self._imports_of(relative_path):
                 if discovered not in seen:
                     queue.append(discovered)
+            # Scan-only pass over the member's ancestor __init__.py files: their imports
+            # are ordinary dependencies that nothing else would discover, because no HOCON
+            # and no scanned module names the init file itself.
+            for ancestor_init in self._ancestor_inits(relative_path):
+                if ancestor_init in seen or ancestor_init in scanned_inits:
+                    continue
+                scanned_inits.add(ancestor_init)
+                for discovered in self._imports_of(ancestor_init):
+                    if discovered not in seen:
+                        queue.append(discovered)
         return ordered
+
+    def _ancestor_inits(self, relative_path: str) -> List[str]:
+        """
+        Return the existing ``__init__.py`` files of every package containing ``relative_path``.
+
+        For a file ``coded_tools/pkg/sub/mod.py`` that is ``coded_tools/__init__.py``,
+        ``coded_tools/pkg/__init__.py`` and ``coded_tools/pkg/sub/__init__.py``. For a
+        directory member only the packages *above* it count — the directory's own
+        ``__init__.py`` is inside the copied tree and ``_imports_of`` already scans it.
+
+        :param relative_path: Root-prefixed relative path of a closure member (file or
+            directory).
+        :return: Root-prefixed relative paths of the ancestor ``__init__.py`` files that
+            exist on disk, outermost first. Empty when the path's root is not configured.
+        """
+        parts: List[str] = relative_path.split("/")
+        root_dir: Optional[str] = self.roots.get(parts[0])
+        if root_dir is None:
+            return []
+        # Dropping the last segment yields the containing-package chain for a file, and the
+        # strictly-above-packages chain for a directory — both exactly what must be scanned.
+        package_parts: List[str] = parts[:-1]
+        inits: List[str] = []
+        for depth in range(1, len(package_parts) + 1):
+            # depth 1 is the root itself: parts[1:1] is empty, so this checks
+            # <root_dir>/__init__.py, i.e. "coded_tools/__init__.py".
+            init_absolute: str = os.path.join(root_dir, *package_parts[1:depth], "__init__.py")
+            if os.path.isfile(init_absolute):
+                init_parts: List[str] = package_parts[:depth] + ["__init__.py"]
+                inits.append("/".join(init_parts))
+        return inits
 
     def _imports_of(self, relative_path: str) -> List[str]:
         """Return the project-local modules imported by ``relative_path``, as relative paths."""

--- a/neuro_san_studio/exporter/agent_network_exporter.py
+++ b/neuro_san_studio/exporter/agent_network_exporter.py
@@ -201,6 +201,13 @@ class AgentNetworkExporter:  # pylint: disable=too-few-public-methods
                     src = os.path.join(root, name)
                     arc = os.path.relpath(src, self.project_dir)
                     self._add_file(zf, src, arc, added, result)
+            # Mirror the importer's _copy_parent_inits, which starts a directory dependency's
+            # package chain at the directory itself. The dir's own __init__.py is bundled by
+            # the walk above; this delivers the ancestors' — without them the receiver gets a
+            # namespace portion whose __init__ re-exports and side effects silently vanish,
+            # and the zip path extracts verbatim with no chain of its own to repair it.
+            # Passing `full` starts the walk at the directory's parent.
+            self._add_parent_inits(zf, full, added, result)
             return
         result.warnings.append(f"Dependency not found: {dep_path}")
 

--- a/tests/neuro_san_studio/commands/exporter/test_agent_network_exporter.py
+++ b/tests/neuro_san_studio/commands/exporter/test_agent_network_exporter.py
@@ -160,6 +160,79 @@ class TestExportWithDeps:
         assert result.dependencies.coded_tools == ["coded_tools/basic/music_nerd/lookup.py"]
         assert not result.warnings
 
+    def test_zip_bundles_init_reexported_helper(self, tmp_path: Path) -> None:
+        """A helper re-exported only by the tool package's __init__.py must be bundled.
+
+        Importing the tool at runtime executes its package __init__.py first, so a bundle
+        without helper.py raises ModuleNotFoundError on the receiver even though no HOCON and
+        no scanned module ever names it.
+
+        :param tmp_path: pytest-provided temporary directory for the project and the zip.
+        """
+        project_dir: Path = tmp_path / "project"
+        registries: Path = project_dir / "registries" / "basic"
+        registries.mkdir(parents=True)
+        (project_dir / "registries" / "manifest.hocon").write_text("{}\n")
+        coded_tools: Path = project_dir / "coded_tools" / "basic" / "music_nerd"
+        coded_tools.mkdir(parents=True)
+        (project_dir / "coded_tools" / "__init__.py").write_text("")
+        (coded_tools / "__init__.py").write_text("from .helper import Helper\n")
+        (coded_tools / "lookup.py").write_text("class Lookup:\n    pass\n")
+        (coded_tools / "helper.py").write_text("class Helper:\n    pass\n")
+        (registries / "music_nerd.hocon").write_text(
+            '{\n    "tools": [\n        { "name": "lookup", "class": "lookup.Lookup" }\n    ]\n}\n'
+        )
+        target: Path = tmp_path / "out" / "music_nerd.zip"
+
+        exporter = AgentNetworkExporter(project_dir=str(project_dir))
+        exporter.export("music_nerd", output_path=str(target))
+
+        with zipfile.ZipFile(target) as zf:
+            names = set(zf.namelist())
+        assert "coded_tools/basic/music_nerd/helper.py" in names
+        assert "coded_tools/basic/music_nerd/__init__.py" in names
+
+    def test_zip_bundles_directory_dep_ancestor_init(self, tmp_path: Path) -> None:
+        """A directory dep's ancestor __init__.py — and what it imports — must be bundled.
+
+        The exporter's directory branch used to skip parent inits entirely (only the file
+        branch called _add_parent_inits), so the receiver got a namespace portion whose
+        __init__ re-exports silently vanished, while the init's own import shipped orphaned.
+
+        :param tmp_path: pytest-provided temporary directory for the project and the zip.
+        """
+        project_dir: Path = tmp_path / "project"
+        registries: Path = project_dir / "registries"
+        registries.mkdir(parents=True)
+        (registries / "manifest.hocon").write_text("{}\n")
+        coded_tools: Path = project_dir / "coded_tools"
+        (coded_tools / "grp" / "pkg").mkdir(parents=True)
+        (coded_tools / "other").mkdir(parents=True)
+        (coded_tools / "__init__.py").write_text("")
+        # The ancestor init's import is the only reference to other/shared.py anywhere.
+        (coded_tools / "grp" / "__init__.py").write_text("from coded_tools.other.shared import VALUE\n")
+        # No pkg.py next to it, so the class ref below resolves to the package *directory*.
+        (coded_tools / "grp" / "pkg" / "__init__.py").write_text("class Tool:\n    pass\n")
+        (coded_tools / "other" / "__init__.py").write_text("")
+        (coded_tools / "other" / "shared.py").write_text("VALUE = 1\n")
+        (registries / "net.hocon").write_text(
+            '{\n    "tools": [\n        { "name": "tool", "class": "grp.pkg.Tool" }\n    ]\n}\n'
+        )
+        target: Path = tmp_path / "out" / "net.zip"
+
+        exporter = AgentNetworkExporter(project_dir=str(project_dir))
+        result = exporter.export("net", output_path=str(target))
+
+        assert "coded_tools/grp/pkg" in result.dependencies.coded_tools
+        with zipfile.ZipFile(target) as zf:
+            names = set(zf.namelist())
+        # The walker scanned the ancestor init, so its import target is in the closure...
+        assert "coded_tools/other/shared.py" in names
+        # ...and the directory branch now bundles the ancestor init itself, so the
+        # receiver's grp package is regular (not a namespace portion) and re-exports work.
+        assert "coded_tools/grp/__init__.py" in names
+        assert "coded_tools/grp/pkg/__init__.py" in names
+
     def test_default_output_is_zip_when_deps_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Omitting -o on a deps network defaults to <name>.zip in cwd."""
         self._build_project_with_coded_tool(tmp_path / "project")

--- a/tests/neuro_san_studio/commands/test_agent_network_importer.py
+++ b/tests/neuro_san_studio/commands/test_agent_network_importer.py
@@ -25,6 +25,7 @@ from neuro_san.internals.graph.persistence.raw_manifest_restorer import RawManif
 
 from neuro_san_studio.discovery.dependency_analyzer import AgentNetworkDependencies
 from neuro_san_studio.importer.agent_network_importer import AgentNetworkImporter
+from neuro_san_studio.importer.bulk_import_result import BulkImportResult
 
 
 def _read_manifest_keys(manifest_path: Path) -> set:
@@ -634,6 +635,42 @@ class TestImportNetworks:
         target_dir.mkdir()
         self._build_source(source_dir)
         return AgentNetworkImporter(str(source_dir), str(target_dir))
+
+    def test_package_init_reexports_land_in_the_target(self, tmp_path: Path) -> None:
+        """A helper re-exported only by a package __init__.py must be copied.
+
+        Importing pkg.entry at runtime executes pkg/__init__.py first, so a tree copied
+        without helper.py raises ModuleNotFoundError before the tool even loads — the exact
+        failure class the dependency walker exists to prevent. coded_tools/tools/now_agents/
+        __init__.py is the in-repo instance of this shape.
+
+        :param tmp_path: pytest-provided temporary directory for the source and target trees.
+        """
+        source_dir: Path = tmp_path / "source"
+        target_dir: Path = tmp_path / "target"
+        target_dir.mkdir()
+        registries: Path = source_dir / "registries"
+        registries.mkdir(parents=True)
+        for shared in AgentNetworkImporter.SHARED_INCLUDES:
+            (registries / shared).write_text('{ "shared_instructions": "be helpful" }\n')
+        (registries / "net.hocon").write_text('{ "tools": [ { "name": "tool", "class": "pkg.entry.Entry" } ] }\n')
+        pkg: Path = source_dir / "coded_tools" / "pkg"
+        pkg.mkdir(parents=True)
+        (source_dir / "coded_tools" / "__init__.py").write_text("")
+        # The re-export is the only reference to helper: no HOCON names it, and entry.py
+        # does not import it.
+        (pkg / "__init__.py").write_text("from .helper import Helper\n")
+        (pkg / "entry.py").write_text("class Entry:\n    pass\n")
+        (pkg / "helper.py").write_text("class Helper:\n    pass\n")
+        (source_dir / "middleware").mkdir(parents=True)
+        importer: AgentNetworkImporter = AgentNetworkImporter(str(source_dir), str(target_dir))
+
+        bulk: BulkImportResult = importer.import_networks(["net.hocon"])
+
+        assert not bulk.all_errors
+        assert (target_dir / "coded_tools" / "pkg" / "helper.py").is_file()
+        # The init itself still arrives through the parent-init chain, not as a closure entry.
+        assert (target_dir / "coded_tools" / "pkg" / "__init__.py").is_file()
 
     def test_import_networks_does_not_touch_the_manifest(self, tmp_path: Path) -> None:
         """The bulk seam must leave the target manifest byte-identical.

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -22,6 +22,7 @@ import os
 import sys
 from pathlib import Path
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 import pytest
@@ -35,6 +36,12 @@ from neuro_san_studio.importer.agent_network_importer import AgentNetworkImporte
 from neuro_san_studio.utils.shared_registries import SHARED_REGISTRY_INCLUDES
 
 LOCAL_ROOTS: Tuple[str, ...] = ("coded_tools", "middleware")
+
+# The repo checkout the scaffold is copied from (PackagePaths.installed_library_root resolves
+# here when the tests run in-repo). Used to tell a `from pkg import name` that names a real
+# source module — which the walker must therefore have copied — from one that names an
+# attribute, which no static check can require.
+REPO_ROOT: Path = Path(__file__).resolve().parents[3]
 
 # What `ns init` must install. Spelled out rather than derived: the production list now comes from
 # neuro_san_studio/templates/manifest.hocon, so pinning the expectation independently makes a change
@@ -64,28 +71,97 @@ def fixture_scaffolded_project(tmp_path_factory: pytest.TempPathFactory) -> Path
     return root
 
 
-def _local_imports_of(source: Path) -> List[str]:
-    """Return every coded_tools.*/middleware.* module name that `source` imports."""
-    modules: List[str] = []
+def _import_from_base_parts(node: ast.ImportFrom, source_parts: List[str]) -> Optional[List[str]]:
+    """
+    Resolve the absolute package a ``from ... import ...`` statement is relative to.
+
+    Mirrors CPython (and LocalImportWalker._import_from_base): an absolute import is just
+    ``node.module``; a relative import anchors at the importing file's own package and climbs
+    ``level - 1`` packages from there.
+
+    :param node: The ``from ... import ...`` statement.
+    :param source_parts: The importing file's path segments relative to the project root,
+        e.g. ["coded_tools", "pkg", "tool.py"].
+    :return: Absolute module segments of the import's base, or None when a relative import
+        climbs above the tree (which CPython would reject too).
+    """
+    if node.level == 0:
+        if node.module is None:
+            return None
+        return node.module.split(".")
+    # Both `pkg/__init__.py` and `pkg/mod.py` sit in package `pkg`, so dropping the filename
+    # yields the anchor package either way.
+    package_parts: List[str] = source_parts[:-1]
+    climb: int = node.level - 1
+    if climb > len(package_parts):
+        return None
+    if climb:
+        anchor: List[str] = package_parts[: len(package_parts) - climb]
+    else:
+        anchor = package_parts
+    if not anchor:
+        return None
+    if node.module:
+        return anchor + node.module.split(".")
+    return anchor
+
+
+def _local_imports_of(source: Path, source_parts: List[str]) -> List[Tuple[List[str], bool]]:
+    """
+    Collect every project-local module reference `source` makes, across all import shapes.
+
+    Covers plain ``import a.b``, absolute ``from a.b import c``, and relative
+    ``from .sibling import c`` / ``from . import c`` — the shapes the dependency walker must
+    close over.
+
+    :param source: The .py file to parse.
+    :param source_parts: `source`'s path segments relative to the project root, used to
+        anchor relative imports the way CPython does.
+    :return: (module_segments, must_exist) pairs whose first segment is a LOCAL_ROOTS
+        package. must_exist is True for references that can only be a module (plain imports
+        and `from` bases). It is False for the names of a `from base import name` statement,
+        which may be attributes: those are required only when the source repo has them as
+        modules (see the caller).
+    """
+    references: List[Tuple[List[str], bool]] = []
     for node in ast.walk(ast.parse(source.read_text(encoding="utf-8"))):
         if isinstance(node, ast.Import):
-            modules.extend(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
-            modules.append(node.module)
-            modules.extend(f"{node.module}.{alias.name}" for alias in node.names)
-    return [module for module in modules if module.split(".")[0] in LOCAL_ROOTS]
+            for alias in node.names:
+                references.append((alias.name.split("."), True))
+        elif isinstance(node, ast.ImportFrom):
+            base: Optional[List[str]] = _import_from_base_parts(node, source_parts)
+            if base is None:
+                continue
+            references.append((base, True))
+            for alias in node.names:
+                # `from pkg import *` names nothing checkable statically.
+                if alias.name == "*":
+                    continue
+                references.append((base + [alias.name], False))
+    local: List[Tuple[List[str], bool]] = []
+    for parts, must_exist in references:
+        if parts and parts[0] in LOCAL_ROOTS:
+            local.append((parts, must_exist))
+    return local
 
 
-def _resolves_in(project: Path, module: str) -> bool:
-    """Whether `module` — or, for a `from x import y` name, its parent — exists under `project`."""
-    parts = module.split(".")
-    for candidate in (parts, parts[:-1]):
-        if not candidate:
-            continue
-        base = project.joinpath(*candidate)
-        if base.with_suffix(".py").is_file() or (base / "__init__.py").is_file():
-            return True
-    return False
+def _module_exists_under(root: Path, parts: List[str]) -> bool:
+    """
+    Whether the dotted module whose segments are `parts` is importable under `root`.
+
+    A bare directory counts too: an init-less directory is a PEP 420 namespace package the
+    runtime imports happily (the repo ships several under coded_tools/), so requiring an
+    __init__.py here would flag imports that actually work.
+
+    :param root: Directory holding the top-level packages (scaffold root or repo root).
+    :param parts: Module path segments, e.g. ["coded_tools", "pkg", "mod"].
+    :return: True when ``<root>/.../mod.py`` exists or ``<root>/.../mod`` is a directory
+        (with or without an ``__init__.py``).
+    """
+    base: Path = root.joinpath(*parts)
+    if base.with_suffix(".py").is_file():
+        return True
+    return base.is_dir()
 
 
 class TestProvidersArgParsing:
@@ -518,16 +594,31 @@ class TestDefaultNetworks:
         constants.py / and_logger.py / progress_handler.py it imports at module scope, and the
         designer died with ModuleNotFoundError on first use. Asserting the closure — rather than
         a hand-written file list — keeps holding as the designer's own imports change.
+
+        All import shapes count: plain `import a.b`, `from a.b import c`, and
+        relative `from .sibling import c` — including imports made only in a package
+        __init__.py, which execute whenever any module of the package is imported. A
+        `from base import name` name may be an attribute rather than a module, which no
+        static check can require; it is required exactly when the source repo has it as a
+        module, because then the walker's job was to copy it.
+
+        :param scaffolded_project: The shared read-only `ns init` scaffold fixture.
         """
         project = scaffolded_project
 
-        missing = [
-            (str(source.relative_to(project)), module)
-            for root in LOCAL_ROOTS
-            for source in (project / root).rglob("*.py")
-            for module in _local_imports_of(source)
-            if not _resolves_in(project, module)
-        ]
+        missing: List[Tuple[str, str]] = []
+        for root in LOCAL_ROOTS:
+            for source in sorted((project / root).rglob("*.py")):
+                source_parts: List[str] = list(source.relative_to(project).parts)
+                for parts, must_exist in _local_imports_of(source, source_parts):
+                    if _module_exists_under(project, parts):
+                        continue
+                    if not must_exist and not _module_exists_under(REPO_ROOT, parts):
+                        # `from base import name` where the repo has no such module either:
+                        # an attribute import, satisfied by `base` alone (checked above via
+                        # its own must_exist entry).
+                        continue
+                    missing.append((str(source.relative_to(project)), ".".join(parts)))
 
         assert not missing, f"scaffolded modules import files that were not scaffolded: {missing}"
 

--- a/tests/neuro_san_studio/discovery/test_local_import_walker.py
+++ b/tests/neuro_san_studio/discovery/test_local_import_walker.py
@@ -207,6 +207,64 @@ class TestExpand:
 
         assert result == ["coded_tools/pkg", "coded_tools/helper.py"]
 
+    def test_package_init_reexports_are_followed(self, tmp_path: Path) -> None:
+        """A re-export made only in a package __init__.py joins the closure.
+
+        Importing pkg.helper_a at runtime executes pkg/__init__.py first, so helper_b is as
+        required as helper_a even though no HOCON and no scanned module ever names it. The
+        init file itself stays out of the closure: the importer's parent-init chain and the
+        exporter's parent-init bundling already deliver it for every member.
+
+        :param tmp_path: pytest-provided temporary directory holding the synthetic roots.
+        """
+        _write(tmp_path, "coded_tools/pkg/__init__.py", "from .helper_a import A\nfrom .helper_b import B\n")
+        _write(tmp_path, "coded_tools/pkg/helper_a.py", "class A: pass\n")
+        _write(tmp_path, "coded_tools/pkg/helper_b.py", "class B: pass\n")
+
+        result = _walker(tmp_path).expand(["coded_tools/pkg/helper_a.py"])
+
+        assert "coded_tools/pkg/helper_b.py" in result
+        assert "coded_tools/pkg/__init__.py" not in result
+
+    def test_every_ancestor_init_is_scanned(self, tmp_path: Path) -> None:
+        """Imports made at any level of the containing-package chain are discovered.
+
+        Importing pkg.sub.mod executes pkg/__init__.py AND pkg/sub/__init__.py, so a
+        dependency named only in the outer init is required too — including one that lives
+        in a different package entirely.
+
+        :param tmp_path: pytest-provided temporary directory holding the synthetic roots.
+        """
+        _write(tmp_path, "coded_tools/other/__init__.py")
+        _write(tmp_path, "coded_tools/other/shared.py", "VALUE = 1\n")
+        _write(tmp_path, "coded_tools/pkg/__init__.py", "from coded_tools.other.shared import VALUE\n")
+        _write(tmp_path, "coded_tools/pkg/sub/__init__.py", "from .mod import Tool\n")
+        _write(tmp_path, "coded_tools/pkg/sub/mod.py", "class Tool: pass\n")
+
+        result = _walker(tmp_path).expand(["coded_tools/pkg/sub/mod.py"])
+
+        assert "coded_tools/other/shared.py" in result
+
+    def test_directory_member_ancestor_init_is_scanned(self, tmp_path: Path) -> None:
+        """A directory dependency's *ancestor* inits are scanned like a file member's.
+
+        The directory's own __init__.py is inside the copied tree and scanned by the
+        directory walk; the root package's __init__.py above it is neither, so an import
+        made only there used to be missed.
+
+        :param tmp_path: pytest-provided temporary directory holding the synthetic roots.
+        """
+        walker = _walker(tmp_path)
+        _write(tmp_path, "coded_tools/util.py", "VALUE = 1\n")
+        _write(tmp_path, "coded_tools/pkg/__init__.py", "class Tool: pass\n")
+        # After _walker(): it scaffolds the root __init__.py empty, and this test needs the
+        # root init to carry a real import.
+        (tmp_path / "coded_tools" / "__init__.py").write_text("from coded_tools.util import VALUE\n")
+
+        result = walker.expand(["coded_tools/pkg"])
+
+        assert "coded_tools/util.py" in result
+
     def test_input_order_preserved_and_deduplicated(self, tmp_path: Path) -> None:
         """Entry points stay ahead of their helpers, and nothing is listed twice."""
         _write(tmp_path, "coded_tools/pkg/__init__.py")


### PR DESCRIPTION
## Description

Fixes the dependency walker's blind spot for package `__init__.py` files.

`ns import` / `ns export` close a network's coded tools over their Python imports, but the walker only ever read the module files themselves — never the `__init__.py` files of the packages they live in. Python executes every ancestor `__init__.py` at import time, so an import made only there (the standard `from .helper import X` re-export) was silently missing from the closure, and the copied/exported tree raised `ModuleNotFoundError` the first time the tool was used.

Three parts:

- **`LocalImportWalker`**: `expand()` now scans each closure member's ancestor `__init__.py` files for imports. The init files themselves stay out of the returned closure — the importer's `_copy_parent_inits` and the exporter's parent-init bundling already deliver them — so existing output contracts (and copy/skip counts) are unchanged.
- **`AgentNetworkExporter`**: `_add_dep` bundled parent `__init__.py` files only for file-shaped deps; a directory-shaped tool's ancestor inits never made it into the zip, so the receiver got a namespace portion whose `__init__` code silently vanished. The directory branch now calls `_add_parent_inits` too, matching the importer.
- **Scaffold guard test**: `test_scaffolded_tree_is_import_complete` previously detected only the `from <dotted.module> import Name` shape of a missing module. It now covers plain imports, from-import submodules (disambiguated from attribute imports via the source repo), and relative imports, and tolerates PEP 420 namespace directories the runtime imports happily.

Note: this is largely a **precaution** — 30 of the 31 `__init__.py` files under `coded_tools/` and `middleware/` are blank today, which is why the gap never bit anyone. The one non-blank instance (`coded_tools/tools/now_agents/__init__.py`, which re-exports its three siblings) survives only because the hocon happens to reference all three directly. The fix matters for user projects going through `ns export`/`ns import` (re-export inits are standard Python style), and as a safety net ahead of the AND packaging refactor's code move (#1371), which is exactly the kind of change that introduces re-export inits.

Fixes #1377

## Impact

- Imported/exported networks whose coded tools rely on `__init__.py` imports now land complete instead of raising `ModuleNotFoundError` at first use. Verified end to end: the repro from #1377 now imports cleanly from the target tree in a fresh interpreter.
- Exported zips of directory-shaped tools now include the ancestor `__init__.py` chain, so the receiver's package is regular rather than a namespace portion.
- No change to what fresh `ns init` copies today (all scaffolded inits are blank), and no change to copy/skip counts.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
