### PR TITLE
Migrate PDF RAG off langchain-community onto SafeFetch and pypdf

### DIFF
--- a/docs/examples/tools/pdf_rag.md
+++ b/docs/examples/tools/pdf_rag.md
@@ -12,11 +12,7 @@ The **PDF RAG Assistant** answers user queries using Retrieval-Augmented Generat
 
 ## Prerequisites
 
-* Install pymupdf package, a high-performance Python library for data extraction, analysis, conversion & manipulation of PDF (and other) documents:
-
-    ```bash
-    pip install pymupdf
-    ```
+* None beyond the repo's standard requirements: PDFs are downloaded through the shared SSRF-hardened fetch path and parsed with `pypdf`, which is already included in `requirements.txt`.
 
 ## Prerequisites for PostgreSQL Vector Store
 

--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -285,10 +285,21 @@ class PdfRag(CodedTool, BaseRag):
             return None
 
         logger.info("Successfully loaded PDF file from %s", source)
+        return self._to_page_documents(source, page_texts)
 
-        # One Document per page, mirroring the granularity of the previous
-        # PyMuPDFLoader-based loader so page numbers survive into the vector-store
-        # metadata (chunking downstream does not preserve them otherwise).
+    @staticmethod
+    def _to_page_documents(source: str, page_texts: list[str]) -> list[Document]:
+        """
+        Wrap extracted page texts as one Document per page.
+
+        Mirrors the granularity of the previous PyMuPDFLoader-based loader so page
+        numbers survive into the vector-store metadata (chunking downstream does
+        not preserve them otherwise).
+
+        :param source: The URL or file path the pages came from, recorded as metadata.
+        :param page_texts: The extracted text of each page, in page order.
+        :return: One Document per page with source, page index, and total_pages metadata.
+        """
         total_pages: int = len(page_texts)
         documents: list[Document] = []
         for page_index, page_text in enumerate(page_texts):

--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -32,6 +32,7 @@ from neuro_san.interfaces.coded_tool import CodedTool
 from neuro_san_studio.coded_tools.base_rag import BaseRag
 from neuro_san_studio.coded_tools.base_rag import PostgresConfig
 from neuro_san_studio.coded_tools.utils.pdf_utils import PdfUtils
+from neuro_san_studio.coded_tools.utils.safe_fetch import MAX_RESPONSE_BYTES
 from neuro_san_studio.coded_tools.utils.safe_fetch import SafeFetch
 
 logging.basicConfig(level=logging.INFO)
@@ -50,8 +51,10 @@ class PdfRag(CodedTool, BaseRag):
     validated at connection time (anti DNS-rebinding), redirects are not followed,
     and response sizes are capped. Local file paths (a documented input form for
     this tool) are read directly from disk — SafeFetch governs network fetches
-    only. All PDFs are parsed with pypdf via the shared PdfUtils helper, one
-    Document per page so page numbers survive into the vector store metadata.
+    only — subject to the same byte cap as downloads. Items with any other URL
+    scheme (file://, s3://, ...) are skipped with a logged message. All PDFs are
+    parsed with pypdf via the shared PdfUtils helper, one Document per page so
+    page numbers survive into the vector store metadata.
     """
 
     async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> str | list[dict[str, Any]]:
@@ -82,7 +85,10 @@ class PdfRag(CodedTool, BaseRag):
         """
         # Extract arguments from the input dictionary
         query: str = args.get("query", "")
-        urls: list[str] = args.get("urls", [])
+        # Deliberately Any: this comes from the operator's hocon args block (the
+        # toolbox schema exposes only 'query' to the LLM) and may be a bare string
+        # instead of a list; load_documents normalizes that case.
+        urls: Any = args.get("urls")
 
         # Validate presence of required inputs
         if not query:
@@ -140,15 +146,25 @@ class PdfRag(CodedTool, BaseRag):
         MAX_CONCURRENT_FETCHES in flight) — remote items over one shared
         SSRF-protected session, local items straight from disk. An item that fails
         to validate, download, or parse is logged and skipped so one bad input does
-        not discard the rest of the corpus.
+        not discard the rest of the corpus. If the surrounding task is cancelled,
+        the cancellation is re-raised only after every in-flight item has unwound,
+        so the shared session never closes while a download is still using it.
 
-        :param loader_args: Dictionary containing 'urls' (PDF URLs or file paths).
+        :param loader_args: Dictionary containing 'urls' (list of PDF URLs or file
+            paths, or a single one as a bare string).
         :return: One Document per page of each successfully loaded PDF, in input
                  order.
         """
-        urls: list[str] = loader_args.get("urls", [])
-        # Nothing to do for an empty list; return early rather than opening a
-        # network session just to await an empty gather().
+        urls: Any = loader_args.get("urls")
+        # A hand-edited hocon may pass a single URL/path as a bare string instead
+        # of a list. A string is itself iterable, so the loop below would "load"
+        # it one character at a time, every character failing, and the whole run
+        # would come back empty with no hint why. Treat a single string as a
+        # one-item list instead.
+        if isinstance(urls, str):
+            urls = [urls]
+        # Nothing to do (or no 'urls' key at all); return early rather than
+        # opening a network session just to await an empty gather().
         if not urls:
             return []
 
@@ -174,14 +190,31 @@ class PdfRag(CodedTool, BaseRag):
             # order as `tasks`. Each result is a list of per-page Documents, or
             # None for an item that was skipped/failed (_load_single returns None
             # instead of raising, so one bad item cannot make gather abort the rest).
-            results: list[list[Document] | None] = await gather(*tasks)
+            #
+            # return_exceptions=True matters for CANCELLATION, the one thing that
+            # can still escape _load_single (CancelledError is a BaseException, so
+            # the broad `except Exception` there deliberately does not catch it).
+            # Without it, gather() re-raises the FIRST child's CancelledError
+            # immediately, while sibling tasks are still unwinding; this
+            # `async with` block would then close the shared session under them,
+            # and they would die with confusing secondary "session is closed"
+            # errors. With it, gather() waits until EVERY child has finished
+            # unwinding before completing — and when the gather itself was
+            # cancelled, asyncio still re-raises CancelledError to our caller at
+            # that point — so the session only closes once nothing is using it.
+            results: list[list[Document] | None | BaseException] = await gather(*tasks, return_exceptions=True)
 
         # Flatten the per-item page lists, dropping skipped items and preserving
-        # input order (and page order within each PDF).
+        # input order (and page order within each PDF). None entries were already
+        # logged by _load_single; anything else is a stray BaseException collected
+        # by return_exceptions=True, which bypassed _load_single's logging, so log
+        # it here.
         documents: list[Document] = []
-        for item_documents in results:
-            if item_documents is not None:
-                documents.extend(item_documents)
+        for result in results:
+            if isinstance(result, list):
+                documents.extend(result)
+            elif result is not None:
+                logger.error("Skipped a PDF after an unexpected error: %r", result)
         return documents
 
     async def _load_single(self, url: str, session: ClientSession, semaphore: Semaphore) -> list[Document] | None:
@@ -189,8 +222,9 @@ class PdfRag(CodedTool, BaseRag):
         Load one PDF (remote URL or local path) into per-page Documents.
 
         Returns None (rather than raising) whenever an item cannot contribute
-        documents — a policy/validation failure, a download or file-read error, or
-        a parse failure — so a single bad input never aborts the load.
+        documents — an unsupported URL scheme, a policy/validation failure, a
+        download or file-read error, or a parse failure — so a single bad input
+        never aborts the load.
 
         :param url: The PDF URL (http/https) or local file path to load.
         :param session: The shared protected session created by open_session.
@@ -198,12 +232,19 @@ class PdfRag(CodedTool, BaseRag):
         :return: One Document per page, or None when the item is skipped.
         """
         try:
-            # An http(s) scheme means a remote download through SafeFetch; anything
-            # else is treated as a local file path, a documented input form this
-            # tool has always accepted (see registries/tools/pdf_rag.hocon). Only
-            # network fetches go through the SSRF policy — a local path is
-            # operator-supplied configuration, not a URL to validate.
-            parsed_scheme: str = urlparse(url).scheme
+            # Route explicitly by URL scheme. http(s) means a remote download
+            # through SafeFetch. No scheme at all means a local file path, a
+            # documented input form this tool has always accepted (see
+            # registries/tools/pdf_rag.hocon); a single-letter "scheme" is really
+            # a Windows drive letter ("C:\\docs\\file.pdf" parses with scheme "c"),
+            # so that is a local path too. Anything else (file://, s3://, ftp://,
+            # or a typo) is skipped with an explicit message — the old
+            # negative-space routing handed every non-http string to open(), which
+            # failed with a misleading "file not found" for URLs this tool simply
+            # does not support. Only network fetches go through the SSRF policy —
+            # a local path is operator-supplied configuration, not a URL to
+            # validate.
+            parsed_scheme: str = urlparse(url).scheme.lower()
             if parsed_scheme in ("http", "https"):
                 validated_url: str = SafeFetch.validate_url(url)
                 async with semaphore:
@@ -213,6 +254,13 @@ class PdfRag(CodedTool, BaseRag):
                     # concurrent downloads (same pattern as SafeFetch.fetch_pdf_text).
                     page_texts: list[str] = await to_thread(PdfUtils.parse_pdf_bytes_per_page, data)
                 source: str = validated_url
+            elif len(parsed_scheme) > 1:
+                logger.warning(
+                    "Skipping %s: unsupported URL scheme '%s'. Use an http(s) URL or a local file path.",
+                    url,
+                    parsed_scheme,
+                )
+                return None
             else:
                 async with semaphore:
                     # File I/O and parsing are both blocking; do the whole read+parse
@@ -253,7 +301,16 @@ class PdfRag(CodedTool, BaseRag):
         :param path: The local filesystem path of the PDF.
         :return: The extracted text of each page, in page order.
         :raises OSError: When the file is missing or unreadable.
+        :raises ValueError: response_too_large when the file exceeds MAX_RESPONSE_BYTES.
         """
+        # Apply the same byte cap the remote path enforces: SafeFetch caps
+        # downloads via Content-Length and on the streamed bytes, and without
+        # this check a huge local file would be read fully into memory.
+        file_size: int = os.path.getsize(path)
+        if file_size > MAX_RESPONSE_BYTES:
+            raise ValueError(
+                f"response_too_large: '{path}' is {file_size} bytes, over the {MAX_RESPONSE_BYTES}-byte limit."
+            )
         with open(path, "rb") as pdf_file:
             data: bytes = pdf_file.read()
         return PdfUtils.parse_pdf_bytes_per_page(data)

--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -235,16 +235,18 @@ class PdfRag(CodedTool, BaseRag):
             # Route explicitly by URL scheme. http(s) means a remote download
             # through SafeFetch. No scheme at all means a local file path, a
             # documented input form this tool has always accepted (see
-            # registries/tools/pdf_rag.hocon); a single-letter "scheme" is really
-            # a Windows drive letter ("C:\\docs\\file.pdf" parses with scheme "c"),
-            # so that is a local path too. Anything else (file://, s3://, ftp://,
-            # or a typo) is skipped with an explicit message — the old
-            # negative-space routing handed every non-http string to open(), which
-            # failed with a misleading "file not found" for URLs this tool simply
-            # does not support. Only network fetches go through the SSRF policy —
-            # a local path is operator-supplied configuration, not a URL to
-            # validate.
+            # registries/tools/pdf_rag.hocon). A single-letter "scheme" is a
+            # Windows drive letter ("C:\\docs\\file.pdf" parses with scheme "c")
+            # only when the rest is path syntax; with URI syntax ("x://host/f.pdf")
+            # it is an unsupported scheme like any other. Everything else
+            # (file://, s3://, ftp://, or a typo) is skipped with an explicit
+            # message — the old negative-space routing handed every non-http
+            # string to open(), which failed with a misleading "file not found"
+            # for URLs this tool simply does not support. Only network fetches go
+            # through the SSRF policy — a local path is operator-supplied
+            # configuration, not a URL to validate.
             parsed_scheme: str = urlparse(url).scheme.lower()
+            is_drive_letter: bool = len(parsed_scheme) == 1 and "://" not in url
             if parsed_scheme in ("http", "https"):
                 validated_url: str = SafeFetch.validate_url(url)
                 async with semaphore:
@@ -254,7 +256,7 @@ class PdfRag(CodedTool, BaseRag):
                     # concurrent downloads (same pattern as SafeFetch.fetch_pdf_text).
                     page_texts: list[str] = await to_thread(PdfUtils.parse_pdf_bytes_per_page, data)
                 source: str = validated_url
-            elif len(parsed_scheme) > 1:
+            elif parsed_scheme and not is_drive_letter:
                 logger.warning(
                     "Skipping %s: unsupported URL scheme '%s'. Use an http(s) URL or a local file path.",
                     url,
@@ -303,14 +305,13 @@ class PdfRag(CodedTool, BaseRag):
         :raises OSError: When the file is missing or unreadable.
         :raises ValueError: response_too_large when the file exceeds MAX_RESPONSE_BYTES.
         """
-        # Apply the same byte cap the remote path enforces: SafeFetch caps
-        # downloads via Content-Length and on the streamed bytes, and without
-        # this check a huge local file would be read fully into memory.
-        file_size: int = os.path.getsize(path)
-        if file_size > MAX_RESPONSE_BYTES:
-            raise ValueError(
-                f"response_too_large: '{path}' is {file_size} bytes, over the {MAX_RESPONSE_BYTES}-byte limit."
-            )
+        # Apply the same byte cap the remote path enforces, as a bound on the read
+        # itself rather than an os.path.getsize() pre-check: a size probe is not a
+        # hard cap (special files such as /dev/zero report size 0, and a regular
+        # file can grow or be replaced between the probe and the read). Reading at
+        # most one byte past the cap is cheap and makes the limit unconditional.
         with open(path, "rb") as pdf_file:
-            data: bytes = pdf_file.read()
+            data: bytes = pdf_file.read(MAX_RESPONSE_BYTES + 1)
+        if len(data) > MAX_RESPONSE_BYTES:
+            raise ValueError(f"response_too_large: '{path}' exceeds the {MAX_RESPONSE_BYTES}-byte limit.")
         return PdfUtils.parse_pdf_bytes_per_page(data)

--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -245,8 +245,15 @@ class PdfRag(CodedTool, BaseRag):
             # for URLs this tool simply does not support. Only network fetches go
             # through the SSRF policy — a local path is operator-supplied
             # configuration, not a URL to validate.
-            parsed_scheme: str = urlparse(url).scheme.lower()
-            is_drive_letter: bool = len(parsed_scheme) == 1 and "://" not in url
+            #
+            # Route on a whitespace-stripped copy: SafeFetch.validate_url strips
+            # padding itself, so " https://host/f.pdf" is a valid remote input, but
+            # urlparse on the raw string would see no scheme and misroute it to the
+            # local reader. The original string is kept for the local path, since
+            # filesystem names may legitimately carry leading/trailing spaces.
+            routing_url: str = url.strip()
+            parsed_scheme: str = urlparse(routing_url).scheme.lower()
+            is_drive_letter: bool = len(parsed_scheme) == 1 and "://" not in routing_url
             if parsed_scheme in ("http", "https"):
                 validated_url: str = SafeFetch.validate_url(url)
                 async with semaphore:

--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -95,6 +95,15 @@ class PdfRag(CodedTool, BaseRag):
             return "❌ Missing required input: 'query'."
         if not urls:
             return "❌ Missing required input: 'urls'."
+        # 'urls' arrives via the hocon args block, which neuro-san does not
+        # schema-validate (only LLM-supplied arguments are), so guard the container
+        # type here: anything but a list or a single string would make
+        # load_documents' for-loop raise TypeError and abort the run with a traceback.
+        if not isinstance(urls, (str, list, tuple)):
+            return (
+                "❌ Invalid input: 'urls' must be a list of PDF URLs/paths (or a single string), "
+                f"got {type(urls).__name__}."
+            )
 
         # Vector store type
         vector_store_type: str = args.get("vector_store_type", "in_memory")
@@ -148,7 +157,10 @@ class PdfRag(CodedTool, BaseRag):
         to validate, download, or parse is logged and skipped so one bad input does
         not discard the rest of the corpus. If the surrounding task is cancelled,
         the cancellation is re-raised only after every in-flight item has unwound,
-        so the shared session never closes while a download is still using it.
+        so the shared session never closes while a download is still using it. A
+        pypdf parse already handed to a worker thread runs to completion (threads
+        cannot be interrupted) but holds only bytes, no session reference, so that
+        guarantee is unaffected.
 
         :param loader_args: Dictionary containing 'urls' (list of PDF URLs or file
             paths, or a single one as a bare string).
@@ -166,6 +178,11 @@ class PdfRag(CodedTool, BaseRag):
         # Nothing to do (or no 'urls' key at all); return early rather than
         # opening a network session just to await an empty gather().
         if not urls:
+            return []
+        # A non-list container (e.g. an int from a hand-edited hocon) cannot be
+        # iterated as URLs; refuse it here rather than letting the loop below raise.
+        if not isinstance(urls, (list, tuple)):
+            logger.error("Ignoring 'urls' of type %s: expected a list of PDF URLs/paths.", type(urls).__name__)
             return []
 
         # Concurrency limiter. A Semaphore holds a fixed number of "slots"

--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -247,10 +247,11 @@ class PdfRag(CodedTool, BaseRag):
             # configuration, not a URL to validate.
             #
             # Route on a whitespace-stripped copy: SafeFetch.validate_url strips
-            # padding itself, so " https://host/f.pdf" is a valid remote input, but
-            # urlparse on the raw string would see no scheme and misroute it to the
-            # local reader. The original string is kept for the local path, since
-            # filesystem names may legitimately carry leading/trailing spaces.
+            # padding itself, so an https URL with leading whitespace is valid remote
+            # input, but urlparse on the raw string would see no scheme and misroute
+            # it to the local reader. The original string is kept for the local
+            # path, since filesystem names may legitimately carry leading/trailing
+            # spaces.
             routing_url: str = url.strip()
             parsed_scheme: str = urlparse(routing_url).scheme.lower()
             is_drive_letter: bool = len(parsed_scheme) == 1 and "://" not in routing_url

--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -18,34 +18,49 @@
 
 import logging
 import os
+from asyncio import Semaphore
+from asyncio import gather
+from asyncio import to_thread
 from typing import Any
-from typing import Dict
-from typing import List
+from urllib.parse import urlparse
 
-from langchain_community.document_loaders import PyMuPDFLoader
+from aiohttp import ClientSession
 from langchain_core.documents import Document
 from langchain_core.vectorstores import VectorStore
 from neuro_san.interfaces.coded_tool import CodedTool
 
 from neuro_san_studio.coded_tools.base_rag import BaseRag
 from neuro_san_studio.coded_tools.base_rag import PostgresConfig
+from neuro_san_studio.coded_tools.utils.pdf_utils import PdfUtils
+from neuro_san_studio.coded_tools.utils.safe_fetch import SafeFetch
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Cap on how many PDFs are processed at once (download/read + parse) in one load_documents call.
+MAX_CONCURRENT_FETCHES: int = 5
+
 
 class PdfRag(CodedTool, BaseRag):
     """
-    CodedTool implementation which provides a way to do RAG on pdf files
+    CodedTool implementation which provides a way to do RAG on pdf files.
+
+    Remote PDFs are downloaded through the shared SSRF-hardened fetch path
+    (SafeFetch): private/loopback/reserved hosts are rejected, DNS records are
+    validated at connection time (anti DNS-rebinding), redirects are not followed,
+    and response sizes are capped. Local file paths (a documented input form for
+    this tool) are read directly from disk — SafeFetch governs network fetches
+    only. All PDFs are parsed with pypdf via the shared PdfUtils helper, one
+    Document per page so page numbers survive into the vector store metadata.
     """
 
-    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+    async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> str | list[dict[str, Any]]:
         """
-        Load a PDF from URL, build a vector store, and run a query against it.
+        Load PDFs from URLs or file paths, build a vector store, and query it.
 
         :param args: Dictionary containing:
           "query": search string
-          "urls": list of pdf files
+          "urls": list of PDF URLs and/or local file paths
           "save_vector_store": save to JSON file if True
           "vector_store_path": relative path to this file
 
@@ -62,12 +77,12 @@ class PdfRag(CodedTool, BaseRag):
 
             Keys expected for this implementation are:
                 None
-        :return: Text result from querying the built vector store,
-            or error message
+        :return: Retrieved chunks as a list of {"content", "metadata"} dicts,
+            or an error/status message string.
         """
         # Extract arguments from the input dictionary
         query: str = args.get("query", "")
-        urls: List[str] = args.get("urls", [])
+        urls: list[str] = args.get("urls", [])
 
         # Validate presence of required inputs
         if not query:
@@ -103,27 +118,142 @@ class PdfRag(CodedTool, BaseRag):
         )
 
         # Run the query against the vector store
-        return await self.query_vectorstore(vector_store, query)
+        results: Any = await self.query_vectorstore(vector_store, query)
 
-    async def load_documents(self, loader_args: Dict[str, Any]) -> List[Document]:
+        # Every input may have been skipped (unreachable/blocked/unparseable),
+        # leaving an empty store whose retriever returns no documents. Surface that
+        # plainly instead of handing the agent an empty list it cannot act on. A
+        # non-empty store always returns its nearest chunks, so an empty list here
+        # means "nothing was ingested", not merely "no strong match".
+        if isinstance(results, list) and not results:
+            return (
+                "❌ No content could be retrieved from the provided PDFs. "
+                "They may be unreachable, blocked, missing, or not parseable as PDF."
+            )
+        return results
+
+    async def load_documents(self, loader_args: dict[str, Any]) -> list[Document]:
         """
-        Load PDF documents from URLs.
+        Load PDF documents from URLs and/or local file paths.
 
-        :param loader_args: Dictionary containing 'urls' (list of PDF file URLs)
-        :return: List of loaded PDF documents
+        Each item is processed concurrently (download/read + parse, capped at
+        MAX_CONCURRENT_FETCHES in flight) — remote items over one shared
+        SSRF-protected session, local items straight from disk. An item that fails
+        to validate, download, or parse is logged and skipped so one bad input does
+        not discard the rest of the corpus.
+
+        :param loader_args: Dictionary containing 'urls' (PDF URLs or file paths).
+        :return: One Document per page of each successfully loaded PDF, in input
+                 order.
         """
-        docs: List[Document] = []
-        urls: List[str] = loader_args.get("urls", [])
+        urls: list[str] = loader_args.get("urls", [])
+        # Nothing to do for an empty list; return early rather than opening a
+        # network session just to await an empty gather().
+        if not urls:
+            return []
 
-        for url in urls:
-            try:
-                loader = PyMuPDFLoader(file_path=url)
-                doc: List[Document] = await loader.aload()
-                docs.extend(doc)
-                logger.info("Successfully loaded PDF file from %s", url)
-            except FileNotFoundError:
-                logger.error("File not found: %s", url)
-            except ValueError as e:
-                logger.error("Invalid file path or unsupported input: %s – %s", url, e)
+        # Concurrency limiter. A Semaphore holds a fixed number of "slots"
+        # (MAX_CONCURRENT_FETCHES); a coroutine must acquire one (via `async with
+        # semaphore` in _load_single) and holds it for that item's WHOLE processing —
+        # download/read and parse — releasing it on block exit. So at most that many
+        # PDFs are in flight at any moment, which is polite to servers and bounds
+        # peak memory (each raw PDF can be megabytes); the rest wait for a slot.
+        semaphore: Semaphore = Semaphore(MAX_CONCURRENT_FETCHES)
+        # One protected session is shared by all remote downloads so they reuse the
+        # SSRF-validated connector (GlobalOnlyResolver) and its connection pool. It
+        # costs nothing until a request is made, so a list of only local paths is
+        # fine — the session simply goes unused.
+        async with SafeFetch.open_session() as session:
+            # Build one coroutine per item but do NOT await them here: awaiting
+            # inside the loop would run them one-after-another (sequentially).
+            tasks: list[Any] = []
+            for url in urls:
+                tasks.append(self._load_single(url, session, semaphore))
+            # gather() launches all the coroutines on the event loop concurrently
+            # and waits for every one to finish, returning results in the SAME
+            # order as `tasks`. Each result is a list of per-page Documents, or
+            # None for an item that was skipped/failed (_load_single returns None
+            # instead of raising, so one bad item cannot make gather abort the rest).
+            results: list[list[Document] | None] = await gather(*tasks)
 
-        return docs
+        # Flatten the per-item page lists, dropping skipped items and preserving
+        # input order (and page order within each PDF).
+        documents: list[Document] = []
+        for item_documents in results:
+            if item_documents is not None:
+                documents.extend(item_documents)
+        return documents
+
+    async def _load_single(self, url: str, session: ClientSession, semaphore: Semaphore) -> list[Document] | None:
+        """
+        Load one PDF (remote URL or local path) into per-page Documents.
+
+        Returns None (rather than raising) whenever an item cannot contribute
+        documents — a policy/validation failure, a download or file-read error, or
+        a parse failure — so a single bad input never aborts the load.
+
+        :param url: The PDF URL (http/https) or local file path to load.
+        :param session: The shared protected session created by open_session.
+        :param semaphore: Caps how many PDFs are processed (fetched and parsed) at once.
+        :return: One Document per page, or None when the item is skipped.
+        """
+        try:
+            # An http(s) scheme means a remote download through SafeFetch; anything
+            # else is treated as a local file path, a documented input form this
+            # tool has always accepted (see registries/tools/pdf_rag.hocon). Only
+            # network fetches go through the SSRF policy — a local path is
+            # operator-supplied configuration, not a URL to validate.
+            parsed_scheme: str = urlparse(url).scheme
+            if parsed_scheme in ("http", "https"):
+                validated_url: str = SafeFetch.validate_url(url)
+                async with semaphore:
+                    data: bytes = await SafeFetch.download_pdf_bytes(validated_url, session)
+                    # pypdf parsing is blocking CPU work; to_thread() runs it on a
+                    # worker thread so the event loop stays free to drive the other
+                    # concurrent downloads (same pattern as SafeFetch.fetch_pdf_text).
+                    page_texts: list[str] = await to_thread(PdfUtils.parse_pdf_bytes_per_page, data)
+                source: str = validated_url
+            else:
+                async with semaphore:
+                    # File I/O and parsing are both blocking; do the whole read+parse
+                    # on a worker thread.
+                    page_texts = await to_thread(self._read_local_pdf_pages, url)
+                source = url
+        # A broad catch keeps the batch resilient: URL-policy failures (ValueError),
+        # network/HTTP failures (ClientError), missing/unreadable files (OSError),
+        # and pypdf parse failures all mean "skip this one item", never "abort the
+        # whole load". The error is logged so nothing fails silently.
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logger.error("Failed to load PDF %s: %s", url, error)
+            return None
+
+        logger.info("Successfully loaded PDF file from %s", source)
+
+        # One Document per page, mirroring the granularity of the previous
+        # PyMuPDFLoader-based loader so page numbers survive into the vector-store
+        # metadata (chunking downstream does not preserve them otherwise).
+        total_pages: int = len(page_texts)
+        documents: list[Document] = []
+        for page_index, page_text in enumerate(page_texts):
+            documents.append(
+                Document(
+                    page_content=page_text,
+                    metadata={"source": source, "page": page_index, "total_pages": total_pages},
+                )
+            )
+        return documents
+
+    @staticmethod
+    def _read_local_pdf_pages(path: str) -> list[str]:
+        """
+        Read a local PDF file and extract its text, one string per page.
+
+        Blocking (file I/O + pypdf parse); callers run it via asyncio.to_thread.
+
+        :param path: The local filesystem path of the PDF.
+        :return: The extracted text of each page, in page order.
+        :raises OSError: When the file is missing or unreadable.
+        """
+        with open(path, "rb") as pdf_file:
+            data: bytes = pdf_file.read()
+        return PdfUtils.parse_pdf_bytes_per_page(data)

--- a/neuro_san_studio/coded_tools/utils/pdf_utils.py
+++ b/neuro_san_studio/coded_tools/utils/pdf_utils.py
@@ -19,17 +19,36 @@ from io import BytesIO
 from pypdf import PdfReader
 
 
-class PdfUtils:  # pylint: disable=too-few-public-methods
+class PdfUtils:
     """Shared helpers for extracting text from PDF documents."""
 
     @staticmethod
     def parse_pdf_bytes(data: bytes) -> str:
-        """Extract text from in-memory PDF bytes, joining pages with newlines."""
+        """
+        Extract text from in-memory PDF bytes, joining pages with newlines.
+
+        :param data: The raw PDF bytes.
+        :return: The extracted text of all pages, separated by newlines.
+        """
+        return "\n".join(PdfUtils.parse_pdf_bytes_per_page(data))
+
+    @staticmethod
+    def parse_pdf_bytes_per_page(data: bytes) -> list[str]:
+        """
+        Extract text from in-memory PDF bytes, one string per page.
+
+        Callers that need page-level granularity (e.g. RAG loaders that record a
+        page number in each Document's metadata) use this directly;
+        parse_pdf_bytes is the joined-text convenience built on top of it.
+
+        :param data: The raw PDF bytes.
+        :return: The extracted text of each page, in page order.
+        """
         reader = PdfReader(BytesIO(data))
         page_texts: list[str] = []
         for page in reader.pages:
             # extract_text() is typed Optional[str] in newer pypdf and can return
             # None for pages without extractable text (e.g. scanned images);
-            # coerce to "" so the join never fails on a valid PDF.
+            # coerce to "" so callers never mix None into the page list.
             page_texts.append(page.extract_text() or "")
-        return "\n".join(page_texts)
+        return page_texts

--- a/neuro_san_studio/toolbox/toolbox_info.hocon
+++ b/neuro_san_studio/toolbox/toolbox_info.hocon
@@ -390,10 +390,11 @@
         }
     },
 
-    # To use tool, start by installing the required package:
-    #     pip install pymupdf >= 1.25.5
     "pdf_rag": {
         # This is a coded tool for RAG on PDF files.
+        # PDFs are fetched through the shared SSRF-hardened SafeFetch path and
+        # parsed with pypdf, which ships with this repo's requirements — no extra
+        # package install is needed.
         "class": "neuro_san_studio.coded_tools.pdf_rag.PdfRag",
         "description": "Retrieve information from the given PDF files",
         "parameters": {

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -136,8 +136,6 @@
     "tools/openai_video_generation.hocon": false,
     "tools/openai_web_search.hocon": true,
 
-    # To use this agent network, start by installing the required package:
-    #     pip install pymupdf >= 1.25.5
     "tools/pdf_rag.hocon": false,
     
     # File system-backed long-term memory tool (per-agent): CRUD + keyword search.

--- a/registries/tools/pdf_rag.hocon
+++ b/registries/tools/pdf_rag.hocon
@@ -14,9 +14,6 @@
 #
 # END COPYRIGHT
 
-# To use this agent network, start by installing the required package:
-#     pip install pymupdf >= 1.25.5
-
 {
     include "registries/expertise_scoping_instructions.hocon",
 

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -349,6 +349,17 @@ class TestPdfRag(TestCase):
 
         self.assertIn("No content could be retrieved", result)
 
+    def test_non_list_urls_is_refused_without_network(self):
+        """A non-list, non-string 'urls' (e.g. an int from a hand-edited hocon) is refused, not crashed on."""
+        with patch.object(SafeFetch, "open_session") as mock_session:
+            result = asyncio.run(self.tool.async_invoke({"query": "q", "urls": 123}, {}))
+            docs = asyncio.run(self.tool.load_documents({"urls": 123}))
+
+        self.assertIn("Invalid input: 'urls' must be a list", result)
+        self.assertIn("got int", result)
+        self.assertEqual(docs, [])  # the loader refuses it too, for direct callers
+        mock_session.assert_not_called()
+
     def test_missing_query_or_urls_returns_error_without_network(self):
         """async_invoke reports missing inputs before any session is opened."""
         with patch.object(SafeFetch, "open_session") as mock_session:

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -36,85 +36,6 @@ PDF_BYTES = b"%PDF-1.4 fake body"
 PAGE_TEXTS = ["Page one text", "Page two text"]
 
 
-def make_session_cm() -> MagicMock:
-    """
-    Build an async-context-manager mock standing in for SafeFetch.open_session().
-
-    :return: A MagicMock usable as ``async with`` that yields a mock session.
-    """
-    session = MagicMock()
-    session_cm = MagicMock()
-    session_cm.__aenter__ = AsyncMock(return_value=session)
-    session_cm.__aexit__ = AsyncMock(return_value=False)
-    return session_cm
-
-
-async def download_failing_bad_urls(url: str, _session: Any) -> bytes:
-    """
-    Stand in for download_pdf_bytes: return PDF bytes, failing URLs containing 'bad'.
-
-    :param url: The URL being downloaded.
-    :param _session: The shared session; unused.
-    :return: The stub PDF bytes for any URL not containing 'bad'.
-    :raises ClientError: For any URL containing 'bad'.
-    """
-    if "bad" in url:
-        raise ClientError("url_not_accessible: connection reset")
-    return PDF_BYTES
-
-
-async def record_session_close(order: list[str], *_args: Any) -> bool:
-    """
-    Stand in for the session context manager's __aexit__, recording when it runs.
-
-    :param order: The shared event-order list the test asserts on.
-    :param _args: The (exc_type, exc, tb) triple passed to __aexit__ (plus the mock
-        itself, prepended by MagicMock's magic-method plumbing); unused.
-    :return: False so any exception keeps propagating.
-    """
-    order.append("session_closed")
-    return False
-
-
-async def blocked_download(order: list[str], url: str, _session: Any) -> Any:
-    """
-    Stand in for download_pdf_bytes: block until cancelled, then record the unwind.
-
-    :param order: The shared event-order list the test asserts on.
-    :param url: The URL being downloaded; 'b.pdf' takes several extra event-loop
-        ticks to unwind, which is what exposes a premature session close (a single
-        tick is absorbed by asyncio's own deferred done-callbacks).
-    :param _session: The shared session; unused.
-    :return: Never returns normally.
-    """
-    try:
-        await asyncio.Event().wait()
-    except asyncio.CancelledError:
-        if url.endswith("b.pdf"):
-            for _ in range(5):
-                await asyncio.sleep(0)
-        order.append("child_unwound")
-        raise
-
-
-async def cancel_mid_flight_load(tool: PdfRag) -> None:
-    """
-    Start a two-URL load, cancel it once both item tasks are in flight, and await teardown.
-
-    :param tool: The PdfRag instance under test.
-    :raises asyncio.CancelledError: always — re-raised from the cancelled load once
-        its teardown (children unwound, session closed) has completed.
-    """
-    task = asyncio.ensure_future(
-        tool.load_documents({"urls": ["http://example.com/a.pdf", "http://example.com/b.pdf"]})
-    )
-    # A few no-op ticks let load_documents start and both children block in the download.
-    for _ in range(3):
-        await asyncio.sleep(0)
-    task.cancel()
-    await task
-
-
 class TestPdfRag(TestCase):
     """Unit tests for PdfRag: SSRF-hardened remote loading, local paths, input guards."""
 
@@ -132,10 +53,89 @@ class TestPdfRag(TestCase):
         """
         return asyncio.run(self.tool.load_documents({"urls": urls}))
 
+    @staticmethod
+    def _make_session_cm() -> MagicMock:
+        """
+        Build an async-context-manager mock standing in for SafeFetch.open_session().
+
+        :return: A MagicMock usable as ``async with`` that yields a mock session.
+        """
+        session = MagicMock()
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=session)
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+        return session_cm
+
+    @staticmethod
+    async def _download_failing_bad_urls(url: str, _session: Any) -> bytes:
+        """
+        Stand in for download_pdf_bytes: return PDF bytes, failing URLs containing 'bad'.
+
+        :param url: The URL being downloaded.
+        :param _session: The shared session; unused.
+        :return: The stub PDF bytes for any URL not containing 'bad'.
+        :raises ClientError: For any URL containing 'bad'.
+        """
+        if "bad" in url:
+            raise ClientError("url_not_accessible: connection reset")
+        return PDF_BYTES
+
+    @staticmethod
+    async def _record_session_close(order: list[str], *_args: Any) -> bool:
+        """
+        Stand in for the session context manager's __aexit__, recording when it runs.
+
+        :param order: The shared event-order list the test asserts on.
+        :param _args: The (exc_type, exc, tb) triple passed to __aexit__ (plus the mock
+            itself, prepended by MagicMock's magic-method plumbing); unused.
+        :return: False so any exception keeps propagating.
+        """
+        order.append("session_closed")
+        return False
+
+    @staticmethod
+    async def _blocked_download(order: list[str], url: str, _session: Any) -> Any:
+        """
+        Stand in for download_pdf_bytes: block until cancelled, then record the unwind.
+
+        :param order: The shared event-order list the test asserts on.
+        :param url: The URL being downloaded; 'b.pdf' takes several extra event-loop
+            ticks to unwind, which is what exposes a premature session close (a single
+            tick is absorbed by asyncio's own deferred done-callbacks).
+        :param _session: The shared session; unused.
+        :return: Never returns normally.
+        """
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            if url.endswith("b.pdf"):
+                for _ in range(5):
+                    await asyncio.sleep(0)
+            order.append("child_unwound")
+            raise
+
+    @staticmethod
+    async def _cancel_mid_flight_load(tool: PdfRag) -> None:
+        """
+        Start a two-URL load, cancel it once both item tasks are in flight, and await teardown.
+
+        :param tool: The PdfRag instance under test.
+        :raises asyncio.CancelledError: always — re-raised from the cancelled load once
+            its teardown (children unwound, session closed) has completed.
+        """
+        task = asyncio.ensure_future(
+            tool.load_documents({"urls": ["http://example.com/a.pdf", "http://example.com/b.pdf"]})
+        )
+        # A few no-op ticks let load_documents start and both children block in the download.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        task.cancel()
+        await task
+
     def test_remote_pdf_produces_per_page_documents(self):
         """A downloaded PDF yields one Document per page with source/page/total_pages metadata."""
         with (
-            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
             patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=PAGE_TEXTS) as mock_parse,
         ):
@@ -155,7 +155,7 @@ class TestPdfRag(TestCase):
             local_path = handle.name
         try:
             with (
-                patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+                patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
                 patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock()) as mock_dl,
                 patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["local text"]) as mock_parse,
             ):
@@ -172,7 +172,7 @@ class TestPdfRag(TestCase):
     def test_private_ip_url_skipped_without_download(self):
         """A URL that fails SSRF validation is skipped and never downloaded; others still load."""
         with (
-            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
             patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
         ):
@@ -186,8 +186,8 @@ class TestPdfRag(TestCase):
     def test_failed_download_does_not_discard_other_pdfs(self):
         """One unreachable PDF is logged and skipped; the rest of the corpus survives."""
         with (
-            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
-            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(side_effect=download_failing_bad_urls)),
+            patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(side_effect=self._download_failing_bad_urls)),
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
         ):
             docs = self._load(["http://bad.example.com/a.pdf", "http://example.com/good.pdf"])
@@ -198,7 +198,7 @@ class TestPdfRag(TestCase):
     def test_parse_failure_skips_only_that_item(self):
         """A pypdf parse error skips that item instead of aborting the whole load."""
         with (
-            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
             patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=b"not a pdf")),
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", side_effect=ValueError("bad pdf")),
         ):
@@ -208,7 +208,7 @@ class TestPdfRag(TestCase):
 
     def test_missing_local_file_is_skipped(self):
         """A nonexistent local path is logged and skipped rather than raising."""
-        with patch.object(SafeFetch, "open_session", return_value=make_session_cm()):
+        with patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()):
             docs = self._load(["/nonexistent/dir/missing.pdf"])
 
         self.assertEqual(docs, [])
@@ -216,7 +216,7 @@ class TestPdfRag(TestCase):
     def test_bare_string_urls_is_treated_as_single_item(self):
         """A single URL passed as a bare string loads as one PDF, not one fetch per character."""
         with (
-            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
             patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=PAGE_TEXTS),
         ):
@@ -234,7 +234,7 @@ class TestPdfRag(TestCase):
         which failed with a misleading "file not found" for such URLs.
         """
         with (
-            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
             patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
         ):
@@ -264,7 +264,7 @@ class TestPdfRag(TestCase):
         on the stripped candidate too; parsing the raw string would see no scheme.
         """
         with (
-            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
             patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
         ):
@@ -277,7 +277,7 @@ class TestPdfRag(TestCase):
     def test_windows_drive_path_is_treated_as_local_file(self):
         """A drive-letter path parses with a one-letter scheme but must route to the local reader."""
         with (
-            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
             patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock()) as mock_dl,
         ):
             with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="WARNING") as logs:
@@ -296,7 +296,7 @@ class TestPdfRag(TestCase):
             local_path = handle.name
         try:
             with (
-                patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+                patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
                 # Shrink the cap below the file size so the tiny temp file trips it.
                 patch("neuro_san_studio.coded_tools.pdf_rag.MAX_RESPONSE_BYTES", len(PDF_BYTES) - 1),
                 patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
@@ -319,15 +319,15 @@ class TestPdfRag(TestCase):
 
         session_cm = MagicMock()
         session_cm.__aenter__ = AsyncMock(return_value=MagicMock())
-        # partial() binds the shared order list; the helpers live at module level.
-        session_cm.__aexit__ = partial(record_session_close, order)
+        # partial() binds the shared order list; the helpers are static methods of this class.
+        session_cm.__aexit__ = partial(self._record_session_close, order)
 
         with (
             patch.object(SafeFetch, "open_session", return_value=session_cm),
-            patch.object(SafeFetch, "download_pdf_bytes", new=partial(blocked_download, order)),
+            patch.object(SafeFetch, "download_pdf_bytes", new=partial(self._blocked_download, order)),
         ):
             with self.assertRaises(asyncio.CancelledError):
-                asyncio.run(cancel_mid_flight_load(self.tool))
+                asyncio.run(self._cancel_mid_flight_load(self.tool))
 
         self.assertEqual(order, ["child_unwound", "child_unwound", "session_closed"])
 

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -239,7 +239,7 @@ class TestPdfRag(TestCase):
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
         ):
             with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="WARNING") as logs:
-                docs = self._load(["s3://bucket/key.pdf", "file:///tmp/x.pdf", "http://example.com/good.pdf"])
+                docs = self._load(["s3://bucket/key.pdf", "file:///path/to/x.pdf", "http://example.com/good.pdf"])
 
         self.assertEqual(len(docs), 1)
         self.assertEqual(docs[0].metadata["source"], "http://example.com/good.pdf")

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -239,7 +239,14 @@ class TestPdfRag(TestCase):
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
         ):
             with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="WARNING") as logs:
-                docs = self._load(["s3://bucket/key.pdf", "file:///path/to/x.pdf", "http://example.com/good.pdf"])
+                docs = self._load(
+                    [
+                        "s3://bucket/key.pdf",
+                        "file:///path/to/x.pdf",
+                        "x://host/file.pdf",
+                        "http://example.com/good.pdf",
+                    ]
+                )
 
         self.assertEqual(len(docs), 1)
         self.assertEqual(docs[0].metadata["source"], "http://example.com/good.pdf")
@@ -247,6 +254,23 @@ class TestPdfRag(TestCase):
         joined_logs: str = "\n".join(logs.output)
         self.assertIn("unsupported URL scheme 's3'", joined_logs)
         self.assertIn("unsupported URL scheme 'file'", joined_logs)
+        # A one-letter scheme with URI syntax is NOT mistaken for a drive letter.
+        self.assertIn("unsupported URL scheme 'x'", joined_logs)
+
+    def test_windows_drive_path_is_treated_as_local_file(self):
+        """A drive-letter path parses with a one-letter scheme but must route to the local reader."""
+        with (
+            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock()) as mock_dl,
+        ):
+            with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="WARNING") as logs:
+                docs = self._load(["C:\\docs\\file.pdf"])
+
+        # The path does not exist on this machine, so it is skipped as a file-read
+        # failure — not as an unsupported scheme, and never as a download.
+        self.assertEqual(docs, [])
+        mock_dl.assert_not_awaited()
+        self.assertNotIn("unsupported URL scheme", "\n".join(logs.output))
 
     def test_oversized_local_file_is_skipped(self):
         """A local file over the byte cap is skipped instead of being read into memory."""

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -19,6 +19,7 @@
 import asyncio
 import os
 import tempfile
+from functools import partial
 from typing import Any
 from unittest import TestCase
 from unittest.mock import AsyncMock
@@ -46,6 +47,72 @@ def make_session_cm() -> MagicMock:
     session_cm.__aenter__ = AsyncMock(return_value=session)
     session_cm.__aexit__ = AsyncMock(return_value=False)
     return session_cm
+
+
+async def download_failing_bad_urls(url: str, _session: Any) -> bytes:
+    """
+    Stand in for download_pdf_bytes: return PDF bytes, failing URLs containing 'bad'.
+
+    :param url: The URL being downloaded.
+    :param _session: The shared session; unused.
+    :return: The stub PDF bytes for any URL not containing 'bad'.
+    :raises ClientError: For any URL containing 'bad'.
+    """
+    if "bad" in url:
+        raise ClientError("url_not_accessible: connection reset")
+    return PDF_BYTES
+
+
+async def record_session_close(order: list[str], *_args: Any) -> bool:
+    """
+    Stand in for the session context manager's __aexit__, recording when it runs.
+
+    :param order: The shared event-order list the test asserts on.
+    :param _args: The (exc_type, exc, tb) triple passed to __aexit__ (plus the mock
+        itself, prepended by MagicMock's magic-method plumbing); unused.
+    :return: False so any exception keeps propagating.
+    """
+    order.append("session_closed")
+    return False
+
+
+async def blocked_download(order: list[str], url: str, _session: Any) -> Any:
+    """
+    Stand in for download_pdf_bytes: block until cancelled, then record the unwind.
+
+    :param order: The shared event-order list the test asserts on.
+    :param url: The URL being downloaded; 'b.pdf' takes several extra event-loop
+        ticks to unwind, which is what exposes a premature session close (a single
+        tick is absorbed by asyncio's own deferred done-callbacks).
+    :param _session: The shared session; unused.
+    :return: Never returns normally.
+    """
+    try:
+        await asyncio.Event().wait()
+    except asyncio.CancelledError:
+        if url.endswith("b.pdf"):
+            for _ in range(5):
+                await asyncio.sleep(0)
+        order.append("child_unwound")
+        raise
+
+
+async def cancel_mid_flight_load(tool: PdfRag) -> None:
+    """
+    Start a two-URL load, cancel it once both item tasks are in flight, and await teardown.
+
+    :param tool: The PdfRag instance under test.
+    :raises asyncio.CancelledError: always — re-raised from the cancelled load once
+        its teardown (children unwound, session closed) has completed.
+    """
+    task = asyncio.ensure_future(
+        tool.load_documents({"urls": ["http://example.com/a.pdf", "http://example.com/b.pdf"]})
+    )
+    # A few no-op ticks let load_documents start and both children block in the download.
+    for _ in range(3):
+        await asyncio.sleep(0)
+    task.cancel()
+    await task
 
 
 class TestPdfRag(TestCase):
@@ -118,16 +185,9 @@ class TestPdfRag(TestCase):
 
     def test_failed_download_does_not_discard_other_pdfs(self):
         """One unreachable PDF is logged and skipped; the rest of the corpus survives."""
-
-        async def download(url: str, _session: Any) -> bytes:
-            """Return PDF bytes, raising ClientError for any URL containing 'bad'."""
-            if "bad" in url:
-                raise ClientError("url_not_accessible: connection reset")
-            return PDF_BYTES
-
         with (
             patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
-            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(side_effect=download)),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(side_effect=download_failing_bad_urls)),
             patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
         ):
             docs = self._load(["http://bad.example.com/a.pdf", "http://example.com/good.pdf"])
@@ -152,6 +212,83 @@ class TestPdfRag(TestCase):
             docs = self._load(["/nonexistent/dir/missing.pdf"])
 
         self.assertEqual(docs, [])
+
+    def test_bare_string_urls_is_treated_as_single_item(self):
+        """A single URL passed as a bare string loads as one PDF, not one fetch per character."""
+        with (
+            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
+            patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=PAGE_TEXTS),
+        ):
+            docs = asyncio.run(self.tool.load_documents({"urls": "http://example.com/report.pdf"}))
+
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(docs[0].metadata["source"], "http://example.com/report.pdf")
+        # Exactly one download — not one per character of the string.
+        mock_dl.assert_awaited_once()
+
+    def test_unsupported_scheme_is_skipped_with_message(self):
+        """file:// and s3:// items are skipped with an explicit message; the corpus survives.
+
+        The old negative-space routing handed every non-http string to open(),
+        which failed with a misleading "file not found" for such URLs.
+        """
+        with (
+            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
+            patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
+        ):
+            with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="WARNING") as logs:
+                docs = self._load(["s3://bucket/key.pdf", "file:///tmp/x.pdf", "http://example.com/good.pdf"])
+
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["source"], "http://example.com/good.pdf")
+        mock_dl.assert_awaited_once()  # only the http URL reached the network
+        joined_logs: str = "\n".join(logs.output)
+        self.assertIn("unsupported URL scheme 's3'", joined_logs)
+        self.assertIn("unsupported URL scheme 'file'", joined_logs)
+
+    def test_oversized_local_file_is_skipped(self):
+        """A local file over the byte cap is skipped instead of being read into memory."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as handle:
+            handle.write(PDF_BYTES)
+            local_path = handle.name
+        try:
+            with (
+                patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+                # Shrink the cap below the file size so the tiny temp file trips it.
+                patch("neuro_san_studio.coded_tools.pdf_rag.MAX_RESPONSE_BYTES", len(PDF_BYTES) - 1),
+                patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
+            ):
+                docs = self._load([local_path])
+        finally:
+            os.unlink(local_path)
+
+        self.assertEqual(docs, [])
+        mock_parse.assert_not_called()
+
+    def test_cancellation_closes_session_only_after_children_unwind(self):
+        """Cancelling the load lets every in-flight item unwind before the session closes.
+
+        Without return_exceptions=True on the gather, the first child's CancelledError
+        propagates as soon as that child finishes unwinding, and the shared session is
+        closed while the slower sibling is still using it.
+        """
+        order: list[str] = []
+
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        # partial() binds the shared order list; the helpers live at module level.
+        session_cm.__aexit__ = partial(record_session_close, order)
+
+        with (
+            patch.object(SafeFetch, "open_session", return_value=session_cm),
+            patch.object(SafeFetch, "download_pdf_bytes", new=partial(blocked_download, order)),
+        ):
+            with self.assertRaises(asyncio.CancelledError):
+                asyncio.run(cancel_mid_flight_load(self.tool))
+
+        self.assertEqual(order, ["child_unwound", "child_unwound", "session_closed"])
 
     def test_empty_url_list_returns_empty_without_session(self):
         """An empty item list returns [] without ever opening a network session."""

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -257,6 +257,23 @@ class TestPdfRag(TestCase):
         # A one-letter scheme with URI syntax is NOT mistaken for a drive letter.
         self.assertIn("unsupported URL scheme 'x'", joined_logs)
 
+    def test_whitespace_padded_remote_url_is_routed_as_remote(self):
+        """A remote URL with surrounding whitespace is downloaded, not mistaken for a local path.
+
+        SafeFetch.validate_url strips padding, so the routing decision must be made
+        on the stripped candidate too; parsing the raw string would see no scheme.
+        """
+        with (
+            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
+            patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
+        ):
+            docs = self._load(["  http://example.com/padded.pdf  "])
+
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["source"], "http://example.com/padded.pdf")
+        mock_dl.assert_awaited_once()
+
     def test_windows_drive_path_is_treated_as_local_file(self):
         """A drive-letter path parses with a one-letter scheme but must route to the local reader."""
         with (

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -1,0 +1,182 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Tests for the PDF RAG coded tool's SafeFetch-backed document loading."""
+
+import asyncio
+import os
+import tempfile
+from typing import Any
+from unittest import TestCase
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from aiohttp import ClientError
+
+from neuro_san_studio.coded_tools.pdf_rag import PdfRag
+from neuro_san_studio.coded_tools.utils.pdf_utils import PdfUtils
+from neuro_san_studio.coded_tools.utils.safe_fetch import SafeFetch
+
+PDF_BYTES = b"%PDF-1.4 fake body"
+PAGE_TEXTS = ["Page one text", "Page two text"]
+
+
+def make_session_cm() -> MagicMock:
+    """
+    Build an async-context-manager mock standing in for SafeFetch.open_session().
+
+    :return: A MagicMock usable as ``async with`` that yields a mock session.
+    """
+    session = MagicMock()
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return session_cm
+
+
+class TestPdfRag(TestCase):
+    """Unit tests for PdfRag: SSRF-hardened remote loading, local paths, input guards."""
+
+    def setUp(self):
+        # Bypass BaseRag.__init__, which instantiates OpenAIEmbeddings and therefore
+        # requires an OPENAI_API_KEY; these tests never embed or build a store.
+        self.tool = object.__new__(PdfRag)
+
+    def _load(self, urls: list[str]) -> list:
+        """
+        Run load_documents with the given items against mocked session and parsing.
+
+        :param urls: The list of URLs/paths to pass to load_documents.
+        :return: The list of loaded Documents.
+        """
+        return asyncio.run(self.tool.load_documents({"urls": urls}))
+
+    def test_remote_pdf_produces_per_page_documents(self):
+        """A downloaded PDF yields one Document per page with source/page/total_pages metadata."""
+        with (
+            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
+            patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=PAGE_TEXTS) as mock_parse,
+        ):
+            docs = self._load(["http://example.com/report.pdf"])
+
+        mock_dl.assert_awaited_once()
+        mock_parse.assert_called_once_with(PDF_BYTES)
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(docs[0].page_content, "Page one text")
+        self.assertEqual(docs[0].metadata, {"source": "http://example.com/report.pdf", "page": 0, "total_pages": 2})
+        self.assertEqual(docs[1].metadata["page"], 1)
+
+    def test_local_path_reads_file_without_network(self):
+        """A local file path is read from disk; no download is attempted."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as handle:
+            handle.write(PDF_BYTES)
+            local_path = handle.name
+        try:
+            with (
+                patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+                patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock()) as mock_dl,
+                patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["local text"]) as mock_parse,
+            ):
+                docs = self._load([local_path])
+        finally:
+            os.unlink(local_path)
+
+        mock_dl.assert_not_awaited()
+        # The parser received the actual bytes read from disk.
+        mock_parse.assert_called_once_with(PDF_BYTES)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["source"], local_path)
+
+    def test_private_ip_url_skipped_without_download(self):
+        """A URL that fails SSRF validation is skipped and never downloaded; others still load."""
+        with (
+            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=PDF_BYTES)) as mock_dl,
+            patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
+        ):
+            # validate_url is NOT mocked, so the private-IP URL is rejected for real.
+            docs = self._load(["http://192.168.1.1/internal.pdf", "http://example.com/good.pdf"])
+
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["source"], "http://example.com/good.pdf")
+        mock_dl.assert_awaited_once()  # only the allowed URL reached the network
+
+    def test_failed_download_does_not_discard_other_pdfs(self):
+        """One unreachable PDF is logged and skipped; the rest of the corpus survives."""
+
+        async def download(url: str, _session: Any) -> bytes:
+            """Return PDF bytes, raising ClientError for any URL containing 'bad'."""
+            if "bad" in url:
+                raise ClientError("url_not_accessible: connection reset")
+            return PDF_BYTES
+
+        with (
+            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(side_effect=download)),
+            patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]),
+        ):
+            docs = self._load(["http://bad.example.com/a.pdf", "http://example.com/good.pdf"])
+
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["source"], "http://example.com/good.pdf")
+
+    def test_parse_failure_skips_only_that_item(self):
+        """A pypdf parse error skips that item instead of aborting the whole load."""
+        with (
+            patch.object(SafeFetch, "open_session", return_value=make_session_cm()),
+            patch.object(SafeFetch, "download_pdf_bytes", new=AsyncMock(return_value=b"not a pdf")),
+            patch.object(PdfUtils, "parse_pdf_bytes_per_page", side_effect=ValueError("bad pdf")),
+        ):
+            docs = self._load(["http://example.com/broken.pdf"])
+
+        self.assertEqual(docs, [])  # skipped, not raised
+
+    def test_missing_local_file_is_skipped(self):
+        """A nonexistent local path is logged and skipped rather than raising."""
+        with patch.object(SafeFetch, "open_session", return_value=make_session_cm()):
+            docs = self._load(["/nonexistent/dir/missing.pdf"])
+
+        self.assertEqual(docs, [])
+
+    def test_empty_url_list_returns_empty_without_session(self):
+        """An empty item list returns [] without ever opening a network session."""
+        with patch.object(SafeFetch, "open_session") as mock_session:
+            docs = self._load([])
+
+        self.assertEqual(docs, [])
+        mock_session.assert_not_called()
+
+    def test_all_items_skipped_returns_clear_message(self):
+        """When nothing is ingested, async_invoke returns a clear message, not an empty list."""
+        with (
+            patch.object(PdfRag, "generate_vector_store", new=AsyncMock(return_value=MagicMock())),
+            patch.object(PdfRag, "query_vectorstore", new=AsyncMock(return_value=[])),
+        ):
+            result = asyncio.run(self.tool.async_invoke({"query": "q", "urls": ["http://example.com/x.pdf"]}, {}))
+
+        self.assertIn("No content could be retrieved", result)
+
+    def test_missing_query_or_urls_returns_error_without_network(self):
+        """async_invoke reports missing inputs before any session is opened."""
+        with patch.object(SafeFetch, "open_session") as mock_session:
+            no_query = asyncio.run(self.tool.async_invoke({"urls": ["http://example.com/x.pdf"]}, {}))
+            no_urls = asyncio.run(self.tool.async_invoke({"query": "hello"}, {}))
+
+        self.assertIn("Missing required input: 'query'", no_query)
+        self.assertIn("Missing required input: 'urls'", no_urls)
+        mock_session.assert_not_called()

--- a/tests/neuro_san_studio/coded_tools/utils/test_pdf_utils.py
+++ b/tests/neuro_san_studio/coded_tools/utils/test_pdf_utils.py
@@ -107,6 +107,18 @@ class TestPdfUtils:
         assert PdfUtils.parse_pdf_bytes(b"fake") == ""
 
     @patch(f"{MODULE}.PdfReader")
+    def test_per_page_returns_list_in_page_order(self, mock_reader_cls):
+        """parse_pdf_bytes_per_page returns one string per page, in page order."""
+        mock_reader_cls.return_value = self._reader_with([self._make_page("Page 1"), self._make_page("Page 2")])
+        assert PdfUtils.parse_pdf_bytes_per_page(b"fake") == ["Page 1", "Page 2"]
+
+    @patch(f"{MODULE}.PdfReader")
+    def test_per_page_none_coerced_to_empty_string(self, mock_reader_cls):
+        """A page with no extractable text yields "" in the per-page list, never None."""
+        mock_reader_cls.return_value = self._reader_with([self._make_page("A"), self._make_page(None)])
+        assert PdfUtils.parse_pdf_bytes_per_page(b"fake") == ["A", ""]
+
+    @patch(f"{MODULE}.PdfReader")
     def test_input_is_wrapped_in_bytesio(self, mock_reader_cls):
         """The raw bytes are wrapped in a BytesIO and forwarded to PdfReader unchanged."""
         mock_reader_cls.return_value = self._reader_with([self._make_page("x")])


### PR DESCRIPTION
## Description

Migrates `PdfRag` off `langchain_community.PyMuPDFLoader` and onto the shared SSRF-hardened fetch path (`SafeFetch`, from #1361/#1366) plus pypdf. Remote PDFs are now downloaded through the same protected session WebFetch and WebpageRag use — private/loopback/reserved hosts rejected, DNS records validated at connection time (anti DNS-rebinding), redirects refused, response sizes capped — and parsed with pypdf via the shared `PdfUtils` helper. Local file paths, a documented input form for this tool, keep working and are read directly from disk. The `pymupdf` extra install is gone.

Fixes #1299 (part of the langchain-community removal, #1242).

## What changed

- **`PdfRag.load_documents`** processes items concurrently (semaphore-capped at 5, held across download *and* parse to bound peak memory) over one shared `SafeFetch.open_session()`:
  - **Explicit scheme routing**: `http(s)` downloads via `SafeFetch.download_pdf_bytes`; no scheme (or a single-letter Windows drive letter in path syntax, e.g. `C:\docs\file.pdf`) is a local file path; any other scheme (`file://`, `s3://`, `x://host/...`, a typo) is skipped with an explicit "unsupported URL scheme" message instead of being handed to `open()` and failing with a misleading "file not found". Routing works on a whitespace-stripped copy so a padded remote URL (which `validate_url` accepts) is not mistaken for a local path.
  - **Resilient batch**: validation, network, file-read, and pypdf parse failures skip that item only. A bare-string `urls` from a hand-edited hocon is treated as a one-item list rather than iterated per character, and a non-list container (e.g. an int) is refused with a clear invalid-input message — `urls` reaches this tool only via the hocon args block, which neuro-san does not schema-validate.
  - **Clean cancellation**: `gather(..., return_exceptions=True)` lets every in-flight item unwind before the shared session closes.
  - **Off-thread parsing**: pypdf runs via `to_thread`, mirroring `SafeFetch.fetch_pdf_text`.
- **Local files get the same byte cap as downloads** (`MAX_RESPONSE_BYTES`), enforced on the read itself (read at most cap + 1 bytes, reject the overflow) rather than an `os.path.getsize()` pre-check, which is not a hard cap (special files report size 0; a file can grow between probe and read).
- **One `Document` per page** with `{source, page, total_pages}` metadata, preserving the granularity of the previous `PyMuPDFLoader` so page numbers survive into the vector store. New `PdfUtils.parse_pdf_bytes_per_page`; `parse_pdf_bytes` now joins it.
- **pymupdf dependency eliminated**: the install notes in `toolbox_info.hocon`, `registries/tools/pdf_rag.hocon`, `registries/tools/manifest.hocon`, and `docs/examples/tools/pdf_rag.md` are updated (pypdf ships in `requirements.txt`).
- **`async_invoke`** returns a clear "no content could be retrieved" message when every item was skipped, instead of an empty list.
- **Tests**: new `tests/.../test_pdf_rag.py` (16 tests) covering per-page remote loading, local files without network, SSRF-validation skip, one-bad-item-survives, parse-failure skip, missing local file, unsupported schemes (including `x://` URI syntax), Windows drive-letter paths, whitespace-padded remote URLs, oversized local file, bare-string and non-list `urls`, cancellation teardown ordering, the all-skipped message, and input guards; `test_pdf_utils.py` gains per-page tests.

## Behavior notes

- Remote PDFs now fall under the SafeFetch policy: redirects are refused (bounded, re-validated following is tracked in #1369), and bodies are capped at the shared 50 MB limit.
- `langchain-community` stays in `requirements.txt` for now: `coded_tools/tools/agentic_rag/rag.py` still imports `PyPDFLoader` from it — tracked in #1401, which also drops the dependency (neuro-san 0.7.0 no longer requires it).
- `BaseRag` (chunk/embed/store/retrieve) is untouched and the tool's public args are unchanged, so existing registry references keep working. The empty-vector-store persistence guard is tracked separately in #1368, and a `%PDF-` header sniff (skip a local non-PDF after 1 KB instead of reading the full cap, clearer `not_a_pdf` error) in #1403.
