### PR TITLE
#1380: Move generated-network timeout constant to base assembler and rename

### DIFF
--- a/middleware/agent_network_designer/persistence/agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/agent_network_assembler.py
@@ -20,6 +20,13 @@ from typing import Any
 
 from neuro_san.internals.validation.network.abstract_network_validator import AbstractNetworkValidator
 
+# Execution timeout stamped into every network the assemblers produce.
+# Not an overridable fallback — each assembler writes it unconditionally,
+# hence no DEFAULT_ prefix. The deployable path gets the same value from
+# deployable_template.hocon; tests assert against this constant so the
+# template and the constant cannot silently drift apart.
+GENERATED_NETWORK_MAX_EXECUTION_SECONDS: int = 600
+
 
 class AgentNetworkAssembler:
     """

--- a/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
+++ b/middleware/agent_network_designer/persistence/hocon_agent_network_assembler.py
@@ -21,9 +21,10 @@ from collections.abc import Mapping
 from copy import copy as shallow_copy
 from typing import Any
 
+from middleware.agent_network_designer.persistence.agent_network_assembler import (
+    GENERATED_NETWORK_MAX_EXECUTION_SECONDS,
+)
 from middleware.agent_network_designer.persistence.agent_network_assembler import AgentNetworkAssembler
-
-DEFAULT_MAX_EXECUTION_SECONDS = 600
 
 HOCON_HEADER_START = (
     "{\n"
@@ -54,7 +55,7 @@ HOCON_HEADER_START = (
     "# Note that the file path here is relative to the root level of the repo.\n"
     '    include "config/llm_config.hocon",\n'
     "\n"
-    f'    "max_execution_seconds": {DEFAULT_MAX_EXECUTION_SECONDS},\n'
+    f'    "max_execution_seconds": {GENERATED_NETWORK_MAX_EXECUTION_SECONDS},\n'
     "\n"
     '   "instructions_prefix": """\n'
     "You are part of a team of assistants in "

--- a/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_deployable_agent_network_assembler.py
@@ -27,11 +27,11 @@ pytest.importorskip("middleware.agent_network_designer.persistence.deployable_ag
 # The import must stay below importorskip so environments whose neuro-san
 # predates the assembler's imports skip cleanly.
 # pylint: disable=wrong-import-position
+from middleware.agent_network_designer.persistence.agent_network_assembler import (  # noqa: E402
+    GENERATED_NETWORK_MAX_EXECUTION_SECONDS,
+)
 from middleware.agent_network_designer.persistence.deployable_agent_network_assembler import (  # noqa: E402
     DeployableAgentNetworkAssembler,
-)
-from middleware.agent_network_designer.persistence.hocon_agent_network_assembler import (  # noqa: E402
-    DEFAULT_MAX_EXECUTION_SECONDS,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -73,10 +73,10 @@ def assemble(client_token_mcp_headers: dict[str, list[str]] | None) -> dict:
 
 
 def test_deployable_assembler_adds_max_execution_seconds():
-    """Generated deployable networks include the default execution timeout."""
+    """Generated deployable networks include the generated-network execution timeout."""
     config = assemble(None)
 
-    assert config["max_execution_seconds"] == DEFAULT_MAX_EXECUTION_SECONDS
+    assert config["max_execution_seconds"] == GENERATED_NETWORK_MAX_EXECUTION_SECONDS
 
 
 class TestDeployableAssemblerSlyDataSchema:

--- a/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
+++ b/tests/middleware/agent_network_designer/persistence/test_hocon_agent_network_assembler.py
@@ -23,7 +23,9 @@ from pathlib import Path
 
 from pyhocon import ConfigFactory
 
-from middleware.agent_network_designer.persistence.hocon_agent_network_assembler import DEFAULT_MAX_EXECUTION_SECONDS
+from middleware.agent_network_designer.persistence.agent_network_assembler import (
+    GENERATED_NETWORK_MAX_EXECUTION_SECONDS,
+)
 from middleware.agent_network_designer.persistence.hocon_agent_network_assembler import HoconAgentNetworkAssembler
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -71,10 +73,10 @@ def unquote(key: str) -> str:
 
 
 def test_hocon_assembler_adds_max_execution_seconds():
-    """Generated HOCON networks include the default execution timeout."""
+    """Generated HOCON networks include the generated-network execution timeout."""
     content = assemble(None)
 
-    assert f'"max_execution_seconds": {DEFAULT_MAX_EXECUTION_SECONDS}' in content
+    assert f'"max_execution_seconds": {GENERATED_NETWORK_MAX_EXECUTION_SECONDS}' in content
 
 
 class TestHoconAssemblerSlyDataSchema:


### PR DESCRIPTION
## Description

Moves the generated-network execution timeout constant from `hocon_agent_network_assembler.py` to the abstract base module `agent_network_assembler.py`, and renames it from `DEFAULT_MAX_EXECUTION_SECONDS` to `GENERATED_NETWORK_MAX_EXECUTION_SECONDS`. The timeout is a property of generated networks in general, not of the HOCON text format, and the value is written unconditionally into every generated network — it is not an overridable fallback, so the `DEFAULT_` prefix was misleading. Both assembler test files now import the constant from the base module instead of `test_deployable_agent_network_assembler.py` reaching into the hocon assembler module for it.

Fixes #1380

## Impact

No behavior change — the value stays 600 and the generated output is identical. Purely a rename and relocation of the constant, plus matching updates to the two tests and their docstrings. The value itself will be revisited separately once load testing settles on the right number.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [x] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**