### PR TITLE
Quiet pyhocon include noise during import analysis; parse-check the scaffolded designer manifest

### DIFF
--- a/neuro_san_studio/discovery/dependency_analyzer.py
+++ b/neuro_san_studio/discovery/dependency_analyzer.py
@@ -17,6 +17,7 @@
 """Walk a HOCON network's `tools` list to extract its file dependencies."""
 
 import contextlib
+import logging
 import os
 from dataclasses import dataclass
 from dataclasses import field
@@ -175,8 +176,24 @@ class DependencyAnalyzer:
         abs_path = os.path.abspath(hocon_path)
         source_root = os.path.dirname(self.registries_dir)
         anchor = contextlib.chdir(source_root) if os.path.isdir(source_root) else contextlib.nullcontext()
-        with anchor:
-            deps = self._walk(abs_path, set())
+        # Demote pyhocon's chatty include-resolution logging for the duration of the walk.
+        # A pip-installed source tree ships no `config/` directory (the package includes only
+        # neuro_san_studio*/registries*/coded_tools*/middleware*/skills*), so nearly every
+        # network's `include "config/llm_config.hocon"` would print "Cannot include file"
+        # to stderr once per parse — noise, not signal: the analyzer tolerates unresolved
+        # includes and substitutions by design (see analyze_network), and a genuinely missing
+        # dependency still surfaces as an importer warning. Same treatment as
+        # AgentNetworkImporter._read_existing_keys. ERROR is the lowest level that mutes the
+        # complaint (pyhocon logs it at WARNING and emits nothing above that), so a genuine
+        # error-level message from a future pyhocon would still get through.
+        pyhocon_logger: logging.Logger = logging.getLogger("pyhocon.config_parser")
+        prev_level: int = pyhocon_logger.level
+        try:
+            pyhocon_logger.setLevel(logging.ERROR)
+            with anchor:
+                deps = self._walk(abs_path, set())
+        finally:
+            pyhocon_logger.setLevel(prev_level)
         # Closing the set under Python-level imports is done once, at the top: `_walk`
         # merges each sub-network's results upward, so one expansion covers everything
         # without re-parsing the same files per level.

--- a/neuro_san_studio/discovery/dependency_analyzer.py
+++ b/neuro_san_studio/discovery/dependency_analyzer.py
@@ -182,10 +182,11 @@ class DependencyAnalyzer:
         # network's `include "config/llm_config.hocon"` would print "Cannot include file"
         # to stderr once per parse — noise, not signal: the analyzer tolerates unresolved
         # includes and substitutions by design (see analyze_network), and a genuinely missing
-        # dependency still surfaces as an importer warning. Same treatment as
-        # AgentNetworkImporter._read_existing_keys. ERROR is the lowest level that mutes the
-        # complaint (pyhocon logs it at WARNING and emits nothing above that), so a genuine
-        # error-level message from a future pyhocon would still get through.
+        # dependency still surfaces as an importer warning. Same scoped-demotion pattern as
+        # AgentNetworkImporter._read_existing_keys, though at ERROR rather than that method's
+        # CRITICAL: pyhocon logs the complaint at WARNING and emits nothing above that, so
+        # ERROR is the lowest level that mutes it — a genuine error-level message from a
+        # future pyhocon would still get through.
         pyhocon_logger: logging.Logger = logging.getLogger("pyhocon.config_parser")
         prev_level: int = pyhocon_logger.level
         try:

--- a/tests/neuro_san_studio/commands/test_init.py
+++ b/tests/neuro_san_studio/commands/test_init.py
@@ -21,6 +21,7 @@ import logging
 import os
 import sys
 from pathlib import Path
+from typing import Any
 from typing import List
 from typing import Tuple
 
@@ -549,6 +550,44 @@ class TestDefaultNetworks:
 
         for network in EXPECTED_DEFAULT_NETWORKS:
             assert network in keys, f"{network} was scaffolded but not registered"
+
+    def test_designer_manifest_parses_and_its_includes_resolve(
+        self, scaffolded_project: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The scaffolded manifest_and.hocon must parse cleanly through the designer's read path.
+
+        The designer's GetSubnetwork reads registries/manifest_and.hocon relative to the
+        project root via RawManifestRestorer, and pyhocon resolves its `include` directives
+        against the process CWD. A template drift — e.g. "syncing" it with the repo-level
+        registries/manifest_and.hocon, which additionally includes the industry manifest that
+        `ns init` never scaffolds — would make every fresh project emit pyhocon
+        "Cannot include file" warnings while still returning an empty mapping, so an
+        existence-only assertion cannot catch it. Guard both: the restore must produce a
+        mapping, and pyhocon must stay silent, meaning every include resolved.
+
+        :param scaffolded_project: The shared read-only `ns init` scaffold fixture.
+        :param caplog: pytest's log capture, used to detect pyhocon include failures.
+        """
+        project = scaffolded_project
+        prev_cwd: str = os.getcwd()
+        try:
+            os.chdir(project)
+            with caplog.at_level(logging.WARNING, logger="pyhocon.config_parser"):
+                # The external restorer is annotated `-> Any`; dict(raw) below proves it is a mapping.
+                raw: Any = RawManifestRestorer().restore(
+                    file_reference=os.path.join("registries", "manifest_and.hocon")
+                )
+        finally:
+            os.chdir(prev_cwd)
+
+        # A fresh scaffold has no generated networks yet, so the designer sees an empty
+        # (but valid) palette. dict() also asserts the restore returned a mapping.
+        assert not dict(raw)
+        pyhocon_complaints: List[str] = []
+        for record in caplog.records:
+            if record.name == "pyhocon.config_parser":
+                pyhocon_complaints.append(record.getMessage())
+        assert not pyhocon_complaints, f"manifest_and.hocon includes did not resolve: {pyhocon_complaints}"
 
     def test_support_networks_are_served_but_not_public(self, scaffolded_project: Path) -> None:
         """The designer's sub-networks and the CRUSE pair must be reachable, not listed.

--- a/tests/neuro_san_studio/discovery/test_analysis_logging.py
+++ b/tests/neuro_san_studio/discovery/test_analysis_logging.py
@@ -33,53 +33,53 @@ from neuro_san_studio.discovery.dependency_analyzer import AgentNetworkDependenc
 from neuro_san_studio.discovery.dependency_analyzer import DependencyAnalyzer
 
 
-def _build_source_with_missing_include(source_dir: Path) -> Path:
-    """
-    Lay out a source tree whose network includes a file that does not exist there.
+class TestAnalysisLogging:
+    """`get_transitive_dependencies` must keep pyhocon quiet and put its logger back."""
 
-    Mirrors the pip layout: the network references `config/llm_config.hocon`, which the
-    installed package never ships. No `${substitution}` is used, so the parse itself
-    succeeds and the class reference below stays extractable.
+    @staticmethod
+    def _build_source_with_missing_include(source_dir: Path) -> Path:
+        """
+        Lay out a source tree whose network includes a file that does not exist there.
 
-    :param source_dir: Root directory to build the synthetic source tree under.
-    :return: The full path of the network HOCON to analyze.
-    """
-    registries: Path = source_dir / "registries"
-    registries.mkdir(parents=True)
-    hocon: Path = registries / "demo.hocon"
-    hocon.write_text(
-        """{
+        Mirrors the pip layout: the network references `config/llm_config.hocon`, which the
+        installed package never ships. No `${substitution}` is used, so the parse itself
+        succeeds and the class reference below stays extractable.
+
+        :param source_dir: Root directory to build the synthetic source tree under.
+        :return: The full path of the network HOCON to analyze.
+        """
+        registries: Path = source_dir / "registries"
+        registries.mkdir(parents=True)
+        hocon: Path = registries / "demo.hocon"
+        hocon.write_text(
+            """{
     include "config/llm_config.hocon",
     "tools": [
         { "name": "demo", "class": "demo_tool.DemoTool" }
     ]
 }
 """
-    )
-    coded_tools: Path = source_dir / "coded_tools"
-    coded_tools.mkdir(parents=True)
-    (coded_tools / "__init__.py").write_text("")
-    (coded_tools / "demo_tool.py").write_text("class DemoTool:\n    pass\n")
-    (source_dir / "middleware").mkdir(parents=True)
-    return hocon
+        )
+        coded_tools: Path = source_dir / "coded_tools"
+        coded_tools.mkdir(parents=True)
+        (coded_tools / "__init__.py").write_text("")
+        (coded_tools / "demo_tool.py").write_text("class DemoTool:\n    pass\n")
+        (source_dir / "middleware").mkdir(parents=True)
+        return hocon
 
+    @staticmethod
+    def _analyzer(source_dir: Path) -> DependencyAnalyzer:
+        """
+        Build an analyzer rooted at `source_dir`.
 
-def _analyzer(source_dir: Path) -> DependencyAnalyzer:
-    """
-    Build an analyzer rooted at `source_dir`.
-
-    :param source_dir: Root of the synthetic source tree.
-    :return: A DependencyAnalyzer over that tree's registries/coded_tools/middleware roots.
-    """
-    return DependencyAnalyzer(
-        str(source_dir / "registries"),
-        str(source_dir / "coded_tools"),
-        str(source_dir / "middleware"),
-    )
-
-
-class TestAnalysisLogging:
-    """`get_transitive_dependencies` must keep pyhocon quiet and put its logger back."""
+        :param source_dir: Root of the synthetic source tree.
+        :return: A DependencyAnalyzer over that tree's registries/coded_tools/middleware roots.
+        """
+        return DependencyAnalyzer(
+            str(source_dir / "registries"),
+            str(source_dir / "coded_tools"),
+            str(source_dir / "middleware"),
+        )
 
     def test_unresolvable_include_logs_nothing(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """An include that cannot resolve must not reach the console, and analysis must still work.
@@ -88,10 +88,10 @@ class TestAnalysisLogging:
         :param caplog: pytest's log capture, used to detect pyhocon's include complaints.
         """
         source: Path = tmp_path / "source"
-        hocon: Path = _build_source_with_missing_include(source)
+        hocon: Path = self._build_source_with_missing_include(source)
 
         with caplog.at_level(logging.WARNING, logger="pyhocon.config_parser"):
-            deps: AgentNetworkDependencies = _analyzer(source).get_transitive_dependencies(str(hocon))
+            deps: AgentNetworkDependencies = self._analyzer(source).get_transitive_dependencies(str(hocon))
 
         # The failed include must not have cost us the actual dependency extraction.
         assert deps.coded_tools == ["coded_tools/demo_tool.py"]
@@ -107,13 +107,13 @@ class TestAnalysisLogging:
         :param tmp_path: pytest-provided temporary directory for the synthetic source tree.
         """
         source: Path = tmp_path / "source"
-        hocon: Path = _build_source_with_missing_include(source)
+        hocon: Path = self._build_source_with_missing_include(source)
         pyhocon_logger: logging.Logger = logging.getLogger("pyhocon.config_parser")
         prev_level: int = pyhocon_logger.level
         try:
             pyhocon_logger.setLevel(logging.DEBUG)
 
-            _analyzer(source).get_transitive_dependencies(str(hocon))
+            self._analyzer(source).get_transitive_dependencies(str(hocon))
 
             assert pyhocon_logger.level == logging.DEBUG
         finally:

--- a/tests/neuro_san_studio/discovery/test_analysis_logging.py
+++ b/tests/neuro_san_studio/discovery/test_analysis_logging.py
@@ -1,0 +1,121 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Dependency analysis must not spam the console with pyhocon include warnings.
+
+A pip-installed source tree ships no `config/` directory, so nearly every network's
+`include "config/llm_config.hocon"` fails to resolve during analysis. That is expected —
+the analyzer tolerates unresolved includes by design — but pyhocon logs
+"Cannot include file ..." once per parse, which interleaved noise into every
+`ns init` / `ns import` run on a pip install.
+"""
+
+import logging
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from neuro_san_studio.discovery.dependency_analyzer import AgentNetworkDependencies
+from neuro_san_studio.discovery.dependency_analyzer import DependencyAnalyzer
+
+
+def _build_source_with_missing_include(source_dir: Path) -> Path:
+    """
+    Lay out a source tree whose network includes a file that does not exist there.
+
+    Mirrors the pip layout: the network references `config/llm_config.hocon`, which the
+    installed package never ships. No `${substitution}` is used, so the parse itself
+    succeeds and the class reference below stays extractable.
+
+    :param source_dir: Root directory to build the synthetic source tree under.
+    :return: The full path of the network HOCON to analyze.
+    """
+    registries: Path = source_dir / "registries"
+    registries.mkdir(parents=True)
+    hocon: Path = registries / "demo.hocon"
+    hocon.write_text(
+        """{
+    include "config/llm_config.hocon",
+    "tools": [
+        { "name": "demo", "class": "demo_tool.DemoTool" }
+    ]
+}
+"""
+    )
+    coded_tools: Path = source_dir / "coded_tools"
+    coded_tools.mkdir(parents=True)
+    (coded_tools / "__init__.py").write_text("")
+    (coded_tools / "demo_tool.py").write_text("class DemoTool:\n    pass\n")
+    (source_dir / "middleware").mkdir(parents=True)
+    return hocon
+
+
+def _analyzer(source_dir: Path) -> DependencyAnalyzer:
+    """
+    Build an analyzer rooted at `source_dir`.
+
+    :param source_dir: Root of the synthetic source tree.
+    :return: A DependencyAnalyzer over that tree's registries/coded_tools/middleware roots.
+    """
+    return DependencyAnalyzer(
+        str(source_dir / "registries"),
+        str(source_dir / "coded_tools"),
+        str(source_dir / "middleware"),
+    )
+
+
+class TestAnalysisLogging:
+    """`get_transitive_dependencies` must keep pyhocon quiet and put its logger back."""
+
+    def test_unresolvable_include_logs_nothing(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """An include that cannot resolve must not reach the console, and analysis must still work.
+
+        :param tmp_path: pytest-provided temporary directory for the synthetic source tree.
+        :param caplog: pytest's log capture, used to detect pyhocon's include complaints.
+        """
+        source: Path = tmp_path / "source"
+        hocon: Path = _build_source_with_missing_include(source)
+
+        with caplog.at_level(logging.WARNING, logger="pyhocon.config_parser"):
+            deps: AgentNetworkDependencies = _analyzer(source).get_transitive_dependencies(str(hocon))
+
+        # The failed include must not have cost us the actual dependency extraction.
+        assert deps.coded_tools == ["coded_tools/demo_tool.py"]
+        pyhocon_complaints: List[str] = []
+        for record in caplog.records:
+            if record.name == "pyhocon.config_parser":
+                pyhocon_complaints.append(record.getMessage())
+        assert not pyhocon_complaints, f"pyhocon noise leaked through: {pyhocon_complaints}"
+
+    def test_pyhocon_logger_level_is_restored(self, tmp_path: Path) -> None:
+        """The demotion is scoped to the walk; a caller's own pyhocon level must survive.
+
+        :param tmp_path: pytest-provided temporary directory for the synthetic source tree.
+        """
+        source: Path = tmp_path / "source"
+        hocon: Path = _build_source_with_missing_include(source)
+        pyhocon_logger: logging.Logger = logging.getLogger("pyhocon.config_parser")
+        prev_level: int = pyhocon_logger.level
+        try:
+            pyhocon_logger.setLevel(logging.DEBUG)
+
+            _analyzer(source).get_transitive_dependencies(str(hocon))
+
+            assert pyhocon_logger.level == logging.DEBUG
+        finally:
+            # Never leak a DEBUG pyhocon logger into the rest of the suite.
+            pyhocon_logger.setLevel(prev_level)


### PR DESCRIPTION
## Description

Part of #1378 (items 1 and 4).

**Item 1 — pyhocon include noise on pip installs.** The dependency-analysis walk chdirs into the *source* tree so relative includes resolve while parsing. For a pip install that's site-packages, which deliberately doesn't ship `config/` (`pyproject.toml` excludes it) — so nearly every shipped network's `include "config/llm_config.hocon"` makes pyhocon log `Cannot include file config/llm_config.hocon. File does not exist or cannot be read.` to stderr: 11 lines during a default `ns init`. The failure is noise, not signal — the analyzer tolerates unresolved includes by design, and I verified the scaffolded output is byte-for-byte identical with and without them. This PR demotes the `pyhocon.config_parser` logger for the duration of the walk and restores the caller's level in a `finally`. ERROR is the mute level because pyhocon logs this complaint at WARNING and emits nothing above WARNING anywhere, so a genuine error-level message from a future pyhocon would still get through.

While verifying I found the noise currently shows only on `ns init`, not `ns import`: loading the import command pulls in `agent_network_registry.py`, whose module-level `setLevel(logging.ERROR)` happens to mute the logger process-wide first. The include failure still occurs during import — it's just hidden by that side effect of module-import order. This change makes the muting deliberate, scoped, and independent of which command module loaded first. (I've corrected the wording in #1378 accordingly.)

**Item 4 — `manifest_and.hocon` test coverage was existence-only.** If the template ever drifts to include a manifest that `ns init` doesn't scaffold (e.g. "syncing" it with the repo-level `registries/manifest_and.hocon`, which additionally includes the industry manifest), every fresh project's designer would emit pyhocon warnings with all tests green. The new test restores the scaffolded `manifest_and.hocon` through `RawManifestRestorer` from the scaffold root — the designer's actual read path — and asserts it produces a mapping with zero pyhocon complaints, i.e. every include resolved.

## Impact

- Pip-install users no longer see 11 lines of spurious "Cannot include file" noise on `ns init`; repo checkouts were never affected (the repo root has `config/`, so the includes resolve there).
- No behavior change to what init/import analyze or copy — verified by diffing the scaffolded trees before/after.
- The pyhocon logger level is restored after the walk, so callers' own logging configuration survives.

## Screenshots / Logs / Examples

Live repro with current main pip-installed into a clean venv, `ns init` in an empty directory:

```
$ ns init 2>stderr.txt; grep -c "Cannot include" stderr.txt
11
```

Same with this branch's `dependency_analyzer.py`:

```
$ ns init 2>stderr.txt; grep -c "Cannot include" stderr.txt
0
```

Scaffolded file sets are identical in both runs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**