### PR TITLE
Document llmman as a local LLM provider via the ollama class

### DIFF
--- a/config/developer_llm_config.hocon
+++ b/config/developer_llm_config.hocon
@@ -46,6 +46,8 @@
         #
         # Note:
         # - For Ollama, the model must be downloaded locally before use.
+        # - llmman (https://github.com/llmmanorg/llmman) serves the Ollama API on port 17434:
+        #   use class `ollama` with `"base_url": "http://localhost:17434"`.
         # - Additional LLM parameters (e.g., `temperature`, `max_tokens`) can be configured below.
         # - Agent-level control (e.g., `max_steps`) can also be set here.
         # - It is possible to have a separate llm_config describing a different LLM with different parameters for each agent network hocon file

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -26,6 +26,7 @@
       - [Ollama Prerequisites](#ollama-prerequisites)
       - [Ollama Configuration](#ollama-configuration)
       - [Using Ollama in Docker or Remote Server](#using-ollama-in-docker-or-remote-server)
+      - [Using llmman](#using-llmman)
       - [Example agent network](#example-agent-network)
     - [Mistral](#mistral)
     - [Configuring Default Models with Environment Variables](#configuring-default-models-with-environment-variables)
@@ -698,6 +699,35 @@ You can also set the environment variable `OLLAMA_HOST`, but `base_url` takes pr
 
 For more information on logic of parsing the `base_url`
 see [Ollama python SDK](https://github.com/ollama/ollama-python/blob/main/ollama/_client.py#L1274)
+
+#### Using llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port `17434`,
+so it works with the `ollama` class; only the port differs.
+
+1. Install and start llmman, then pull a model:
+
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+    llmman serve
+    llmman pull gemma4
+    ```
+
+2. Point the `ollama` class at llmman via `base_url`:
+
+    ```hocon
+        "llm_config": {
+            "class": "ollama",
+            "model_name": "gemma4",
+            "base_url": "http://localhost:17434"
+        }
+    ```
+
+    Alternatively, set `OLLAMA_HOST=127.0.0.1:17434` in the environment and omit `base_url`.
+
+llmman model names (e.g. `gemma4`, `hf.co/unsloth/Qwen3.5-0.8B-GGUF`) are not in the
+[default llm info file](https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon),
+so `"class": "ollama"` must be set explicitly. As with Ollama, the model must support tool calling.
 
 #### Example agent network
 


### PR DESCRIPTION
## Description

Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- `docs/user_guide.md`: new "Using llmman" subsection (plus TOC entry) after "Using Ollama in Docker or Remote Server", since it is the same mechanism: the `ollama` class with `"base_url": "http://localhost:17434"` (or `OLLAMA_HOST`).
- Notes that llmman model names are not in neuro-san's default llm info file, so `"class": "ollama"` must be set explicitly.
- `config/developer_llm_config.hocon`: one-line note next to the existing Ollama note.
- No code or dependency changes; provider classes live in the `neuro-san` library.

## Impact

Documentation only; no behavior change.

## Type of Change

- [x] Documentation

## Checklist

- [x] Tested locally
- [x] Updated relevant documentation

**Testing:** `pymarkdown --config ./.pymarkdownlint.yaml scan ./docs` (pymarkdownlnt 0.9.30) passes.

> AI-assisted, reviewed before submitting.

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**
