### PR TITLE
#1386: Split AGENT_MANIFEST_FILE on os.pathsep instead of whitespace

### DIFF
--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -51,6 +51,9 @@ from coded_tools.agent_network_editor.constants import AGENT_NETWORK_NAME
 from coded_tools.agent_network_editor.progress_handler import ProgressHandler
 from coded_tools.agent_network_editor.sly_data_lock import SlyDataLock
 from middleware.agent_network_designer.persistence.file_system_agent_network_persistor import DEFAULT_REGISTRIES_DIR
+from middleware.agent_network_designer.persistence.file_system_agent_network_persistor import (
+    FileSystemAgentNetworkPersistor,
+)
 
 AGENT_NETWORK_HOCON_FILE: str = "agent_network_hocon_file"
 AGENT_RESERVATIONS: str = "agent_reservations"
@@ -492,10 +495,10 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
              existing file under cwd, it is used as-is. This covers paths copied from the
              repo tree such as "registries/generated/foo.hocon".
           3. Otherwise, paths are resolved against ``base_dir`` — the directory of the
-             first entry in ``AGENT_MANIFEST_FILE`` (an ``os.pathsep``-separated list of
-             manifest files, like ``PATH``), or ``DEFAULT_REGISTRIES_DIR`` when the env
-             var is empty or unset. This mirrors ``FileSystemAgentNetworkPersistor`` so
-             loads and saves agree on file location.
+             first non-empty entry in ``AGENT_MANIFEST_FILE`` (an ``os.pathsep``-separated
+             list of manifest files, like ``PATH``), or ``DEFAULT_REGISTRIES_DIR`` when the
+             env var is empty or unset. The parse is shared with
+             ``FileSystemAgentNetworkPersistor`` so loads and saves agree on file location.
 
         Backslashes in the input are normalized to forward slashes so Windows-style paths
         work on POSIX (and vice versa).
@@ -540,13 +543,10 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             return trimmed_input
 
         # Derive the base registries directory from AGENT_MANIFEST_FILE (the dirname of the
-        # first listed manifest), falling back to the default registries directory. The env
-        # var is an os.pathsep-separated list (like PATH), matching how neuro-san's
-        # RegistryManifestRestorer and FileSystemAgentNetworkPersistor parse it. Splitting
-        # an empty string yields [""], so guard on the first entry being non-empty.
-        agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
-        manifest_parts: list[str] = agent_manifest_file.split(os.pathsep)
-        base_dir: str = os.path.dirname(manifest_parts[0]) if manifest_parts[0] else DEFAULT_REGISTRIES_DIR
+        # first non-empty entry), falling back to the default registries directory. The
+        # parse is shared with the persistor so loads and saves cannot drift apart again.
+        first_manifest: str = FileSystemAgentNetworkPersistor.get_first_manifest_path()
+        base_dir: str = os.path.dirname(first_manifest) if first_manifest else DEFAULT_REGISTRIES_DIR
         return (Path(base_dir) / trimmed_input).as_posix()
 
     async def _hocon_to_config(self, network_hocon_file: str | None) -> dict[str, Any] | None:

--- a/middleware/agent_network_designer/agent_network_definition_middleware.py
+++ b/middleware/agent_network_designer/agent_network_definition_middleware.py
@@ -492,10 +492,10 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
              existing file under cwd, it is used as-is. This covers paths copied from the
              repo tree such as "registries/generated/foo.hocon".
           3. Otherwise, paths are resolved against ``base_dir`` — the directory of the
-             first entry in ``AGENT_MANIFEST_FILE`` (a whitespace-separated list of
-             manifest files), or ``DEFAULT_REGISTRIES_DIR`` when the env var is empty or
-             unset. This mirrors ``FileSystemAgentNetworkPersistor`` so loads and saves
-             agree on file location.
+             first entry in ``AGENT_MANIFEST_FILE`` (an ``os.pathsep``-separated list of
+             manifest files, like ``PATH``), or ``DEFAULT_REGISTRIES_DIR`` when the env
+             var is empty or unset. This mirrors ``FileSystemAgentNetworkPersistor`` so
+             loads and saves agree on file location.
 
         Backslashes in the input are normalized to forward slashes so Windows-style paths
         work on POSIX (and vice versa).
@@ -540,10 +540,13 @@ class AgentNetworkDefinitionMiddleware(AgentMiddleware):
             return trimmed_input
 
         # Derive the base registries directory from AGENT_MANIFEST_FILE (the dirname of the
-        # first listed manifest), falling back to the default registries directory.
+        # first listed manifest), falling back to the default registries directory. The env
+        # var is an os.pathsep-separated list (like PATH), matching how neuro-san's
+        # RegistryManifestRestorer and FileSystemAgentNetworkPersistor parse it. Splitting
+        # an empty string yields [""], so guard on the first entry being non-empty.
         agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
-        manifest_parts: list[str] = agent_manifest_file.split()
-        base_dir: str = os.path.dirname(manifest_parts[0]) if manifest_parts else DEFAULT_REGISTRIES_DIR
+        manifest_parts: list[str] = agent_manifest_file.split(os.pathsep)
+        base_dir: str = os.path.dirname(manifest_parts[0]) if manifest_parts[0] else DEFAULT_REGISTRIES_DIR
         return (Path(base_dir) / trimmed_input).as_posix()
 
     async def _hocon_to_config(self, network_hocon_file: str | None) -> dict[str, Any] | None:

--- a/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
+++ b/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
@@ -47,20 +47,38 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
         self.demo_mode: bool = demo_mode
         self.subdirectory: str = subdirectory.strip("/")
 
-        # Derive output_path from the first file listed in AGENT_MANIFEST_FILE.
-        # The env var is an os.pathsep-separated list (like PATH), matching how
-        # neuro-san's RegistryManifestRestorer parses the same variable.
-        agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
-        parts: list[str] = agent_manifest_file.split(os.pathsep)
-        # Splitting on an explicit separator never yields an empty list — an empty
-        # env var gives [""] — so guard on the first entry being non-empty before
-        # trusting it as the main manifest path; otherwise fall back to defaults.
-        if parts[0]:
-            self.output_path: str = os.path.dirname(parts[0])
-            self.main_manifest_path: str = parts[0]
+        # Derive output_path from the first file listed in AGENT_MANIFEST_FILE,
+        # falling back to the repo defaults when no usable entry exists.
+        first_manifest: str = self.get_first_manifest_path()
+        if first_manifest:
+            self.output_path: str = os.path.dirname(first_manifest)
+            self.main_manifest_path: str = first_manifest
         else:
             self.output_path = DEFAULT_REGISTRIES_DIR
             self.main_manifest_path = os.path.join(DEFAULT_REGISTRIES_DIR, MANIFEST_FILENAME)
+
+    @staticmethod
+    def get_first_manifest_path() -> str:
+        """
+        Returns the first non-empty entry of the AGENT_MANIFEST_FILE environment variable.
+
+        The env var is an os.pathsep-separated list (like PATH), matching how neuro-san's
+        RegistryManifestRestorer parses the same variable. Empty entries — from a stray
+        leading or doubled separator, or an empty env var (which splits to [""]) — are
+        skipped because the neuro-san server likewise skips them and serves the remaining
+        manifests. Entries are deliberately NOT stripped of whitespace: the server does not
+        strip either, so padded values fail consistently on both sides instead of silently
+        diverging. AgentNetworkDefinitionMiddleware shares this helper so loads and saves
+        agree on file location.
+
+        :return: The first non-empty manifest path, or "" when no such entry exists.
+        """
+        agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
+        parts: list[str] = agent_manifest_file.split(os.pathsep)
+        for part in parts:
+            if part:
+                return part
+        return ""
 
     def get_assembler(self) -> AgentNetworkAssembler:
         """

--- a/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
+++ b/middleware/agent_network_designer/persistence/file_system_agent_network_persistor.py
@@ -47,10 +47,15 @@ class FileSystemAgentNetworkPersistor(AgentNetworkPersistor):
         self.demo_mode: bool = demo_mode
         self.subdirectory: str = subdirectory.strip("/")
 
-        # Derive output_path from the first file listed in AGENT_MANIFEST_FILE
+        # Derive output_path from the first file listed in AGENT_MANIFEST_FILE.
+        # The env var is an os.pathsep-separated list (like PATH), matching how
+        # neuro-san's RegistryManifestRestorer parses the same variable.
         agent_manifest_file: str = os.environ.get("AGENT_MANIFEST_FILE", "")
-        parts: list[str] = agent_manifest_file.split()
-        if parts:
+        parts: list[str] = agent_manifest_file.split(os.pathsep)
+        # Splitting on an explicit separator never yields an empty list — an empty
+        # env var gives [""] — so guard on the first entry being non-empty before
+        # trusting it as the main manifest path; otherwise fall back to defaults.
+        if parts[0]:
             self.output_path: str = os.path.dirname(parts[0])
             self.main_manifest_path: str = parts[0]
         else:

--- a/registries/manifest_multiuser_overlay.hocon
+++ b/registries/manifest_multiuser_overlay.hocon
@@ -40,7 +40,9 @@
     # To use this file, we simply add a reference to it at the end of our existing
     # AGENT_MANIFEST_FILE specification # like this:
     #
-    #    export AGENT_MANIFEST_FILE="registries/manifest.hocon registries/manifest_multiuser_overlay.hocon"
+    #    export AGENT_MANIFEST_FILE="registries/manifest.hocon:registries/manifest_multiuser_overlay.hocon"
+    #
+    # The list is os.pathsep-separated (like PATH): ":" on Linux/macOS, ";" on Windows.
     #
     # Basically the data for later manifest files gets overlayed on top of earlier ones.
 

--- a/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
+++ b/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
@@ -53,6 +53,17 @@ class TestFileSystemAgentNetworkPersistor:
         assert persistor.main_manifest_path == first_manifest
         assert persistor.output_path == "first_dir"
 
+    def test_init_skips_empty_leading_entry(self) -> None:
+        """
+        __init__ uses the first non-empty entry when AGENT_MANIFEST_FILE has a leading separator.
+        """
+        manifest: str = os.path.join("real_dir", "manifest.hocon")
+        env_value: str = os.pathsep + manifest
+        with patch.dict(os.environ, {"AGENT_MANIFEST_FILE": env_value}):
+            persistor = FileSystemAgentNetworkPersistor(demo_mode=False)
+        assert persistor.main_manifest_path == manifest
+        assert persistor.output_path == "real_dir"
+
     def test_init_defaults_when_manifest_env_var_empty(self) -> None:
         """
         __init__ falls back to the default registries paths when AGENT_MANIFEST_FILE is empty.

--- a/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
+++ b/tests/middleware/agent_network_designer/persistence/test_file_system_agent_network_persistor.py
@@ -39,6 +39,29 @@ class TestFileSystemAgentNetworkPersistor:
         persistor.subdirectory = subdirectory
         return persistor
 
+    # Tests for AGENT_MANIFEST_FILE parsing in __init__
+
+    def test_init_splits_manifest_env_var_on_pathsep(self) -> None:
+        """
+        __init__ takes the first entry of an os.pathsep-separated AGENT_MANIFEST_FILE.
+        """
+        first_manifest: str = os.path.join("first_dir", "manifest.hocon")
+        second_manifest: str = os.path.join("second_dir", "manifest.hocon")
+        env_value: str = os.pathsep.join([first_manifest, second_manifest])
+        with patch.dict(os.environ, {"AGENT_MANIFEST_FILE": env_value}):
+            persistor = FileSystemAgentNetworkPersistor(demo_mode=False)
+        assert persistor.main_manifest_path == first_manifest
+        assert persistor.output_path == "first_dir"
+
+    def test_init_defaults_when_manifest_env_var_empty(self) -> None:
+        """
+        __init__ falls back to the default registries paths when AGENT_MANIFEST_FILE is empty.
+        """
+        with patch.dict(os.environ, {"AGENT_MANIFEST_FILE": ""}):
+            persistor = FileSystemAgentNetworkPersistor(demo_mode=False)
+        assert persistor.output_path == "registries"
+        assert persistor.main_manifest_path == os.path.join("registries", "manifest.hocon")
+
     # Tests for async_persist reading a manifest with various encodings
 
     def test_persist_appends_to_utf8_manifest(self):

--- a/tests/middleware/agent_network_designer/test_agent_network_definition_middleware.py
+++ b/tests/middleware/agent_network_designer/test_agent_network_definition_middleware.py
@@ -1,0 +1,57 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for AgentNetworkDefinitionMiddleware path resolution."""
+
+import os
+from unittest.mock import patch
+
+from middleware.agent_network_designer.agent_network_definition_middleware import (
+    AgentNetworkDefinitionMiddleware,
+)
+
+
+class TestAgentNetworkDefinitionMiddleware:
+    """Tests for AgentNetworkDefinitionMiddleware._resolve_hocon_path."""
+
+    # Tests for AGENT_MANIFEST_FILE parsing, mirroring the persistor's parsing tests
+    # so loads and saves stay in agreement on file location.
+
+    def test_resolve_splits_manifest_env_var_on_pathsep(self) -> None:
+        """
+        _resolve_hocon_path derives base_dir from the first entry of an os.pathsep-separated AGENT_MANIFEST_FILE.
+        """
+        first_manifest: str = os.path.join("first_dir", "manifest.hocon")
+        second_manifest: str = os.path.join("second_dir", "manifest.hocon")
+        env_value: str = os.pathsep.join([first_manifest, second_manifest])
+        with patch.dict(os.environ, {"AGENT_MANIFEST_FILE": env_value}):
+            middleware = AgentNetworkDefinitionMiddleware(sly_data={})
+            # The input must not exist relative to cwd, so resolution falls through to base_dir.
+            resolved: str | None = middleware._resolve_hocon_path(  # pylint: disable=protected-access
+                "generated/does_not_exist.hocon"
+            )
+        assert resolved == "first_dir/generated/does_not_exist.hocon"
+
+    def test_resolve_defaults_when_manifest_env_var_empty(self) -> None:
+        """
+        _resolve_hocon_path falls back to the default registries dir when AGENT_MANIFEST_FILE is empty.
+        """
+        with patch.dict(os.environ, {"AGENT_MANIFEST_FILE": ""}):
+            middleware = AgentNetworkDefinitionMiddleware(sly_data={})
+            resolved: str | None = middleware._resolve_hocon_path(  # pylint: disable=protected-access
+                "generated/does_not_exist.hocon"
+            )
+        assert resolved == "registries/generated/does_not_exist.hocon"

--- a/tests/middleware/agent_network_designer/test_agent_network_definition_middleware.py
+++ b/tests/middleware/agent_network_designer/test_agent_network_definition_middleware.py
@@ -19,9 +19,7 @@
 import os
 from unittest.mock import patch
 
-from middleware.agent_network_designer.agent_network_definition_middleware import (
-    AgentNetworkDefinitionMiddleware,
-)
+from middleware.agent_network_designer.agent_network_definition_middleware import AgentNetworkDefinitionMiddleware
 
 
 class TestAgentNetworkDefinitionMiddleware:
@@ -40,6 +38,18 @@ class TestAgentNetworkDefinitionMiddleware:
         with patch.dict(os.environ, {"AGENT_MANIFEST_FILE": env_value}):
             middleware = AgentNetworkDefinitionMiddleware(sly_data={})
             # The input must not exist relative to cwd, so resolution falls through to base_dir.
+            resolved: str | None = middleware._resolve_hocon_path(  # pylint: disable=protected-access
+                "generated/does_not_exist.hocon"
+            )
+        assert resolved == "first_dir/generated/does_not_exist.hocon"
+
+    def test_resolve_skips_empty_leading_entry(self) -> None:
+        """
+        _resolve_hocon_path uses the first non-empty entry when AGENT_MANIFEST_FILE has a leading separator.
+        """
+        env_value: str = os.pathsep + os.path.join("first_dir", "manifest.hocon")
+        with patch.dict(os.environ, {"AGENT_MANIFEST_FILE": env_value}):
+            middleware = AgentNetworkDefinitionMiddleware(sly_data={})
             resolved: str | None = middleware._resolve_hocon_path(  # pylint: disable=protected-access
                 "generated/does_not_exist.hocon"
             )


### PR DESCRIPTION
## Description

`FileSystemAgentNetworkPersistor` derived its output location by splitting `AGENT_MANIFEST_FILE` on whitespace, but the env var is a `PATH`-style, `os.pathsep`-separated list — that is how neuro-san's [`RegistryManifestRestorer`](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/graph/persistence/registry_manifest_restorer.py) parses the same variable (and the pinned `neuro-san==0.6.95` already does). With a multi-entry value, the whole string was treated as a single token, so generated networks were silently saved to a directory containing a literal `:` and the main-manifest include update no-oped.

This PR:

- Splits on `os.pathsep` in the persistor, with a guard on the first entry because `"".split(os.pathsep)` yields `[""]` — preserving the fallback to `registries/manifest.hocon` when the env var is unset or empty.
- Applies the same fix to `_resolve_hocon_path` in `agent_network_definition_middleware.py`, whose docstring promises it "mirrors `FileSystemAgentNetworkPersistor` so loads and saves agree on file location" — fixing only the persistor would have made saves and loads disagree.
- Corrects the usage example in `registries/manifest_multiuser_overlay.hocon`, which told users to space-separate the list (a format the server itself mishandles).
- Adds regression tests for both parse sites (multi-entry split and empty-env fallback).

I deliberately split on `os.pathsep` rather than a hardcoded `":"` — `os.pathsep` is `;` on Windows, where colon-splitting would also break drive-letter paths like `C:\...`.

Credit to @rstrickland-ohpen, who first reported the bug in #1253; this supersedes the persistor portion of that PR.

Fixes #1386

## Impact

Deployments that list multiple manifests in `AGENT_MANIFEST_FILE` (e.g. `deploy/Dockerfile` uses a colon-separated pair) now get designer-generated networks saved under the first manifest's directory — the location the neuro-san server actually watches — and the designer can load back the networks it just saved. Single-entry and unset/empty values behave exactly as before.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**