### PR TITLE
Don't plant __init__.py in package roots the import never touched

### DIFF
--- a/neuro_san_studio/importer/agent_network_importer.py
+++ b/neuro_san_studio/importer/agent_network_importer.py
@@ -236,7 +236,11 @@ class AgentNetworkImporter:
                     try:
                         os.makedirs(os.path.dirname(init_dst), exist_ok=True)
                         shutil.copy2(init_src, init_dst)
-                        result.copied_files.append(os.path.join(os.path.basename(roots.target), rel))
+                        # Record with forward slashes regardless of platform: every other
+                        # display uses "/", and downstream bookkeeping (`_touched_under`)
+                        # compares displays as "/"-separated strings.
+                        display = os.path.join(os.path.basename(roots.target), rel).replace(os.sep, "/")
+                        result.copied_files.append(display)
                     except OSError as exc:
                         result.errors.append(f"Failed to copy __init__.py: {exc}")
             if current_dir == roots.source:
@@ -255,9 +259,15 @@ class AgentNetworkImporter:
         Only ever creates an empty file, never copies: if the source had one to give,
         `_copy_parent_inits` already delivered it. Deliberately does not create the directory
         -- the contract is "if we put files there, make it importable", not "every project
-        gets a coded_tools/".
+        gets a coded_tools/". The same contract is why a root this import never touched is
+        left alone: a self-contained .hocon import must not convert a target's intentional
+        namespace-package coded_tools/ into a regular package as a side effect.
         """
         for roots in (self.coded_tools, self.middleware):
+            # Skipped files count as "touched" too: on a re-run of the same import, the files
+            # are already in place and a missing root __init__.py should still be healed.
+            if not self._touched_under(result, os.path.basename(roots.target) + "/"):
+                continue
             target = os.path.join(roots.target, "__init__.py")
             if os.path.exists(target) or not os.path.isdir(roots.target):
                 continue
@@ -268,6 +278,26 @@ class AgentNetworkImporter:
                 result.errors.append(f"Failed to create {target}: {exc}")
                 continue
             result.copied_files.append(f"{os.path.basename(roots.target)}/__init__.py")
+
+    @staticmethod
+    def _touched_under(result: ImportResult, prefix: str) -> bool:
+        """
+        Whether this import copied or skipped anything under the given root prefix.
+
+        Skips count: a skipped file proves the import *wanted* to place content there, so the
+        root is part of this import's footprint even when every file already existed.
+
+        :param result: The in-progress import outcome to inspect.
+        :param prefix: Root-relative display prefix, e.g. ``"coded_tools/"``.
+        :return: True when any copied or skipped display path starts with ``prefix``.
+        """
+        for copied_file in result.copied_files:
+            if copied_file.startswith(prefix):
+                return True
+        for skipped_file in result.skipped_files:
+            if skipped_file.startswith(prefix):
+                return True
+        return False
 
     def import_from_path(self, source_path: str, force: bool = False) -> ImportResult:
         """Import a single network from a local file path.
@@ -327,19 +357,24 @@ class AgentNetworkImporter:
                     payload = zf.read(info).decode("utf-8")
                     self._merge_mcp_text(payload, result)
                     continue
-                target = os.path.join(self.target_dir, rel)
+                # Extract to — and record — the normalized path, not the raw entry name.
+                # A zip may spell entries "./coded_tools/tool.py" or (from a Windows builder)
+                # "coded_tools\\tool.py"; validation normalizes only its whitelist check, so
+                # raw names would land odd paths on disk and leave displays that downstream
+                # bookkeeping (`_touched_under`) cannot match against.
+                target = os.path.join(self.target_dir, normalized)
                 # Track every bundled registry HOCON for manifest registration — including
                 # skipped (already-present) ones, so re-running with the same bundle still
                 # ensures the entry exists in the receiver's manifest.
                 if normalized.startswith("registries/") and normalized.endswith(".hocon"):
                     self._register_manifest_entry(result, normalized[len("registries/") :])
                 if os.path.exists(target) and not force:
-                    result.skipped_files.append(rel)
+                    result.skipped_files.append(normalized)
                     continue
                 os.makedirs(os.path.dirname(target), exist_ok=True)
                 with zf.open(info) as src, open(target, "wb") as dst:
                     shutil.copyfileobj(src, dst)
-                result.copied_files.append(rel)
+                result.copied_files.append(normalized)
         return result
 
     @staticmethod

--- a/tests/neuro_san_studio/commands/test_agent_network_importer.py
+++ b/tests/neuro_san_studio/commands/test_agent_network_importer.py
@@ -871,11 +871,13 @@ class TestPackageRootsAreRegularPackages:
         assert not (target_dir / "middleware").exists()
 
     def test_root_init_healed_when_all_files_skip(self, tmp_path: Path) -> None:
-        """A re-import whose files all already exist must still heal a missing root __init__.py.
+        """A re-import whose coded-tool files all already exist must still heal the root __init__.py.
 
-        Skips prove the import wanted to place content under the root, so the root is part
-        of the import's footprint even when nothing was copied — e.g. a user hand-copied the
-        tool files but not the package inits, then ran the import to repair the project.
+        Everything under coded_tools/ skips here (only the registry hocon copies), so the
+        heal must be triggered by the skips alone: they prove the import wanted to place
+        content under the root, making it part of the import's footprint — e.g. a user
+        hand-copied the tool files but not the package inits, then re-ran the import to
+        repair the project.
 
         :param tmp_path: pytest-provided temporary directory for the source and target trees.
         """
@@ -883,7 +885,8 @@ class TestPackageRootsAreRegularPackages:
         target_dir: Path = tmp_path / "target"
         target_dir.mkdir()
         self._source_without_root_init(source_dir)
-        # Pre-place every file the import would deliver, but no root __init__.py.
+        # Pre-place every coded-tool file the import would deliver, but no root __init__.py.
+        # The registry hocon is deliberately NOT pre-placed; it still copies normally.
         pre_placed: Path = target_dir / "coded_tools" / "demo"
         pre_placed.mkdir(parents=True)
         (pre_placed / "__init__.py").write_text("")

--- a/tests/neuro_san_studio/commands/test_agent_network_importer.py
+++ b/tests/neuro_san_studio/commands/test_agent_network_importer.py
@@ -25,21 +25,27 @@ from neuro_san.internals.graph.persistence.raw_manifest_restorer import RawManif
 
 from neuro_san_studio.discovery.dependency_analyzer import AgentNetworkDependencies
 from neuro_san_studio.importer.agent_network_importer import AgentNetworkImporter
-
-
-def _read_manifest_keys(manifest_path: Path) -> set:
-    """Read a manifest.hocon (with possible includes) into a set of declared keys."""
-    prev_cwd = os.getcwd()
-    try:
-        os.chdir(manifest_path.parent.parent)
-        raw = RawManifestRestorer().restore(file_reference=str(manifest_path))
-    finally:
-        os.chdir(prev_cwd)
-    return {key.strip('"') for key in raw if isinstance(key, str)}
+from neuro_san_studio.importer.import_result import ImportResult
 
 
 class TestImportNetwork:
     """Integration tests for AgentNetworkImporter."""
+
+    @staticmethod
+    def _read_manifest_keys(manifest_path: Path) -> set:
+        """
+        Read a manifest.hocon (with possible includes) into a set of declared keys.
+
+        :param manifest_path: Path of the manifest.hocon to restore.
+        :return: The set of network keys the manifest declares, quotes stripped.
+        """
+        prev_cwd = os.getcwd()
+        try:
+            os.chdir(manifest_path.parent.parent)
+            raw = RawManifestRestorer().restore(file_reference=str(manifest_path))
+        finally:
+            os.chdir(prev_cwd)
+        return {key.strip('"') for key in raw if isinstance(key, str)}
 
     @staticmethod
     def _build_fake_source(source_dir: Path) -> None:
@@ -146,7 +152,7 @@ class TestImportNetwork:
         importer = AgentNetworkImporter(str(tmp_path / "source"), str(target_dir))
         importer.update_manifest(["basic/music_nerd.hocon", "agent_network_designer.hocon"])
 
-        merged = _read_manifest_keys(manifest_path)
+        merged = self._read_manifest_keys(manifest_path)
         assert merged == {
             "agent_network_designer.hocon",
             "basic/coffee_finder.hocon",
@@ -160,7 +166,7 @@ class TestImportNetwork:
         importer.update_manifest(["basic/music_nerd.hocon"])
 
         manifest_path = target_dir / "registries" / "manifest.hocon"
-        assert _read_manifest_keys(manifest_path) == {"basic/music_nerd.hocon"}
+        assert self._read_manifest_keys(manifest_path) == {"basic/music_nerd.hocon"}
 
     def test_update_manifest_preserves_include_directive(self, tmp_path: Path) -> None:
         """The scaffolded `include "registries/generated/manifest.hocon"` line must survive imports.
@@ -196,7 +202,7 @@ class TestImportNetwork:
         # music_nerd.hocon was already declared — never duplicated, never re-emitted.
         assert text.count('"music_nerd.hocon"') == 1
         # Both new entries got registered.
-        keys = _read_manifest_keys(manifest_path)
+        keys = self._read_manifest_keys(manifest_path)
         assert "agent_network_designer.hocon" in keys
         assert "advanced_calculator.hocon" in keys
         assert "music_nerd.hocon" in keys
@@ -826,6 +832,80 @@ class TestPackageRootsAreRegularPackages:
 
         assert not (target_dir / "coded_tools").exists()
         assert not (target_dir / "middleware").exists()
+
+    def test_root_init_healed_when_all_files_skip(self, tmp_path: Path) -> None:
+        """A re-import whose files all already exist must still heal a missing root __init__.py.
+
+        Skips prove the import wanted to place content under the root, so the root is part
+        of the import's footprint even when nothing was copied — e.g. a user hand-copied the
+        tool files but not the package inits, then ran the import to repair the project.
+
+        :param tmp_path: pytest-provided temporary directory for the source and target trees.
+        """
+        source_dir: Path = tmp_path / "source"
+        target_dir: Path = tmp_path / "target"
+        target_dir.mkdir()
+        self._source_without_root_init(source_dir)
+        # Pre-place every file the import would deliver, but no root __init__.py.
+        pre_placed: Path = target_dir / "coded_tools" / "demo"
+        pre_placed.mkdir(parents=True)
+        (pre_placed / "__init__.py").write_text("")
+        (pre_placed / "tool.py").write_text("class Tool:\n    pass\n")
+        importer: AgentNetworkImporter = AgentNetworkImporter(str(source_dir), str(target_dir))
+        deps: AgentNetworkDependencies = AgentNetworkDependencies(coded_tools=["coded_tools/demo/tool.py"])
+
+        result: ImportResult = importer.import_network("demo.hocon", deps)
+
+        assert "coded_tools/demo/tool.py" in result.skipped_files
+        assert (target_dir / "coded_tools" / "__init__.py").is_file()
+
+    def test_dot_prefixed_zip_entries_land_normalized_and_heal_the_root(self, tmp_path: Path) -> None:
+        """Zip entries spelled "./coded_tools/..." must extract to clean paths with a healed root.
+
+        Validation normalizes entry names only for its whitelist check; extraction and the
+        recorded displays must use the same normalized form, or the files land under odd
+        paths and the root-__init__ gate cannot see that coded_tools/ was touched.
+
+        :param tmp_path: pytest-provided temporary directory for the bundle and target tree.
+        """
+        zip_path: Path = tmp_path / "bundle.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("./registries/demo.hocon", '{ "tools": [] }\n')
+            zf.writestr("./coded_tools/demo/tool.py", "class Tool:\n    pass\n")
+        target_dir: Path = tmp_path / "target"
+        target_dir.mkdir()
+        importer: AgentNetworkImporter = AgentNetworkImporter(str(target_dir), str(target_dir))
+
+        result: ImportResult = importer.import_from_path(str(zip_path))
+
+        assert (target_dir / "coded_tools" / "demo" / "tool.py").is_file()
+        assert (target_dir / "coded_tools" / "__init__.py").is_file()
+        # Displays are the normalized paths, so batch bookkeeping can match on them.
+        assert "coded_tools/demo/tool.py" in result.copied_files
+
+    def test_untouched_root_is_left_alone(self, tmp_path: Path) -> None:
+        """A self-contained .hocon import must not mutate a coded_tools/ it never wrote to.
+
+        The target's init-less coded_tools/ may be an intentional PEP 420 namespace package
+        (e.g. merged across sys.path entries). Creating an __init__.py there as a side effect
+        of importing an unrelated network silently converts it to a regular package —
+        the contract is "if we put files there, make it importable", and this import put
+        nothing there.
+
+        :param tmp_path: pytest-provided temporary directory for the target project.
+        """
+        target_dir: Path = tmp_path / "target"
+        target_dir.mkdir()
+        # An intentional namespace-package root, present before the import, no __init__.py.
+        (target_dir / "coded_tools").mkdir()
+        solo: Path = tmp_path / "solo.hocon"
+        solo.write_text('{ "tools": [] }\n')
+        importer: AgentNetworkImporter = AgentNetworkImporter(str(target_dir), str(target_dir))
+
+        result: ImportResult = importer.import_from_path(str(solo))
+
+        assert not (target_dir / "coded_tools" / "__init__.py").exists()
+        assert "coded_tools/__init__.py" not in result.copied_files
 
     def test_existing_root_init_is_never_clobbered(self, tmp_path: Path) -> None:
         """A project's own __init__.py survives a re-import byte-for-byte."""


### PR DESCRIPTION
## Description

Part of #1378 (item 3).

**The one-line version:** after *any* import, the importer creates an empty `coded_tools/__init__.py` in the target project if that file is missing — even when the import didn't put a single file under `coded_tools/`. This PR makes it only do that when the import actually placed files there.

**Why an empty `__init__.py` is not a trivial side effect:** whether that file exists changes Python's import semantics for the whole project. A `coded_tools/` *without* `__init__.py` is a namespace package — Python merges it with (or defers to) other `coded_tools` packages on `sys.path`, and some projects rely on that deliberately. The moment a regular-package `__init__.py` appears, that merging stops and this directory shadows everything else. So the importer creating this file is genuinely useful when it just copied tools in (it protects the project's tools from being shadowed by neuro-san-studio's own bundled `coded_tools` on a pip install) — and genuinely harmful when the import had nothing to do with that directory: importing one self-contained `.hocon` with no coded tools at all silently rewires how the target project imports, and reports the phantom file under "Copied". `_ensure_package_roots`'s own docstring states the contract — *"if we put files there, make it importable"* — the code just never checked the "if we put files there" half.

**The fix:** a `_touched_under` gate — heal a root only when this import copied **or skipped** at least one file under it. Skipped files count on purpose: when you re-run an import and every file already exists, the skips still prove the import's footprint covers that root, so a missing root `__init__.py` is still healed.

**Supporting fix — zip path normalization:** the gate compares recorded paths against the `coded_tools/` prefix, so those records must be trustworthy. The zip path previously extracted and recorded raw entry names: a bundle built as `zip -r net.zip ./coded_tools` spells entries `./coded_tools/tool.py` (and a Windows-built zip can use backslashes), which landed odd literal paths on disk and produced records the prefix check could never match. Zip entries are now extracted to — and recorded as — their normalized paths, and parent-init copies record forward-slash paths regardless of platform.

## Impact

- Imports that place files under `coded_tools/` or `middleware/` behave exactly as before — the root is still healed, including on all-files-skipped re-runs.
- Imports that never touch a root no longer modify it: an intentionally namespace-package `coded_tools/` survives unrelated imports, and the import report no longer lists a file the import didn't deliver.
- `./`-prefixed or backslash-spelled zip bundles now land canonical paths on disk instead of odd literal ones.
- A follow-up PR (item 2 of #1378, the skip-count reporting fix) builds on these normalized path records.

## Screenshots / Logs / Examples

New regression test (fails on main): a target with a deliberately init-less `coded_tools/` imports a self-contained `.hocon` — on main, `coded_tools/__init__.py` appears out of nowhere; with this PR the directory is left exactly as it was.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**