### PR TITLE
#1399 part 1: BYOK key resolver for coded tools (ByokApiKey, OpenAITool, AnthropicTool)

### DIFF
--- a/neuro_san_studio/coded_tools/anthropic_tool.py
+++ b/neuro_san_studio/coded_tools/anthropic_tool.py
@@ -23,7 +23,9 @@ from langchain_core.messages import AIMessage
 
 from neuro_san_studio.coded_tools.utils.byok_api_key import ByokApiKey
 
-DEFAULT_ANTHROPIC_MODEL = "claude-3-7-sonnet-20250219"
+# Current-generation default (claude-3-7-sonnet-20250219 is retired); networks override it per
+# tool via the "anthropic_model" arg.
+DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-5"
 
 # Where a Bring-Your-Own-Key (BYOK) client puts its Anthropic key inside sly_data["llm_config"],
 # and the server-side environment variable used when the client did not send one. The names
@@ -78,7 +80,7 @@ class AnthropicTool:
         :param tool_type: The versioned type of the built-in Anthropic tool, e.g. "web_search_20250305".
         :param tool_name: The name of the built-in Anthropic tool, e.g. "web_search".
         :param anthropic_model: The Anthropic model to use when calling the tool.
-            Defaults to "claude-3-7-sonnet-20250219" if not provided.
+            Defaults to "claude-sonnet-5" if not provided.
         :param betas: Some tools are still in beta and requires this parameter.
         :param sly_data: The sly_data dictionary of the calling coded tool. When it carries a
             BYOK key under llm_config.anthropic_api_key, that key authenticates the call instead

--- a/neuro_san_studio/coded_tools/anthropic_tool.py
+++ b/neuro_san_studio/coded_tools/anthropic_tool.py
@@ -21,10 +21,17 @@ from anthropic import AnthropicError
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage
 
+from neuro_san_studio.coded_tools.utils.byok_api_key import ByokApiKey
+
 DEFAULT_ANTHROPIC_MODEL = "claude-3-7-sonnet-20250219"
 
+# Where a Bring-Your-Own-Key (BYOK) client puts its Anthropic key inside sly_data["llm_config"],
+# and the server-side environment variable used when the client did not send one. The names
+# match what neuro-san uses for agents' llm_config so one client convention covers both.
+ANTHROPIC_API_KEY_NAME = "anthropic_api_key"
+ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY"
 
-# pylint: disable=too-few-public-methods
+
 class AnthropicTool:
     """
     An implementation for invoking Anthropic built-in tools using LangChain's ChatAnthropic.
@@ -41,20 +48,41 @@ class AnthropicTool:
     logger = logging.getLogger(__name__)
 
     @staticmethod
-    async def arun(
+    def get_api_key(sly_data: dict[str, Any] | None) -> str | None:
+        """
+        Resolve the Anthropic API key for a tool call.
+
+        The BYOK key in sly_data["llm_config"]["anthropic_api_key"] wins; the ANTHROPIC_API_KEY
+        environment variable is the fallback. Shared by every coded tool that talks to Anthropic
+        directly so the precedence rule lives in one place.
+
+        :param sly_data: The sly_data dictionary handed to the calling coded tool. May be None.
+        :return: The API key to use, or None when neither source provides one.
+        """
+        return ByokApiKey.resolve(sly_data, ANTHROPIC_API_KEY_NAME, ANTHROPIC_API_KEY_ENV)
+
+    @staticmethod
+    async def arun(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         query: str,
         tool_type: str,
         tool_name: str,
         anthropic_model: str | None = DEFAULT_ANTHROPIC_MODEL,
         betas: list[str] | None = None,
+        sly_data: dict[str, Any] | None = None,
         **additional_kwargs: dict[str, Any],
     ) -> list[dict[str, Any]] | str:
         """
+        Invoke an Anthropic built-in tool through ChatAnthropic and return its content blocks.
+
         :param query: Request from the user prompt.
-        :param builtin_tool: The name of the built-in OpenAI tool to invoke.
+        :param tool_type: The versioned type of the built-in Anthropic tool, e.g. "web_search_20250305".
+        :param tool_name: The name of the built-in Anthropic tool, e.g. "web_search".
         :param anthropic_model: The Anthropic model to use when calling the tool.
             Defaults to "claude-3-7-sonnet-20250219" if not provided.
         :param betas: Some tools are still in beta and requires this parameter.
+        :param sly_data: The sly_data dictionary of the calling coded tool. When it carries a
+            BYOK key under llm_config.anthropic_api_key, that key authenticates the call instead
+            of the ANTHROPIC_API_KEY environment variable.
         :param additional_kwargs: Additional keyword arguments to pass to the selected tool.
             Refer to https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview
 
@@ -77,8 +105,14 @@ class AnthropicTool:
         AnthropicTool.logger.info("Additional Keyword Arguments: %s", additional_kwargs)
 
         try:
+            # A BYOK key from sly_data must win over the server's ANTHROPIC_API_KEY, so resolve
+            # it here instead of letting ChatAnthropic read the environment on its own. None
+            # (neither source has a key) is accepted at construction; the request then fails
+            # exactly as it did before this resolution existed.
+            api_key: str | None = AnthropicTool.get_api_key(sly_data)
+
             # Instantiate the chat model using specified model.
-            anthropic_llm = ChatAnthropic(model=anthropic_model)
+            anthropic_llm = ChatAnthropic(model=anthropic_model, api_key=api_key)
 
             tool: dict[str, Any] = {"type": tool_type, "name": tool_name} | additional_kwargs
 

--- a/neuro_san_studio/coded_tools/openai_tool.py
+++ b/neuro_san_studio/coded_tools/openai_tool.py
@@ -23,7 +23,8 @@ from openai import OpenAIError
 
 from neuro_san_studio.coded_tools.utils.byok_api_key import ByokApiKey
 
-DEFAULT_OPENAI_MODEL = "gpt-4o-2024-08-06"
+# Current-generation default; networks override it per tool via the "openai_model" arg.
+DEFAULT_OPENAI_MODEL = "gpt-5.2"
 
 # Where a Bring-Your-Own-Key (BYOK) client puts its OpenAI key inside sly_data["llm_config"],
 # and the server-side environment variable used when the client did not send one. The names
@@ -78,7 +79,7 @@ class OpenAITool:
         :param query: Request from the user prompt.
         :param builtin_tool: The name of the built-in OpenAI tool to invoke.
         :param openai_model: The OpenAI model to use when calling the tool.
-            Defaults to "gpt-4o-2024-08-06" if not provided.
+            Defaults to "gpt-5.2" if not provided.
         :param sly_data: The sly_data dictionary of the calling coded tool. When it carries a
             BYOK key under llm_config.openai_api_key, that key authenticates the call instead
             of the OPENAI_API_KEY environment variable.

--- a/neuro_san_studio/coded_tools/openai_tool.py
+++ b/neuro_san_studio/coded_tools/openai_tool.py
@@ -21,10 +21,17 @@ from langchain_core.messages import AIMessage
 from langchain_openai import ChatOpenAI
 from openai import OpenAIError
 
+from neuro_san_studio.coded_tools.utils.byok_api_key import ByokApiKey
+
 DEFAULT_OPENAI_MODEL = "gpt-4o-2024-08-06"
 
+# Where a Bring-Your-Own-Key (BYOK) client puts its OpenAI key inside sly_data["llm_config"],
+# and the server-side environment variable used when the client did not send one. The names
+# match what neuro-san uses for agents' llm_config so one client convention covers both.
+OPENAI_API_KEY_NAME = "openai_api_key"
+OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
 
-# pylint: disable=too-few-public-methods
+
 class OpenAITool:
     """
     An implementation for invoking OpenAI built-in tools using LangChain's ChatOpenAI.
@@ -44,17 +51,37 @@ class OpenAITool:
     logger = logging.getLogger(__name__)
 
     @staticmethod
+    def get_api_key(sly_data: dict[str, Any] | None) -> str | None:
+        """
+        Resolve the OpenAI API key for a tool call.
+
+        The BYOK key in sly_data["llm_config"]["openai_api_key"] wins; the OPENAI_API_KEY
+        environment variable is the fallback. Shared by every coded tool that talks to OpenAI
+        directly so the precedence rule lives in one place.
+
+        :param sly_data: The sly_data dictionary handed to the calling coded tool. May be None.
+        :return: The API key to use, or None when neither source provides one.
+        """
+        return ByokApiKey.resolve(sly_data, OPENAI_API_KEY_NAME, OPENAI_API_KEY_ENV)
+
+    @staticmethod
     async def arun(
         query: str,
         builtin_tool: str,
         openai_model: str | None = DEFAULT_OPENAI_MODEL,
+        sly_data: dict[str, Any] | None = None,
         **additional_kwargs: dict[str, Any],
     ) -> list[dict[str, Any]] | str:
         """
+        Invoke an OpenAI built-in tool through ChatOpenAI and return its content blocks.
+
         :param query: Request from the user prompt.
         :param builtin_tool: The name of the built-in OpenAI tool to invoke.
         :param openai_model: The OpenAI model to use when calling the tool.
             Defaults to "gpt-4o-2024-08-06" if not provided.
+        :param sly_data: The sly_data dictionary of the calling coded tool. When it carries a
+            BYOK key under llm_config.openai_api_key, that key authenticates the call instead
+            of the OPENAI_API_KEY environment variable.
         :param additional_kwargs: Additional keyword arguments to pass to the selected tool.
             Tool-specific requirements:
                 - "web_search_preview": no additional kwargs needed.
@@ -79,10 +106,16 @@ class OpenAITool:
         OpenAITool.logger.info("Additional Keyword Arguments: %s", additional_kwargs)
 
         try:
+            # A BYOK key from sly_data must win over the server's OPENAI_API_KEY, so resolve
+            # it here instead of letting ChatOpenAI read the environment on its own. When
+            # neither source has a key this is None and ChatOpenAI raises its usual
+            # missing-credentials OpenAIError, which the except below turns into the error string.
+            api_key: str | None = OpenAITool.get_api_key(sly_data)
+
             # Instantiate the chat model using specified model.
             # The "output_version" key format output from built-in tool invocations into
             # the message’s content field, rather than additional_kwargs.
-            openai_llm = ChatOpenAI(model=openai_model, output_version="responses/v1")
+            openai_llm = ChatOpenAI(model=openai_model, output_version="responses/v1", api_key=api_key)
             tool: dict[str, Any] = {"type": builtin_tool} | additional_kwargs
 
             # Invoke with the provided query and tool,

--- a/neuro_san_studio/coded_tools/utils/byok_api_key.py
+++ b/neuro_san_studio/coded_tools/utils/byok_api_key.py
@@ -1,0 +1,84 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import logging
+import os
+from typing import Any
+
+# The sly_data key under which a Bring-Your-Own-Key (BYOK) client sends its provider
+# API keys. This is the same convention neuro-san uses for agents whose llm_config says
+# "<provider>_api_key": "sly_data" -- see config/byok_llm_config.hocon.
+LLM_CONFIG_KEY = "llm_config"
+
+
+# pylint: disable=too-few-public-methods
+class ByokApiKey:
+    """
+    Resolves a provider API key for coded tools that call an LLM provider directly.
+
+    neuro-san's BYOK support only covers the agents' own llm_config: the client sends its
+    keys in sly_data["llm_config"] and the LLM factory substitutes them into the agent's
+    config before the chat model is built. Coded tools that instantiate their own provider
+    clients (OpenAI and Anthropic built-in tools, Gemini image generation, OpenAI video
+    generation, ...) never went through that path, so they authenticated from environment
+    variables only and either failed on a key-less BYOK deployment or silently billed the
+    platform's key. This class gives those tools the same precedence rule as agents: the
+    user's key from sly_data wins and the server's environment variable is the fallback.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    @staticmethod
+    def resolve(sly_data: dict[str, Any] | None, key_name: str, env_var: str) -> str | None:
+        """
+        Look up a provider API key, preferring the BYOK value in sly_data over the environment.
+
+        :param sly_data: The sly_data dictionary handed to the coded tool. May be None or
+                malformed; anything that is not a dict holding a dict under "llm_config" is
+                treated as "no key provided" so the environment fallback still applies.
+        :param key_name: The entry to read inside sly_data["llm_config"], using the names
+                neuro-san uses for agents: "openai_api_key", "anthropic_api_key" or
+                "google_api_key".
+        :param env_var: The environment variable to fall back to when sly_data has no usable
+                value, e.g. "OPENAI_API_KEY".
+        :return: The resolved key, or None when neither source provides one.
+        """
+        llm_config: Any = None
+        if isinstance(sly_data, dict):
+            llm_config = sly_data.get(LLM_CONFIG_KEY)
+
+        value: Any = None
+        if isinstance(llm_config, dict):
+            value = llm_config.get(key_name)
+
+        if isinstance(value, str):
+            # Keys end up in HTTP headers, which reject surrounding whitespace, so strip
+            # exactly like neuro-san does for agent keys. A blank string is "not provided".
+            stripped: str = value.strip()
+            if stripped:
+                return stripped
+        elif value is not None:
+            # A list/dict/number here is a client-side bug. Fall back rather than send
+            # something the provider will reject with a confusing error, and say why.
+            ByokApiKey.logger.warning(
+                "Ignoring non-string %s.%s in sly_data (got %s); falling back to %s",
+                LLM_CONFIG_KEY,
+                key_name,
+                type(value).__name__,
+                env_var,
+            )
+
+        return os.getenv(env_var)

--- a/tests/neuro_san_studio/coded_tools/test_anthropic_tool.py
+++ b/tests/neuro_san_studio/coded_tools/test_anthropic_tool.py
@@ -1,0 +1,134 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import os
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from anthropic import AnthropicError
+
+from neuro_san_studio.coded_tools.anthropic_tool import DEFAULT_ANTHROPIC_MODEL
+from neuro_san_studio.coded_tools.anthropic_tool import AnthropicTool
+
+# Patch the name in the module under test, not "langchain_anthropic.ChatAnthropic".
+MODULE = "neuro_san_studio.coded_tools.anthropic_tool"
+SLY_DATA: dict[str, Any] = {"llm_config": {"anthropic_api_key": "sly-key"}}
+CONTENT: list[dict[str, Any]] = [{"type": "text", "text": "hello"}]
+
+
+class TestAnthropicTool(IsolatedAsyncioTestCase):
+    """
+    Unit tests for AnthropicTool.
+
+    ChatAnthropic is replaced by a stand-in so no network is touched. The tests pin which
+    api_key reaches the constructor under each BYOK scenario and that the existing
+    tool-spec plumbing (betas, additional kwargs, tool_choice, error string) is unchanged.
+    """
+
+    @staticmethod
+    def _chat_anthropic_mock() -> MagicMock:
+        """
+        Build a stand-in for the ChatAnthropic class whose instances answer ainvoke with fixed content.
+
+        :return: A MagicMock usable as the patched ChatAnthropic class.
+        """
+        message = MagicMock(name="AIMessage")
+        message.content = CONTENT
+        llm = MagicMock(name="ChatAnthropic instance")
+        llm.ainvoke = AsyncMock(return_value=message)
+        return MagicMock(name="ChatAnthropic", return_value=llm)
+
+    async def test_sly_data_key_is_passed_to_chat_anthropic(self) -> None:
+        """
+        A BYOK key in sly_data reaches ChatAnthropic even when ANTHROPIC_API_KEY is also set.
+        """
+        chat_cls: MagicMock = self._chat_anthropic_mock()
+        with patch(f"{MODULE}.ChatAnthropic", chat_cls), patch.dict(os.environ, {"ANTHROPIC_API_KEY": "env-key"}):
+            result: Any = await AnthropicTool.arun(
+                query="q", tool_type="web_search_20250305", tool_name="web_search", sly_data=SLY_DATA
+            )
+        self.assertEqual(result, CONTENT)
+        self.assertEqual(chat_cls.call_args.kwargs["api_key"], "sly-key")
+        self.assertEqual(chat_cls.call_args.kwargs["model"], DEFAULT_ANTHROPIC_MODEL)
+
+    async def test_env_key_used_without_sly_data(self) -> None:
+        """
+        Without sly_data the ANTHROPIC_API_KEY environment variable is passed explicitly.
+        """
+        chat_cls: MagicMock = self._chat_anthropic_mock()
+        with patch(f"{MODULE}.ChatAnthropic", chat_cls), patch.dict(os.environ, {"ANTHROPIC_API_KEY": "env-key"}):
+            await AnthropicTool.arun(query="q", tool_type="web_search_20250305", tool_name="web_search")
+        self.assertEqual(chat_cls.call_args.kwargs["api_key"], "env-key")
+
+    async def test_none_key_when_no_source(self) -> None:
+        """
+        With neither source available, None is passed so ChatAnthropic behaves as it always did.
+        """
+        chat_cls: MagicMock = self._chat_anthropic_mock()
+        with patch(f"{MODULE}.ChatAnthropic", chat_cls), patch.dict(os.environ, {}, clear=True):
+            await AnthropicTool.arun(query="q", tool_type="web_search_20250305", tool_name="web_search", sly_data={})
+        self.assertIsNone(chat_cls.call_args.kwargs["api_key"])
+
+    async def test_betas_and_additional_kwargs_still_reach_invoke(self) -> None:
+        """
+        Inserting the sly_data parameter must not disturb betas, tool kwargs or tool_choice.
+        """
+        chat_cls: MagicMock = self._chat_anthropic_mock()
+        with patch(f"{MODULE}.ChatAnthropic", chat_cls), patch.dict(os.environ, {}, clear=True):
+            await AnthropicTool.arun(
+                query="q",
+                tool_type="code_execution_20250522",
+                tool_name="code_execution",
+                anthropic_model="claude-opus-4-1-20250805",
+                betas=["code-execution-2025-05-22"],
+                sly_data=SLY_DATA,
+                max_uses=3,
+            )
+        ainvoke: AsyncMock = chat_cls.return_value.ainvoke
+        self.assertEqual(ainvoke.call_args.args, ("q",))
+        self.assertEqual(ainvoke.call_args.kwargs["betas"], ["code-execution-2025-05-22"])
+        self.assertEqual(
+            ainvoke.call_args.kwargs["tools"],
+            [{"type": "code_execution_20250522", "name": "code_execution", "max_uses": 3}],
+        )
+        self.assertEqual(ainvoke.call_args.kwargs["tool_choice"], {"type": "any"})
+        self.assertEqual(chat_cls.call_args.kwargs["model"], "claude-opus-4-1-20250805")
+
+    async def test_anthropic_error_is_returned_as_string(self) -> None:
+        """
+        An AnthropicError raised while building the client is returned as the documented error string.
+        """
+        chat_cls = MagicMock(name="ChatAnthropic", side_effect=AnthropicError("invalid x-api-key"))
+        with patch(f"{MODULE}.ChatAnthropic", chat_cls), patch.dict(os.environ, {}, clear=True):
+            result: Any = await AnthropicTool.arun(query="q", tool_type="web_search_20250305", tool_name="web_search")
+        self.assertEqual(result, "Anthropic Error: invalid x-api-key")
+
+    def test_get_api_key_prefers_sly_data(self) -> None:
+        """
+        get_api_key returns the BYOK key when sly_data carries one.
+        """
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "env-key"}):
+            self.assertEqual(AnthropicTool.get_api_key(SLY_DATA), "sly-key")
+
+    def test_get_api_key_falls_back_to_env(self) -> None:
+        """
+        get_api_key returns ANTHROPIC_API_KEY when sly_data has no usable key.
+        """
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "env-key"}):
+            self.assertEqual(AnthropicTool.get_api_key({}), "env-key")
+            self.assertEqual(AnthropicTool.get_api_key(None), "env-key")

--- a/tests/neuro_san_studio/coded_tools/test_openai_tool.py
+++ b/tests/neuro_san_studio/coded_tools/test_openai_tool.py
@@ -1,0 +1,124 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import os
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from openai import OpenAIError
+
+from neuro_san_studio.coded_tools.openai_tool import DEFAULT_OPENAI_MODEL
+from neuro_san_studio.coded_tools.openai_tool import OpenAITool
+
+# Patch the name in the module under test, not "langchain_openai.ChatOpenAI".
+MODULE = "neuro_san_studio.coded_tools.openai_tool"
+SLY_DATA: dict[str, Any] = {"llm_config": {"openai_api_key": "sly-key"}}
+CONTENT_BLOCKS: list[dict[str, Any]] = [{"type": "text", "text": "hello"}]
+
+
+class TestOpenAITool(IsolatedAsyncioTestCase):
+    """
+    Unit tests for OpenAITool.
+
+    ChatOpenAI is replaced by a stand-in so no network is touched. The tests pin which
+    api_key reaches the constructor under each BYOK scenario and that the existing
+    tool-spec plumbing (additional kwargs, tool_choice, error string) is unchanged.
+    """
+
+    @staticmethod
+    def _chat_openai_mock() -> MagicMock:
+        """
+        Build a stand-in for the ChatOpenAI class whose instances answer ainvoke with fixed content.
+
+        :return: A MagicMock usable as the patched ChatOpenAI class.
+        """
+        message = MagicMock(name="AIMessage")
+        message.content_blocks = CONTENT_BLOCKS
+        llm = MagicMock(name="ChatOpenAI instance")
+        llm.ainvoke = AsyncMock(return_value=message)
+        return MagicMock(name="ChatOpenAI", return_value=llm)
+
+    async def test_sly_data_key_is_passed_to_chat_openai(self) -> None:
+        """
+        A BYOK key in sly_data reaches ChatOpenAI even when OPENAI_API_KEY is also set.
+        """
+        chat_cls: MagicMock = self._chat_openai_mock()
+        with patch(f"{MODULE}.ChatOpenAI", chat_cls), patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}):
+            result: Any = await OpenAITool.arun("q", "web_search_preview", None, sly_data=SLY_DATA)
+        self.assertEqual(result, CONTENT_BLOCKS)
+        self.assertEqual(chat_cls.call_args.kwargs["api_key"], "sly-key")
+        # A None model still resolves to the default, as before.
+        self.assertEqual(chat_cls.call_args.kwargs["model"], DEFAULT_OPENAI_MODEL)
+        self.assertEqual(chat_cls.call_args.kwargs["output_version"], "responses/v1")
+
+    async def test_env_key_used_without_sly_data(self) -> None:
+        """
+        Without sly_data the OPENAI_API_KEY environment variable is passed explicitly.
+        """
+        chat_cls: MagicMock = self._chat_openai_mock()
+        with patch(f"{MODULE}.ChatOpenAI", chat_cls), patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}):
+            await OpenAITool.arun("q", "web_search_preview")
+        self.assertEqual(chat_cls.call_args.kwargs["api_key"], "env-key")
+
+    async def test_none_key_when_no_source(self) -> None:
+        """
+        With neither source available, None is passed so ChatOpenAI behaves as it always did.
+        """
+        chat_cls: MagicMock = self._chat_openai_mock()
+        with patch(f"{MODULE}.ChatOpenAI", chat_cls), patch.dict(os.environ, {}, clear=True):
+            await OpenAITool.arun("q", "web_search_preview", sly_data={})
+        self.assertIsNone(chat_cls.call_args.kwargs["api_key"])
+
+    async def test_additional_kwargs_still_reach_tool_spec(self) -> None:
+        """
+        Inserting the sly_data parameter must not swallow the tool's own keyword arguments.
+        """
+        chat_cls: MagicMock = self._chat_openai_mock()
+        with patch(f"{MODULE}.ChatOpenAI", chat_cls), patch.dict(os.environ, {}, clear=True):
+            await OpenAITool.arun("q", "code_interpreter", "gpt-5", sly_data=SLY_DATA, container={"type": "auto"})
+        ainvoke: AsyncMock = chat_cls.return_value.ainvoke
+        self.assertEqual(ainvoke.call_args.args, ("q",))
+        self.assertEqual(
+            ainvoke.call_args.kwargs["tools"], [{"type": "code_interpreter", "container": {"type": "auto"}}]
+        )
+        self.assertEqual(ainvoke.call_args.kwargs["tool_choice"], "required")
+        self.assertEqual(chat_cls.call_args.kwargs["model"], "gpt-5")
+
+    async def test_openai_error_is_returned_as_string(self) -> None:
+        """
+        An OpenAIError raised while building the client is returned as the documented error string.
+        """
+        chat_cls = MagicMock(name="ChatOpenAI", side_effect=OpenAIError("Missing credentials"))
+        with patch(f"{MODULE}.ChatOpenAI", chat_cls), patch.dict(os.environ, {}, clear=True):
+            result: Any = await OpenAITool.arun("q", "web_search_preview")
+        self.assertEqual(result, "OpenAI Error: Missing credentials")
+
+    def test_get_api_key_prefers_sly_data(self) -> None:
+        """
+        get_api_key returns the BYOK key when sly_data carries one.
+        """
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}):
+            self.assertEqual(OpenAITool.get_api_key(SLY_DATA), "sly-key")
+
+    def test_get_api_key_falls_back_to_env(self) -> None:
+        """
+        get_api_key returns OPENAI_API_KEY when sly_data has no usable key.
+        """
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}):
+            self.assertEqual(OpenAITool.get_api_key({}), "env-key")
+            self.assertEqual(OpenAITool.get_api_key(None), "env-key")

--- a/tests/neuro_san_studio/coded_tools/utils/test_byok_api_key.py
+++ b/tests/neuro_san_studio/coded_tools/utils/test_byok_api_key.py
@@ -1,0 +1,117 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from neuro_san_studio.coded_tools.utils.byok_api_key import LLM_CONFIG_KEY
+from neuro_san_studio.coded_tools.utils.byok_api_key import ByokApiKey
+
+KEY_NAME = "openai_api_key"
+# A private env var name so a real provider key in the developer's shell can never leak
+# into these assertions.
+ENV_VAR = "TEST_BYOK_API_KEY"
+LOGGER_NAME = "neuro_san_studio.coded_tools.utils.byok_api_key"
+
+
+class TestByokApiKey(TestCase):
+    """
+    Unit tests for ByokApiKey.resolve.
+
+    Pins the precedence rule shared by every coded tool that calls an LLM provider directly:
+    a usable key in sly_data["llm_config"] wins, the environment variable is the fallback, and
+    anything malformed in sly_data degrades to the fallback instead of raising.
+    """
+
+    def test_sly_data_key_wins_over_env(self) -> None:
+        """
+        A key in sly_data is returned even when the environment variable is also set.
+        """
+        sly_data: dict = {LLM_CONFIG_KEY: {KEY_NAME: "sly-key"}}
+        with patch.dict(os.environ, {ENV_VAR: "env-key"}):
+            self.assertEqual(ByokApiKey.resolve(sly_data, KEY_NAME, ENV_VAR), "sly-key")
+
+    def test_env_used_when_llm_config_absent(self) -> None:
+        """
+        Without an llm_config entry in sly_data the environment variable is used.
+        """
+        with patch.dict(os.environ, {ENV_VAR: "env-key"}):
+            self.assertEqual(ByokApiKey.resolve({}, KEY_NAME, ENV_VAR), "env-key")
+
+    def test_env_used_when_key_absent_in_llm_config(self) -> None:
+        """
+        An llm_config that only carries another provider's key falls back to the environment.
+        """
+        sly_data: dict = {LLM_CONFIG_KEY: {"anthropic_api_key": "other-key"}}
+        with patch.dict(os.environ, {ENV_VAR: "env-key"}):
+            self.assertEqual(ByokApiKey.resolve(sly_data, KEY_NAME, ENV_VAR), "env-key")
+
+    def test_none_sly_data_uses_env(self) -> None:
+        """
+        A None sly_data (tool invoked outside a network) falls back to the environment.
+        """
+        with patch.dict(os.environ, {ENV_VAR: "env-key"}):
+            self.assertEqual(ByokApiKey.resolve(None, KEY_NAME, ENV_VAR), "env-key")
+
+    def test_non_dict_sly_data_uses_env(self) -> None:
+        """
+        A sly_data that is not a dict is treated as "no key provided".
+        """
+        with patch.dict(os.environ, {ENV_VAR: "env-key"}):
+            self.assertEqual(ByokApiKey.resolve("not a dict", KEY_NAME, ENV_VAR), "env-key")
+
+    def test_non_dict_llm_config_uses_env(self) -> None:
+        """
+        An llm_config that is a bare string instead of a dict is treated as "no key provided".
+        """
+        sly_data: dict = {LLM_CONFIG_KEY: "sk-raw-string"}
+        with patch.dict(os.environ, {ENV_VAR: "env-key"}):
+            self.assertEqual(ByokApiKey.resolve(sly_data, KEY_NAME, ENV_VAR), "env-key")
+
+    def test_whitespace_is_stripped(self) -> None:
+        """
+        Surrounding whitespace is removed so the key is safe to put in an HTTP header.
+        """
+        sly_data: dict = {LLM_CONFIG_KEY: {KEY_NAME: "  sly-key\n"}}
+        with patch.dict(os.environ, {ENV_VAR: "env-key"}):
+            self.assertEqual(ByokApiKey.resolve(sly_data, KEY_NAME, ENV_VAR), "sly-key")
+
+    def test_blank_string_uses_env(self) -> None:
+        """
+        A whitespace-only key counts as "not provided" and falls back to the environment.
+        """
+        sly_data: dict = {LLM_CONFIG_KEY: {KEY_NAME: "   "}}
+        with patch.dict(os.environ, {ENV_VAR: "env-key"}):
+            self.assertEqual(ByokApiKey.resolve(sly_data, KEY_NAME, ENV_VAR), "env-key")
+
+    def test_non_string_value_is_ignored_with_warning(self) -> None:
+        """
+        A non-string key (a client bug) is ignored with a warning and the environment is used.
+        """
+        sly_data: dict = {LLM_CONFIG_KEY: {KEY_NAME: ["not", "a", "string"]}}
+        with patch.dict(os.environ, {ENV_VAR: "env-key"}), self.assertLogs(LOGGER_NAME, level="WARNING") as logs:
+            result: str | None = ByokApiKey.resolve(sly_data, KEY_NAME, ENV_VAR)
+        self.assertEqual(result, "env-key")
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("Ignoring non-string llm_config.openai_api_key", logs.output[0])
+        self.assertIn("list", logs.output[0])
+
+    def test_returns_none_when_no_source(self) -> None:
+        """
+        With neither a sly_data key nor the environment variable set, None is returned.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(ByokApiKey.resolve({}, KEY_NAME, ENV_VAR))


### PR DESCRIPTION
## Description

Part 1 of 2 for #1399 (tools that call LLMs directly bypass BYOK keys). Part 2 is #1408, stacked on this branch.

Coded tools that instantiate their own LLM/provider clients authenticate from environment variables only (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`) and never consult the Bring-Your-Own-Key values a client sends in `sly_data["llm_config"]`. This PR adds the shared resolution logic and applies it to the two provider classes the OpenAI and Anthropic toolbox tools are built on. It is deliberately behavior-neutral on its own: the new `sly_data` parameter defaults to `None`, so until part 2 forwards it, every existing caller still falls back to the same environment variable as today.

Part of #1399 (closed by part 2).

### What changed

- **New shared resolver** `ByokApiKey.resolve(sly_data, key_name, env_var)` (`neuro_san_studio/coded_tools/utils/byok_api_key.py`): reads `sly_data["llm_config"][key_name]`, strips whitespace, falls back to the env var. Malformed `sly_data` (not a dict, `llm_config` not a dict, non-string value) degrades to the env fallback; a non-string value logs a warning that does not include the value. Mirrors neuro-san 0.7.0's `replace_any_required_api_keys` + `get_value_or_env`.
- **`OpenAITool` / `AnthropicTool`**: new `get_api_key(sly_data)` static method, the one place each provider's key name / env var pairing lives; `arun` gains `sly_data=None`, placed before `**additional_kwargs` so existing positional callers are unaffected, and passes `api_key=` to `ChatOpenAI` / `ChatAnthropic`.
- **Tests**: `test_byok_api_key.py` (precedence, stripping, blank and non-string values, malformed `sly_data`, no source), `test_openai_tool.py` and `test_anthropic_tool.py` (which key reaches the constructor in each scenario; tool kwargs, `betas`, `tool_choice` and the error-string path unchanged).
- **Default models**: `DEFAULT_OPENAI_MODEL` moves from `gpt-4o-2024-08-06` to `gpt-5.2`, and `DEFAULT_ANTHROPIC_MODEL` from the retired `claude-3-7-sonnet-20250219` to `claude-sonnet-5`. Networks that pass `openai_model` / `anthropic_model` in their tool args are unaffected.

### Behavior notes

- Precedence is `sly_data` first, environment second. Agents only consult `sly_data` when their `llm_config` literally says `"sly_data"`, but tools have no `llm_config`, so this is the rule the issue asks for.
- Passing `api_key=None` (neither source has a key) is equivalent to today's behavior, verified against the pinned versions: `ChatOpenAI` raises the same missing-credentials `OpenAIError` (still caught and returned as the error string); `ChatAnthropic` constructs and reads the environment itself.
- A blank string in `sly_data.llm_config` is treated as "not provided" and falls back to the env var (neuro-san's agent path would forward `""` and let the provider reject it). Deliberate, pinned by a test.

## Impact

- The BYOK plumbing has no runtime effect until part 2: `sly_data` is optional and no caller passes it yet.
- The default-model change does take effect here: tool calls that omit `openai_model` / `anthropic_model` now run on `gpt-5.2` / `claude-sonnet-5` instead of `gpt-4o-2024-08-06` / the retired `claude-3-7-sonnet-20250219`.
- API surface: `OpenAITool.arun` / `AnthropicTool.arun` gain an optional parameter; `get_api_key` is new. No dependencies added.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [ ] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [ ] Updated relevant documentation (docs land in part 2, where the behavior becomes user-visible)
- [ ] Added dependencies to appropriate `requirements.txt` (no new dependencies)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**