### PR TITLE
ANDe: research named organizations with internet_info_gatherer before designing

### DIFF
--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -229,11 +229,15 @@ You may repeat steps 1–3 (create/modify structure, refine instructions, regene
 
 0) Research the organization or domain
 - If the user names a specific company, organization, product, or brand (e.g. "Grab", "UNHCR"),
-  you MUST call `internet_info_gatherer` before designing anything. Your training data may be
-  outdated or wrong about a specific organization; do not rely on it.
-- Ask for: what the organization does, its main business lines or services, key operational
-  workflows and departments, the customer/partner types it serves, and any recent changes
-  (new services, restructuring, regulations). Ask a second time if the first answer is thin.
+  you MUST call `internet_info_gatherer` before designing anything. This includes prompts where
+  the organization appears only as context (e.g. "support for Shopify merchants"). Your training
+  data may be outdated or wrong about a specific organization; do not rely on it.
+- In your inquiry to `internet_info_gatherer`, ask for: what the organization does, its main
+  business lines or services, key operational workflows and departments, the customer/partner
+  types it serves, and any recent changes (new services, restructuring, regulations).
+- If the answer leaves any of those items uncovered, call `internet_info_gatherer` again with a
+  narrower inquiry for the missing items, up to 3 calls in total. Stop as soon as the items above
+  are covered well enough to design the network.
 - If the user gives only a generic domain (e.g. "employee onboarding"), you may skip this step,
   but call `internet_info_gatherer` if you are unsure about industry-specific roles or regulations.
 - Fold what you learn into the `agent_network_description` you pass to `agent_network_editor`

--- a/registries/agent_network_designer.hocon
+++ b/registries/agent_network_designer.hocon
@@ -227,10 +227,23 @@ Take the following steps. Make sure you don't miss any details and follow the st
 LOOPABLE WORKFLOW (steps 1–3 can repeat any number of times):
 You may repeat steps 1–3 (create/modify structure, refine instructions, regenerate queries) until the network is ready for finalization.
 
+0) Research the organization or domain
+- If the user names a specific company, organization, product, or brand (e.g. "Grab", "UNHCR"),
+  you MUST call `internet_info_gatherer` before designing anything. Your training data may be
+  outdated or wrong about a specific organization; do not rely on it.
+- Ask for: what the organization does, its main business lines or services, key operational
+  workflows and departments, the customer/partner types it serves, and any recent changes
+  (new services, restructuring, regulations). Ask a second time if the first answer is thin.
+- If the user gives only a generic domain (e.g. "employee onboarding"), you may skip this step,
+  but call `internet_info_gatherer` if you are unsure about industry-specific roles or regulations.
+- Fold what you learn into the `agent_network_description` you pass to `agent_network_editor`
+  and `agent_network_instructions_editor`. Do not pass the research verbatim; summarize the
+  workflows, departments, and terminology that should shape the agents.
+
 1) Create or modify the network structure
 - If the user provides a company name or domain description for a new network, generate an agent network definition that mirrors relevant workflows and responsible nodes. Call your `agent_network_editor` tool. Ensure the agent network name is snake case.
 - If the user asks to modify an existing network's structure (add/remove agents, or change up-chains/down-chains), call `agent_network_editor` with the modification instructions.
-- You may call `web_search` to find more details on the company or domain.
+- You may call `internet_info_gatherer` to find more details on the company or domain.
 - If the user only asks to modify agent instructions (no structural changes), skip structural edits and go to step 2.
 - Wait for and inspect the response from `agent_network_editor` before proceeding.
 
@@ -238,7 +251,7 @@ You may repeat steps 1–3 (create/modify structure, refine instructions, regene
 - Always call `agent_network_instructions_editor` to generate instructions after step 1 if the network structure is created.
 - After structural modification, you may call `agent_network_instructions_editor` to update agents' instructions.
 - You may call `agent_network_instructions_editor` multiple times as you iterate on the network; call it whenever agents are added or when their responsibilities change.
-- You may call `web_search` to find more details on the company or domain.
+- You may call `internet_info_gatherer` to find more details on the company or domain.
 - Wait for and inspect the response from `agent_network_instructions_editor` before proceeding.
 
 3) Generate sample queries
@@ -286,7 +299,7 @@ Operational notes:
                     ]
                 }
             },
-            "tools": ["/agent_network_editor", "/agent_network_query_generator", "/agent_network_instructions_editor", "web_search"],
+            "tools": ["/agent_network_editor", "/agent_network_query_generator", "/agent_network_instructions_editor", "/tools/internet_info_gatherer"],
             # Parse any JSON in responses into the structure field of the ChatMessage.
             "structure_formats": "json",
             "middleware": [
@@ -328,11 +341,6 @@ Operational notes:
                     }
                 }
             ]
-        },
-
-        {
-            "name": "web_search",
-            "toolbox": "ddgs_search"
         },
 
     ]


### PR DESCRIPTION
## Summary

The agent network designer almost never used its web search tool. In today's logs it went straight to `agent_network_editor` from its own training knowledge, even for prompts that named a real company ("Create a network for food delivery company like Grab"). The instructions only said "You may call `web_search`", every other step was phrased as required, and the tool description gave no trigger for when research is needed.

This PR:

- Replaces the local ddgs `web_search` toolbox tool with the external agent `/tools/internet_info_gatherer` network (you.com search + `web_fetch` page reads).
- Adds a **step 0** to the front man's instructions: when the user names a specific company, organization, product, or brand, it must call `internet_info_gatherer` before designing, ask for what the organization does, its workflows, departments, customer types and recent changes, and fold the findings into the `agent_network_description` it passes to `agent_network_editor` and `agent_network_instructions_editor`. Generic domain prompts ("employee onboarding") may skip it.
- Keeps the optional "you may call `internet_info_gatherer`" hints in steps 1 and 2 so the front man can go back to the tool mid-loop when a specific question comes up.

## Test results

I benchmarked the run-time cost of step 0 against the live server (neuro-san 0.6.95, gpt-5.2 via `developer_llm_config.hocon`) with an A/B on the same prompts: the hocon in this PR versus the same file with only the step 0 block removed. Five prompts naming organizations (GrabFood, Maersk, Mayo Clinic, Shopify, UNHCR) × 2 variants × 2 repeats = 20 sequential runs, order counterbalanced per prompt, MAXIMAL chat filter, client-side timing from request to last streamed message. The variant actually loaded for each run was verified from the server's reload log. All 20 runs completed.

| | with step 0 | without step 0 |
|---|---|---|
| runs | 10 | 10 |
| total time, mean | 106.2 s | 58.6 s |
| total time, median | 108.9 s | 59.4 s |
| total time, range | 57–138 s | 45–65 s |
| time until first `agent_network_editor` call | 49.4 s | 3.3 s |

- The added time is essentially the gatherer call itself: 8 calls, mean 54.6 s (38.5–77.3 s), about 8 you.com searches and 7 page fetches per call. The richer description neither slows nor speeds the editor / instructions / query steps.
- Caveat: all prompts named an organization. For generic domain prompts step 0 is designed to skip, so the added time there should be near zero. I did test a generic domain a few times to confirm that it does not call the search tool.
