### PR TITLE
Use build-common 1.0.12 test-python-versions input

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,11 @@ jobs:
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository)
-    # 1.0.9
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+    # 1.0.12
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3f4cdab31b6ac10382c99452b720eb0b8b2dab8f
     with:
       python-version: '3.12'
+      test-python-versions: '["3.12", "3.13", "3.14"]'
       run-hadolint: true
       dockerfile-path: 'deploy/Dockerfile'
       lint-command-override: |
@@ -41,25 +42,8 @@ jobs:
         # - 503 (temporary outage)
         /tmp/lychee --max-retries 3 --retry-wait-time 3 --max-concurrency 32 --verbose --accept '200..=299,401,403,405,406,422,429,502,503' --exclude-path venv --include-verbatim '**/*.py' '**/*.md' '**/*.rst' '**/*.hocon' '**/*.txt' '**/*.yaml' '**/*.yml' '**/*.json' '**/*.html' '**/*.sh' .
       run-pytest: false
+      test-command-override: 'VIRTUAL_ENV=system AGENT_TOOL_PATH=./neuro_san/coded_tools PYTHONPATH=.:$PYTHONPATH make test-unit'
       check-readme-pypi: true
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  unit-tests:
-    name: Unit tests
-    if: >
-      (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
-      (github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name != github.repository)
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.12', '3.13', '3.14']
-    # 1.0.9
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
-    with:
-      python-version: ${{ matrix.python-version }}
-      # Lint, hadolint and the README check belong to the quality-gate job
-      lint-command-override: 'true'
-      test-command-override: 'VIRTUAL_ENV=system AGENT_TOOL_PATH=./neuro_san/coded_tools PYTHONPATH=.:$PYTHONPATH make test-unit'
-      enable-slack: false


### PR DESCRIPTION
## Description

Follow-up to #1363. build-common 1.0.12 (cognizant-ai-lab/build-common#36) added a `test-python-versions` input to `_python-quality-gate.yml` that runs the tests in an internal per-version matrix, so the hand-rolled `unit-tests` matrix job in `tests.yml` is no longer needed.

```diff
   quality-gate:
-    # 1.0.9
-    uses: .../_python-quality-gate.yml@b14b3de
+    # 1.0.12
+    uses: .../_python-quality-gate.yml@3f4cdab
     with:
       python-version: '3.12'
+      test-python-versions: '["3.12", "3.13", "3.14"]'
       ...
       run-pytest: false
+      test-command-override: '... make test-unit'
       check-readme-pypi: true

-  unit-tests:            # 3-version matrix calling the same reusable workflow
-    ...
```

Only `tests.yml` is bumped to 1.0.12; the other workflows stay on 1.0.9 to keep this change scoped.

## Impact

Same coverage as before: lint/hadolint/lychee/README check run once on 3.12 in `quality-gate`, `make test-unit` runs on 3.12/3.13/3.14 as `Unit tests (3.x)` jobs, and one Slack notification is sent for the combined result (rather than the quality-gate job alone). Job names in the checks list change from `Unit tests (3.12)` under the `unit-tests` job to `quality-gate / Unit tests (3.12)` etc.

## Type of Change

- [x] Refactoring / Improvement

## Checklist

- [x] Tested locally (`actionlint` clean; same reusable-workflow config verified on leaf-common#191)
- [ ] Added/updated tests
- [ ] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (tool-specific preferred; main only for core functionality)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**


Link to Devin session: https://app.devin.ai/sessions/25fc14ae7bdc496f98837871f43ed0ea
Open in Devin Desktop: https://app.devin.ai/desktop/session/25fc14ae7bdc496f98837871f43ed0ea?variant=devin
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san-studio/pull/1388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->