### PR TITLE
#1399 part 2: Wire coded tools to the BYOK key resolver

### DIFF
--- a/coded_tools/tools/video_describer.py
+++ b/coded_tools/tools/video_describer.py
@@ -24,6 +24,8 @@ from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
 from neuro_san.interfaces.coded_tool import CodedTool
 
+from neuro_san_studio.coded_tools.openai_tool import OpenAITool
+
 INSTRUCTIONS = "Describe the content of the video in detail."
 
 
@@ -50,6 +52,10 @@ class VideoDescriber(CodedTool):
         :param sly_data: A dictionary whose keys are defined by the agent hierarchy,
                 but whose values are meant to be kept out of the chat stream.
 
+                Keys expected for this implementation are:
+                    - "llm_config" (dict, optional): BYOK keys sent by the client. When it holds
+                        "openai_api_key", that key is used instead of the OPENAI_API_KEY env var.
+
         :return: Text string describing the video.
         """
 
@@ -74,7 +80,9 @@ class VideoDescriber(CodedTool):
         video.release()
         self.logger.info("%d frames read from %s.", len(base64_frames), file_path)
 
-        llm = ChatOpenAI(model=openai_model)
+        # A BYOK key from sly_data must win over the server's OPENAI_API_KEY, so resolve it
+        # here instead of letting ChatOpenAI read the environment on its own.
+        llm = ChatOpenAI(model=openai_model, api_key=OpenAITool.get_api_key(sly_data))
         content = [
             {
                 "type": "text",

--- a/docs/examples/tools/anthropic_code_execution.md
+++ b/docs/examples/tools/anthropic_code_execution.md
@@ -31,6 +31,12 @@ This is already included with neuro-san-studio, so no need to install anything n
 export ANTHROPIC_API_KEY="your_anthropic_api_key_here"
 ```
 
+On a Bring-Your-Own-Key (BYOK) deployment the client can send the key in the request's `sly_data` instead,
+under `llm_config.anthropic_api_key`. A key provided that way takes precedence over the environment variable,
+so the tool call is billed to the user's key just like the agents' own LLM calls. Without such a key the tool
+falls back to the environment variable, so leave that variable unset on a BYOK-only server.
+See [config/byok_llm_config.hocon](../../../config/byok_llm_config.hocon) for the `sly_data` convention.
+
 ### System Requirements
 
   - Appplications for opening generated files (charts, reports, etc.)

--- a/docs/examples/tools/anthropic_code_execution.md
+++ b/docs/examples/tools/anthropic_code_execution.md
@@ -104,7 +104,7 @@ which leverages Anthropic's built-in code execution capabilities.
 
 - `query`: The user's natural language request for code execution
 
-- `anthropic_model`: Model used for code generation ("claude-3-7-sonnet-20250219" as default)
+- `anthropic_model`: Model used for code generation ("claude-sonnet-5" as default)
 
 - `save_file`: Boolean flag to automatically save generated files (Default to `false`)
 

--- a/docs/examples/tools/anthropic_web_search.md
+++ b/docs/examples/tools/anthropic_web_search.md
@@ -90,7 +90,7 @@ which leverages Anthropic's built-in web search capabilities.
 
 - `query`: The search query derived from user inquiry that `searcher` passes to the tool
 
-- `anthropic_model`: Model used for search processing ("claude-3-7-sonnet-20250219" as default)
+- `anthropic_model`: Model used for search processing ("claude-sonnet-5" as default)
 
 - `additional_kwargs`: Optional parameters for fine-tuning search behavior
 

--- a/docs/examples/tools/anthropic_web_search.md
+++ b/docs/examples/tools/anthropic_web_search.md
@@ -31,6 +31,12 @@ This is already included with neuro-san-studio, so no need to install anything n
 export ANTHROPIC_API_KEY="your_anthropic_api_key_here"
 ```
 
+On a Bring-Your-Own-Key (BYOK) deployment the client can send the key in the request's `sly_data` instead,
+under `llm_config.anthropic_api_key`. A key provided that way takes precedence over the environment variable,
+so the tool call is billed to the user's key just like the agents' own LLM calls. Without such a key the tool
+falls back to the environment variable, so leave that variable unset on a BYOK-only server.
+See [config/byok_llm_config.hocon](../../../config/byok_llm_config.hocon) for the `sly_data` convention.
+
 For more information on setting up Anthropic tools, see:
 
 - [Anthropic Tool Use Overview](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview)

--- a/docs/examples/tools/gemini_image_generation.md
+++ b/docs/examples/tools/gemini_image_generation.md
@@ -44,6 +44,12 @@ export GOOGLE_API_KEY="your_google_api_key_here"
 export GEMINI_API_KEY="your_gemini_api_key_here"
 ```
 
+On a Bring-Your-Own-Key (BYOK) deployment the client can send the key in the request's `sly_data` instead,
+under `llm_config.google_api_key`. A key provided that way takes precedence over the environment variable,
+so the tool call is billed to the user's key just like the agents' own LLM calls. Without such a key the tool
+falls back to the environment variable, so leave that variable unset on a BYOK-only server.
+See [config/byok_llm_config.hocon](../../../config/byok_llm_config.hocon) for the `sly_data` convention.
+
 For more information on setting up Gemini, see:
 
 - [Gemini API Documentation](https://ai.google.dev/gemini-api/docs)

--- a/docs/examples/tools/openai_code_interpreter.md
+++ b/docs/examples/tools/openai_code_interpreter.md
@@ -31,6 +31,12 @@ This is already included with neuro-san-studio, so no need to install anything n
 export OPENAI_API_KEY="your_openai_api_key_here"
 ```
 
+On a Bring-Your-Own-Key (BYOK) deployment the client can send the key in the request's `sly_data` instead,
+under `llm_config.openai_api_key`. A key provided that way takes precedence over the environment variable,
+so the tool call is billed to the user's key just like the agents' own LLM calls. Without such a key the tool
+falls back to the environment variable, so leave that variable unset on a BYOK-only server.
+See [config/byok_llm_config.hocon](../../../config/byok_llm_config.hocon) for the `sly_data` convention.
+
 For more information on setting up OpenAI tools, see:
 
 - [OpenAI Tools Guide](https://developers.openai.com/api/docs/guides/tools)

--- a/docs/examples/tools/openai_code_interpreter.md
+++ b/docs/examples/tools/openai_code_interpreter.md
@@ -112,7 +112,7 @@ which leverages Anthropic's built-in code execution capabilities.
 
 - `query`: The user's natural language request for code execution
 
-- `openai_model`: Model used for code generation ("gpt-4o-2024-08-06" as default)
+- `openai_model`: Model used for code generation ("gpt-5.2" as default)
 
 - `container`: Execution container configuration (automatically created if not specified)
 

--- a/docs/examples/tools/openai_image_generation.md
+++ b/docs/examples/tools/openai_image_generation.md
@@ -31,6 +31,12 @@ This is already included with neuro-san-studio, so no need to install anything n
 export OPENAI_API_KEY="your_openai_api_key_here"
 ```
 
+On a Bring-Your-Own-Key (BYOK) deployment the client can send the key in the request's `sly_data` instead,
+under `llm_config.openai_api_key`. A key provided that way takes precedence over the environment variable,
+so the tool call is billed to the user's key just like the agents' own LLM calls. Without such a key the tool
+falls back to the environment variable, so leave that variable unset on a BYOK-only server.
+See [config/byok_llm_config.hocon](../../../config/byok_llm_config.hocon) for the `sly_data` convention.
+
 For more information on setting up OpenAI tools, see:
 
 - [OpenAI Tools Guide](https://developers.openai.com/api/docs/guides/tools)

--- a/docs/examples/tools/openai_video_generation.md
+++ b/docs/examples/tools/openai_video_generation.md
@@ -46,6 +46,12 @@ pip install opencv-python aiohttp
 export OPENAI_API_KEY="your_openai_api_key_here"
 ```
 
+On a Bring-Your-Own-Key (BYOK) deployment the client can send the key in the request's `sly_data` instead,
+under `llm_config.openai_api_key`. A key provided that way takes precedence over the environment variable,
+so the tool call is billed to the user's key just like the agents' own LLM calls. Without such a key the tool
+falls back to the environment variable, so leave that variable unset on a BYOK-only server.
+See [config/byok_llm_config.hocon](../../../config/byok_llm_config.hocon) for the `sly_data` convention.
+
 For more information on setting up OpenAI tools, see:
 
 - [OpenAI Video Generation Guide](https://developers.openai.com/api/docs/guides/video-generation)

--- a/docs/examples/tools/openai_web_search.md
+++ b/docs/examples/tools/openai_web_search.md
@@ -31,6 +31,12 @@ This is already included with neuro-san-studio, so no need to install anything n
 export OPENAI_API_KEY="your_openai_api_key_here"
 ```
 
+On a Bring-Your-Own-Key (BYOK) deployment the client can send the key in the request's `sly_data` instead,
+under `llm_config.openai_api_key`. A key provided that way takes precedence over the environment variable,
+so the tool call is billed to the user's key just like the agents' own LLM calls. Without such a key the tool
+falls back to the environment variable, so leave that variable unset on a BYOK-only server.
+See [config/byok_llm_config.hocon](../../../config/byok_llm_config.hocon) for the `sly_data` convention.
+
 For more information on setting up OpenAI tools, see:
 
 - [OpenAI Tools Guide](https://developers.openai.com/api/docs/guides/tools)

--- a/docs/examples/tools/openai_web_search.md
+++ b/docs/examples/tools/openai_web_search.md
@@ -92,7 +92,7 @@ which leverages OpenAI's built-in web search capabilities.
 
 - `query`: The search query derived from user inquiry
 
-- `openai_model`: Model used for search processing ("gpt-4o-2024-08-06" as default)
+- `openai_model`: Model used for search processing ("gpt-5.2" as default)
 
 - `additional_kwargs`: Optional parameters for fine-tuning search behavior
 

--- a/docs/search_tools.md
+++ b/docs/search_tools.md
@@ -28,6 +28,11 @@ Get an API key by visiting [https://console.anthropic.com/settings/keys](https:/
 Once you have the API key, set it using the `ANTHROPIC_API_KEY` environment variable. The required
 langchain-anthropic package is already included with neuro-san-studio.
 
+On a Bring-Your-Own-Key (BYOK) deployment the client can instead send the key per request in `sly_data` under
+`llm_config.anthropic_api_key`. That key takes precedence over the environment variable; without it the tool
+falls back to `ANTHROPIC_API_KEY`. See [config/byok_llm_config.hocon](../config/byok_llm_config.hocon) for the
+`sly_data` convention.
+
 _Example Usage in Neuro San Studio_:
 
 - [anthropic\_web_search.hocon](../neuro_san_studio/coded_tools/anthropic_web_search.py),
@@ -154,6 +159,11 @@ To use this search tool, obtain an API key from:
 [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys). Once you have the API key, set it using
 the `OPENAI_API_KEY` environment variable. The required
 langchain-openai package is already included with neuro-san-studio.
+
+On a Bring-Your-Own-Key (BYOK) deployment the client can instead send the key per request in `sly_data` under
+`llm_config.openai_api_key`. That key takes precedence over the environment variable; without it the tool
+falls back to `OPENAI_API_KEY`. See [config/byok_llm_config.hocon](../config/byok_llm_config.hocon) for the
+`sly_data` convention.
 
 _Example Usage in Neuro San Studio:_
 

--- a/neuro_san_studio/coded_tools/anthropic_code_execution.py
+++ b/neuro_san_studio/coded_tools/anthropic_code_execution.py
@@ -48,7 +48,7 @@ class AnthropicCodeExecution(CodedTool):
                 - from calling agent
                     - "query" (str): Request from the user prompt.
                 - from user
-                    - "anthropic_model" (str): Anthropic model to call the tool. Default to claude-3-7-sonnet-20250219.
+                    - "anthropic_model" (str): Anthropic model to call the tool. Default to claude-sonnet-5.
                     - "save_file" (bool): Whether or not to save generated files.
                     - "additional_kwargs" (dict): Any additional arguments for the tool.
 

--- a/neuro_san_studio/coded_tools/anthropic_code_execution.py
+++ b/neuro_san_studio/coded_tools/anthropic_code_execution.py
@@ -63,7 +63,8 @@ class AnthropicCodeExecution(CodedTool):
                 adding the data is not invoke()-ed more than once.
 
                 Keys expected for this implementation are:
-                    None
+                    - "llm_config" (dict, optional): BYOK keys sent by the client. When it holds
+                        "anthropic_api_key", that key is used instead of the ANTHROPIC_API_KEY env var.
 
         :return:
             In case of successful execution:
@@ -95,13 +96,17 @@ class AnthropicCodeExecution(CodedTool):
             tool_name="code_execution",
             anthropic_model=anthropic_model,
             betas=[CODE_EXECUTION_BETA],
+            # Forward sly_data so a BYOK Anthropic key sent by the client is used for this call.
+            sly_data=sly_data,
             **additional_kwargs,
         )
 
         # If there are generated files and user wants to save them
         file_ids: list[str] = self.extract_file_ids(content)
         if file_ids and save_file:
-            self.save_file(file_ids)
+            # The download uses the raw Anthropic client, so it needs the same key resolution
+            # as the tool call above or it would silently fall back to the server's env var.
+            self.save_file(file_ids, AnthropicTool.get_api_key(sly_data))
 
         return content
 
@@ -123,14 +128,17 @@ class AnthropicCodeExecution(CodedTool):
                         file_ids.append(file.get("file_id"))
         return file_ids
 
-    def save_file(self, file_ids: list[str]):
+    def save_file(self, file_ids: list[str], api_key: str | None) -> None:
         """
         Save the file on disk.
 
         :param file_ids: ID of the files to save.
+        :param api_key: The Anthropic API key to download with, resolved the same way as the
+                tool call (BYOK sly_data key first, ANTHROPIC_API_KEY second). None when neither
+                source provided one; the SDK then fails the request as it always did.
         """
         # Initialize the client
-        client = Anthropic()
+        client = Anthropic(api_key=api_key)
 
         for file_id in file_ids:
             # Get the file name e.g. output.png

--- a/neuro_san_studio/coded_tools/anthropic_web_search.py
+++ b/neuro_san_studio/coded_tools/anthropic_web_search.py
@@ -40,7 +40,7 @@ class AnthropicWebSearch(CodedTool):
                 - from calling agent
                     - "query" (str): Request from the user prompt.
                 - from user
-                    - "anthropic_model" (str): Anthropic model to call the tool. Default to claude-3-7-sonnet-20250219.
+                    - "anthropic_model" (str): Anthropic model to call the tool. Default to claude-sonnet-5.
                     - "additional_kwargs" (dict): Any additional arguments for the tool.
 
         :param sly_data: A dictionary whose keys are defined by the agent hierarchy,

--- a/neuro_san_studio/coded_tools/anthropic_web_search.py
+++ b/neuro_san_studio/coded_tools/anthropic_web_search.py
@@ -54,7 +54,8 @@ class AnthropicWebSearch(CodedTool):
                 adding the data is not invoke()-ed more than once.
 
                 Keys expected for this implementation are:
-                    None
+                    - "llm_config" (dict, optional): BYOK keys sent by the client. When it holds
+                        "anthropic_api_key", that key is used instead of the ANTHROPIC_API_KEY env var.
 
         :return:
             In case of successful execution:
@@ -84,5 +85,7 @@ class AnthropicWebSearch(CodedTool):
             tool_name="web_search",
             anthropic_model=anthropic_model,
             betas=None,
+            # Forward sly_data so a BYOK Anthropic key sent by the client is used for this call.
+            sly_data=sly_data,
             **additional_kwargs,
         )

--- a/neuro_san_studio/coded_tools/gemini_image_generation.py
+++ b/neuro_san_studio/coded_tools/gemini_image_generation.py
@@ -15,7 +15,6 @@
 # END COPYRIGHT
 
 import logging
-import os
 import webbrowser
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -27,6 +26,14 @@ from google.genai.types import GenerateContentConfig
 from google.genai.types import GenerateContentResponse
 from google.genai.types import ImageConfig
 from neuro_san.interfaces.coded_tool import CodedTool
+
+from neuro_san_studio.coded_tools.utils.byok_api_key import ByokApiKey
+
+# Where a Bring-Your-Own-Key (BYOK) client puts its Google key inside sly_data["llm_config"],
+# and the server-side environment variable used when the client did not send one. google.genai
+# also honors GEMINI_API_KEY on its own when handed None, so that alias keeps working last.
+GOOGLE_API_KEY_NAME = "google_api_key"
+GOOGLE_API_KEY_ENV = "GOOGLE_API_KEY"
 
 
 class GeminiImageGeneration(CodedTool):
@@ -71,7 +78,8 @@ class GeminiImageGeneration(CodedTool):
                 adding the data is not invoke()-ed more than once.
 
                 Keys expected for this implementation are:
-                    None
+                    - "llm_config" (dict, optional): BYOK keys sent by the client. When it holds
+                        "google_api_key", that key is used instead of the GOOGLE_API_KEY env var.
 
         :return:
             In case of successful execution:
@@ -84,8 +92,11 @@ class GeminiImageGeneration(CodedTool):
         # Extract arguments
         (query, gemini_model, open_in_browser, save_image_file, image_config, tools) = self.extract_arguments(args)
 
+        # A BYOK key from sly_data must win over the server's GOOGLE_API_KEY.
+        api_key: str | None = ByokApiKey.resolve(sly_data, GOOGLE_API_KEY_NAME, GOOGLE_API_KEY_ENV)
+
         # Call Gemini model for image generation
-        response: GenerateContentResponse = await self.get_response(query, gemini_model, image_config, tools)
+        response: GenerateContentResponse = await self.get_response(query, gemini_model, image_config, tools, api_key)
 
         # Extract text and image blocks
         text: str = ""
@@ -146,20 +157,29 @@ class GeminiImageGeneration(CodedTool):
 
         return query, gemini_model, open_in_browser, save_image_file, image_config, tools
 
-    async def get_response(
-        self, query: str, gemini_model: str, image_config: dict[str, Any], tools: list[dict[str, Any]]
+    async def get_response(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        query: str,
+        gemini_model: str,
+        image_config: dict[str, Any],
+        tools: list[dict[str, Any]],
+        api_key: str | None,
     ) -> GenerateContentResponse:
         """
         Asynchronous version of the Gemini image generation call.
+
         :param query: The prompt for image generation.
         :param gemini_model: The Gemini model to use when calling the tool.
         :param image_config: Configurations for image generation.
         :param tools: Configurations for tools.
+        :param api_key: The Google API key to authenticate with, resolved from sly_data first and
+                GOOGLE_API_KEY second. None lets google.genai run its own environment lookup,
+                which also covers the GEMINI_API_KEY alias.
         :return: GenerateContentResponse from Gemini API.
         """
 
-        # Initialize Gemini client
-        client = Client(api_key=os.environ.get("GOOGLE_API_KEY"))
+        # Initialize Gemini client with the resolved key rather than reading the environment here.
+        client = Client(api_key=api_key)
         # Call Gemini model for image generation
         response: GenerateContentResponse = await client.aio.models.generate_content(
             model=gemini_model,

--- a/neuro_san_studio/coded_tools/openai_code_interpreter.py
+++ b/neuro_san_studio/coded_tools/openai_code_interpreter.py
@@ -38,7 +38,7 @@ class OpenAICodeInterpreter(CodedTool):
                 - from calling agent
                     - "query" (str): Request from the user prompt.
                 - from user
-                    - "openai_model" (str): OpenAI model to call the tool. Default to gpt-4o-2024-08-06.
+                    - "openai_model" (str): OpenAI model to call the tool. Default to gpt-5.2.
                     - "additional_kwargs" (dict): Any additional arguments for the tool.
 
         :param sly_data: A dictionary whose keys are defined by the agent hierarchy,

--- a/neuro_san_studio/coded_tools/openai_code_interpreter.py
+++ b/neuro_san_studio/coded_tools/openai_code_interpreter.py
@@ -52,7 +52,8 @@ class OpenAICodeInterpreter(CodedTool):
                 adding the data is not invoke()-ed more than once.
 
                 Keys expected for this implementation are:
-                    None
+                    - "llm_config" (dict, optional): BYOK keys sent by the client. When it holds
+                        "openai_api_key", that key is used instead of the OPENAI_API_KEY env var.
 
         :return:
             In case of successful execution:
@@ -81,4 +82,7 @@ class OpenAICodeInterpreter(CodedTool):
             # This is to create a new container if an existing container ID is not specified.
             copy_additional_kwargs["container"] = {"type": "auto"}
 
-        return await OpenAITool.arun(query, "code_interpreter", openai_model, **copy_additional_kwargs)
+        # Forward sly_data so a BYOK OpenAI key sent by the client is used for this call.
+        return await OpenAITool.arun(
+            query, "code_interpreter", openai_model, sly_data=sly_data, **copy_additional_kwargs
+        )

--- a/neuro_san_studio/coded_tools/openai_image_generation.py
+++ b/neuro_san_studio/coded_tools/openai_image_generation.py
@@ -62,7 +62,8 @@ class OpenAIImageGeneration(CodedTool):
                 adding the data is not invoke()-ed more than once.
 
                 Keys expected for this implementation are:
-                    None
+                    - "llm_config" (dict, optional): BYOK keys sent by the client. When it holds
+                        "openai_api_key", that key is used instead of the OPENAI_API_KEY env var.
 
         :return:
             In case of successful execution:
@@ -88,8 +89,9 @@ class OpenAIImageGeneration(CodedTool):
         save_image_file: bool = args.get("save_image_file", False)
 
         # This should be a list of content blocks if success and a string of error text otherwise.
+        # Forward sly_data so a BYOK OpenAI key sent by the client is used for this call.
         content_blocks: list[dict[str, Any]] | str = await OpenAITool.arun(
-            query, "image_generation", openai_model, **additional_kwargs
+            query, "image_generation", openai_model, sly_data=sly_data, **additional_kwargs
         )
 
         if isinstance(content_blocks, str):

--- a/neuro_san_studio/coded_tools/openai_image_generation.py
+++ b/neuro_san_studio/coded_tools/openai_image_generation.py
@@ -48,7 +48,7 @@ class OpenAIImageGeneration(CodedTool):
                         Note that the model may revise the prompt for the user.
                         The revised prompt can be seen it the log.
                 - from user
-                    - "openai_model" (str): OpenAI model to call the tool. Default to gpt-4o-2024-08-06.
+                    - "openai_model" (str): OpenAI model to call the tool. Default to gpt-5.2.
                     - "additional_kwargs" (dict): Any additional arguments for the tool.
 
         :param sly_data: A dictionary whose keys are defined by the agent hierarchy,

--- a/neuro_san_studio/coded_tools/openai_video_generation.py
+++ b/neuro_san_studio/coded_tools/openai_video_generation.py
@@ -16,7 +16,6 @@
 
 import asyncio
 import logging
-import os
 import webbrowser
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -25,9 +24,9 @@ from typing import Any
 import aiohttp
 from neuro_san.interfaces.coded_tool import CodedTool
 
+from neuro_san_studio.coded_tools.openai_tool import OpenAITool
+
 URL_ENDPOINT = "https://api.openai.com/v1/videos"
-API_KEY = os.getenv("OPENAI_API_KEY")
-HEADERS = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
 POLL_INTERVAL = 5  # seconds between status checks
 TIMEOUT = 600  # maximum wait time in seconds
 
@@ -58,6 +57,10 @@ class OpenAIVideoGeneration(CodedTool):
         :param sly_data: A dictionary whose keys are defined by the agent hierarchy,
                 but whose values are meant to be kept out of the chat stream.
 
+                Keys expected for this implementation are:
+                    - "llm_config" (dict, optional): BYOK keys sent by the client. When it holds
+                        "openai_api_key", that key is used instead of the OPENAI_API_KEY env var.
+
         :return:
             In case of successful execution:
                 Text string indicating video generation is completed.
@@ -81,15 +84,20 @@ class OpenAIVideoGeneration(CodedTool):
         save_video_file: bool = args.get("save_video_file", False)
         open_in_browser: bool = args.get("open_in_browser", False)
 
+        # Build the auth headers per call so a BYOK key in sly_data is honored. Reading
+        # OPENAI_API_KEY into module constants at import time (the previous behavior) froze
+        # the server's key and could never see a per-request key.
+        headers: dict[str, str] = self.build_headers(OpenAITool.get_api_key(sly_data))
+
         async with aiohttp.ClientSession() as session:
             if video_id:
                 # Remix existing video
                 self.logger.info("Starting video remix for ID: %s", video_id)
-                video_id = await self._remix_video(session, video_id, query)
+                video_id = await self._remix_video(session, headers, video_id, query)
             else:
                 self.logger.info("Starting new video generation.")
                 # Start video generation job
-                video_id = await self._create_video(session, query, openai_model, size, seconds)
+                video_id = await self._create_video(session, headers, query, openai_model, size, seconds)
 
             if not video_id:
                 # pylint: disable=broad-exception-raised
@@ -97,14 +105,14 @@ class OpenAIVideoGeneration(CodedTool):
             self.logger.info("Video generation started with ID: %s", video_id)
 
             # Poll for completion
-            status_data = await self._poll_status(session, video_id)
+            status_data = await self._poll_status(session, headers, video_id)
 
             if status_data.get("status") != "completed":
                 error_msg = status_data.get("error", "Unknown error")
                 return f"Error: Video generation failed - {error_msg}"
 
             # Download and display video
-            video_path = await self._display_video(session, video_id, save_video_file, open_in_browser)
+            video_path = await self._display_video(session, headers, video_id, save_video_file, open_in_browser)
 
             if video_path:
                 return f"Video generation completed with id {video_id}. Saved to: {video_path}"
@@ -112,20 +120,44 @@ class OpenAIVideoGeneration(CodedTool):
             # pylint: disable=broad-exception-raised
             raise Exception("Failed to download generated video.")
 
+    @staticmethod
+    def build_headers(api_key: str | None) -> dict[str, str]:
+        """
+        Build the HTTP headers for the OpenAI videos endpoint.
+
+        :param api_key: The OpenAI API key to send as a bearer token, already resolved from
+                sly_data or the environment. None produces an unusable token and the API
+                rejects the request, exactly as it did before when OPENAI_API_KEY was unset.
+        :return: Headers carrying the bearer token and the JSON content type.
+        """
+        return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
     # pylint: disable=too-many-arguments
     # pylint: disable=too-many-positional-arguments
     async def _create_video(
-        self, session: aiohttp.ClientSession, query: str, model: str, size: str, seconds: str
+        self,
+        session: aiohttp.ClientSession,
+        headers: dict[str, str],
+        query: str,
+        model: str,
+        size: str,
+        seconds: str,
     ) -> str | None:
         """
         Create a video generation job.
 
+        :param session: aiohttp session
+        :param headers: Request headers carrying the resolved bearer token
+        :param query: The prompt for video generation
+        :param model: The OpenAI video model, e.g. "sora-2"
+        :param size: Video resolution, e.g. "720x1280"
+        :param seconds: Video duration in seconds
         :return: Video ID if successful, None otherwise
         """
         payload = {"prompt": query, "model": model, "size": size, "seconds": str(seconds)}
 
         try:
-            async with session.post(URL_ENDPOINT, headers=HEADERS, json=payload) as response:
+            async with session.post(URL_ENDPOINT, headers=headers, json=payload) as response:
                 response.raise_for_status()
                 data = await response.json()
                 self.logger.info("Video creation response: %s", data)
@@ -139,12 +171,17 @@ class OpenAIVideoGeneration(CodedTool):
     async def _remix_video(
         self,
         session: aiohttp.ClientSession,
+        headers: dict[str, str],
         video_id: str,
         query: str,
     ) -> str | None:
         """
         Create a video remix job.
 
+        :param session: aiohttp session
+        :param headers: Request headers carrying the resolved bearer token
+        :param video_id: The ID of the existing video to remix
+        :param query: The prompt describing the remix
         :return: Video ID if successful, None otherwise
         """
         payload = {
@@ -152,7 +189,7 @@ class OpenAIVideoGeneration(CodedTool):
         }
 
         try:
-            async with session.post(f"{URL_ENDPOINT}/{video_id}/remix", headers=HEADERS, json=payload) as response:
+            async with session.post(f"{URL_ENDPOINT}/{video_id}/remix", headers=headers, json=payload) as response:
                 response.raise_for_status()
                 data = await response.json()
                 self.logger.info("Video remix response: %s", data)
@@ -163,19 +200,29 @@ class OpenAIVideoGeneration(CodedTool):
             self.logger.error("Exception details: %s", data)
             return None
 
-    async def _get_status(self, session: aiohttp.ClientSession, video_id: str) -> dict[str, Any]:
+    async def _get_status(
+        self, session: aiohttp.ClientSession, headers: dict[str, str], video_id: str
+    ) -> dict[str, Any]:
         """
         Get the current status of a video generation job.
+
+        :param session: aiohttp session
+        :param headers: Request headers carrying the resolved bearer token
+        :param video_id: The ID of the video to check
+        :return: The status payload returned by the API
         """
-        async with session.get(f"{URL_ENDPOINT}/{video_id}", headers=HEADERS) as response:
+        async with session.get(f"{URL_ENDPOINT}/{video_id}", headers=headers) as response:
             response.raise_for_status()
             return await response.json()
 
-    async def _poll_status(self, session: aiohttp.ClientSession, video_id: str) -> dict[str, Any]:
+    async def _poll_status(
+        self, session: aiohttp.ClientSession, headers: dict[str, str], video_id: str
+    ) -> dict[str, Any]:
         """
         Poll the status of video generation until it is complete or times out.
 
         :param session: aiohttp session
+        :param headers: Request headers carrying the resolved bearer token
         :param video_id: The ID of the video to poll
         :return: The final status response
         """
@@ -186,7 +233,7 @@ class OpenAIVideoGeneration(CodedTool):
             if elapsed > TIMEOUT:
                 raise asyncio.TimeoutError(f"Video generation exceeded timeout of {TIMEOUT}s")
 
-            status_data = await self._get_status(session, video_id)
+            status_data = await self._get_status(session, headers, video_id)
             status = status_data.get("status")
             progress = status_data.get("progress")
 
@@ -204,6 +251,7 @@ class OpenAIVideoGeneration(CodedTool):
     async def _display_video(
         self,
         session: aiohttp.ClientSession,
+        headers: dict[str, str],
         video_id: str,
         save_video_file: bool = False,
         open_in_browser: bool = True,
@@ -212,13 +260,14 @@ class OpenAIVideoGeneration(CodedTool):
         Download video from OpenAI, save it, and optionally open in browser.
 
         :param session: aiohttp session
+        :param headers: Request headers carrying the resolved bearer token
         :param video_id: The ID of the video to download
         :param save_video_file: Whether to save as permanent file
         :param open_in_browser: Whether to open video in browser
         :return: Path to saved video file, or None on error
         """
         try:
-            async with session.get(f"{URL_ENDPOINT}/{video_id}/content", headers=HEADERS) as response:
+            async with session.get(f"{URL_ENDPOINT}/{video_id}/content", headers=headers) as response:
                 response.raise_for_status()
                 video_data = await response.read()
 

--- a/neuro_san_studio/coded_tools/openai_web_search.py
+++ b/neuro_san_studio/coded_tools/openai_web_search.py
@@ -52,7 +52,8 @@ class OpenAIWebSearch(CodedTool):
                 adding the data is not invoke()-ed more than once.
 
                 Keys expected for this implementation are:
-                    None
+                    - "llm_config" (dict, optional): BYOK keys sent by the client. When it holds
+                        "openai_api_key", that key is used instead of the OPENAI_API_KEY env var.
 
         :return:
             In case of successful execution:
@@ -76,4 +77,5 @@ class OpenAIWebSearch(CodedTool):
         # See https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses
         additional_kwargs: dict[str, Any] = args.get("additional_kwargs", {})
 
-        return await OpenAITool.arun(query, "web_search_preview", openai_model, **additional_kwargs)
+        # Forward sly_data so a BYOK OpenAI key sent by the client is used for this call.
+        return await OpenAITool.arun(query, "web_search_preview", openai_model, sly_data=sly_data, **additional_kwargs)

--- a/neuro_san_studio/coded_tools/openai_web_search.py
+++ b/neuro_san_studio/coded_tools/openai_web_search.py
@@ -38,7 +38,7 @@ class OpenAIWebSearch(CodedTool):
                 - from calling agent
                     - "query" (str): Request from the user prompt.
                 - from user
-                    - "openai_model" (str): OpenAI model to call the tool. Default to gpt-4o-2024-08-06.
+                    - "openai_model" (str): OpenAI model to call the tool. Default to gpt-5.2.
                     - "additional_kwargs" (dict): Any additional arguments for the tool.
 
         :param sly_data: A dictionary whose keys are defined by the agent hierarchy,

--- a/neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon
+++ b/neuro_san_studio/toolbox/agent_network_designer_toolbox_info.hocon
@@ -55,6 +55,7 @@
     # Requirement to use these tools:
     # - langchain-openai >= 0.3.26
     # - OPENAI_API_KEY
+    #   (or llm_config.openai_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
     # See https://platform.openai.com/docs/guides/tools?api-mode=responses and
     # https://python.langchain.com/docs/integrations/chat/openai/#responses-api
 

--- a/neuro_san_studio/toolbox/toolbox_info.hocon
+++ b/neuro_san_studio/toolbox/toolbox_info.hocon
@@ -25,6 +25,7 @@
     # Requirement to use this agent network:
     # - langchain-anthropic>=0.3.13
     # - ANTHROPIC_API_KEY
+    #   (or llm_config.anthropic_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
     # See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview and
     # https://python.langchain.com/docs/integrations/chat/anthropic/#built-in-tools
 
@@ -173,6 +174,7 @@
     # Requirement to use this agent network:
     # - google-genai
     # - GOOGLE_API_KEY
+    #   (or llm_config.google_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
     # Note: If `langchain-google-genai` is already installed in your environment, `google-genai` is already included.
     # See also:
     # - https://ai.google.dev/gemini-api/docs
@@ -270,6 +272,7 @@
     # Requirement to use these tools:
     # - langchain-openai >= 0.3.26
     # - OPENAI_API_KEY
+    #   (or llm_config.openai_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
     # See https://platform.openai.com/docs/guides/tools?api-mode=responses and
     # https://python.langchain.com/docs/integrations/chat/openai/#responses-api
 

--- a/registries/basic/coding_assistant.hocon
+++ b/registries/basic/coding_assistant.hocon
@@ -159,7 +159,7 @@ Once all checklist items are done and the code has been verified, present the fi
 
             # --- Optional Arguments ---
             "args": {
-                # OpenAI code interpreter uses this model. Default to gpt-4o-2024-08-06.
+                # OpenAI code interpreter uses this model. Default to gpt-5.2.
                 "openai_model": "gpt-4.1"
             }
         },

--- a/registries/tools/anthropic_code_execution.hocon
+++ b/registries/tools/anthropic_code_execution.hocon
@@ -20,6 +20,7 @@
 # Requirement to use this agent network:
 # - langchain-anthropic>=0.3.13
 # - ANTHROPIC_API_KEY
+#   (or llm_config.anthropic_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
 # See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview and
 # https://python.langchain.com/docs/integrations/chat/anthropic/#built-in-tools
 

--- a/registries/tools/anthropic_code_execution.hocon
+++ b/registries/tools/anthropic_code_execution.hocon
@@ -85,7 +85,7 @@ Just relay the user message to your tool. Do not create code yourself.
 
             # --- Optional Arguments ---
             "args": {
-                # Anthropic model to call the built-in code execution tool. Default to claude-3-7-sonnet-20250219.
+                # Anthropic model to call the built-in code execution tool. Default to claude-sonnet-5.
                 "anthropic_model": "claude-opus-4-1-20250805",
 
                 # Save generated files. Default to False.

--- a/registries/tools/anthropic_web_search.hocon
+++ b/registries/tools/anthropic_web_search.hocon
@@ -84,7 +84,7 @@
 
             # --- Optional Arguments ---
             "args": {
-                # Anthropic model to call the built-in web search tool. Default to claude-3-7-sonnet-20250219.
+                # Anthropic model to call the built-in web search tool. Default to claude-sonnet-5.
                 "anthropic_model": "claude-opus-4-1-20250805"
             }
         },

--- a/registries/tools/anthropic_web_search.hocon
+++ b/registries/tools/anthropic_web_search.hocon
@@ -20,6 +20,7 @@
 # Requirement to use this agent network:
 # - langchain-anthropic>=0.3.13
 # - ANTHROPIC_API_KEY
+#   (or llm_config.anthropic_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
 # See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview and
 # https://python.langchain.com/docs/integrations/chat/anthropic/#built-in-tools
 

--- a/registries/tools/gemini_image_generation.hocon
+++ b/registries/tools/gemini_image_generation.hocon
@@ -20,6 +20,7 @@
 # Requirement to use this agent network:
 # - google-genai package installed
 # - GOOGLE_API_KEY or GEMINI_API_KEY environment variable set
+#   (or llm_config.google_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
 # See https://ai.google.dev/gemini-api/docs
 # Note: If `langchain-google-genai` is already installed in your environment, `google-genai` is already included.
 

--- a/registries/tools/manifest.hocon
+++ b/registries/tools/manifest.hocon
@@ -37,6 +37,7 @@
     # Requirement to use this anthropic based agent network:
     # - langchain-anthropic>=0.3.13
     # - ANTHROPIC_API_KEY
+    #   (or llm_config.anthropic_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
     # See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview and
     # https://python.langchain.com/docs/integrations/chat/anthropic/#built-in-tools
     "tools/anthropic_web_search.hocon": true,
@@ -67,6 +68,7 @@
     # Requirement to use this agent network:
     # - google-genai
     # - GOOGLE_API_KEY
+    #   (or llm_config.google_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
     # See https://ai.google.dev/gemini-api/docs
     # Note: If `langchain-google-genai` is already installed in your environment, `google-genai` is already included.
     "tools/gemini_image_generation.hocon": false,
@@ -127,6 +129,7 @@
     # Requirement to use this openai based agent network:
     # - langchain-openai >= 0.3.26
     # - OPENAI_API_KEY
+    #   (or llm_config.openai_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
     # See https://platform.openai.com/docs/guides/tools?api-mode=responses and
     # https://python.langchain.com/docs/integrations/chat/openai/#responses-api
     "tools/openai_code_interpreter.hocon": true,

--- a/registries/tools/openai_code_interpreter.hocon
+++ b/registries/tools/openai_code_interpreter.hocon
@@ -82,7 +82,7 @@
 
             # --- Optional Arguments ---
             "args": {
-                # OpenAI model calls the built-in web search tool. Default to gpt-5.2.
+                # OpenAI model calls the built-in code interpreter tool. Default to gpt-5.2.
                 "openai_model": "gpt-4.1"
             }
         },

--- a/registries/tools/openai_code_interpreter.hocon
+++ b/registries/tools/openai_code_interpreter.hocon
@@ -20,6 +20,7 @@
 # Requirement to use this agent network:
 # - langchain-openai >= 0.3.26
 # - OPENAI_API_KEY
+#   (or llm_config.openai_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
 # See https://platform.openai.com/docs/guides/tools?api-mode=responses and
 # https://python.langchain.com/docs/integrations/chat/openai/#responses-api
 

--- a/registries/tools/openai_code_interpreter.hocon
+++ b/registries/tools/openai_code_interpreter.hocon
@@ -82,7 +82,7 @@
 
             # --- Optional Arguments ---
             "args": {
-                # OpenAI model calls the built-in web search tool. Default to gpt-4o-2024-08-06.
+                # OpenAI model calls the built-in web search tool. Default to gpt-5.2.
                 "openai_model": "gpt-4.1"
             }
         },

--- a/registries/tools/openai_image_generation.hocon
+++ b/registries/tools/openai_image_generation.hocon
@@ -84,7 +84,7 @@
 
             # --- Optional Arguments ---
             "args": {
-                # OpenAI model calls the built-in image generation tool. Default to gpt-4o-2024-08-06.
+                # OpenAI model calls the built-in image generation tool. Default to gpt-5.2.
                 "openai_model": "gpt-5"
                 # Whether to save image on disk
                 "save_image_file": true

--- a/registries/tools/openai_image_generation.hocon
+++ b/registries/tools/openai_image_generation.hocon
@@ -20,6 +20,7 @@
 # Requirement to use this agent network:
 # - langchain-openai >= 0.3.26
 # - OPENAI_API_KEY
+#   (or llm_config.openai_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
 # See https://platform.openai.com/docs/guides/tools?api-mode=responses and
 # https://python.langchain.com/docs/integrations/chat/openai/#responses-api
 

--- a/registries/tools/openai_video_generation.hocon
+++ b/registries/tools/openai_video_generation.hocon
@@ -19,6 +19,7 @@
 
 # Requirement to use this agent network:
 # - OPENAI_API_KEY
+#   (or llm_config.openai_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
 # - opencv-python
 # See https://platform.openai.com/docs/guides/video-generation
 

--- a/registries/tools/openai_web_search.hocon
+++ b/registries/tools/openai_web_search.hocon
@@ -84,7 +84,7 @@
 
             # --- Optional Arguments ---
             "args": {
-                # OpenAI model calls the built-in web search tool. Default to gpt-4o-2024-08-06.
+                # OpenAI model calls the built-in web search tool. Default to gpt-5.2.
                 "openai_model": "gpt-4.1"
             }
         },

--- a/registries/tools/openai_web_search.hocon
+++ b/registries/tools/openai_web_search.hocon
@@ -20,6 +20,7 @@
 # Requirement to use this agent network:
 # - langchain-openai >= 0.3.26
 # - OPENAI_API_KEY
+#   (or llm_config.openai_api_key in the request's sly_data on a BYOK deployment; see config/byok_llm_config.hocon)
 # See https://platform.openai.com/docs/guides/tools?api-mode=responses and
 # https://python.langchain.com/docs/integrations/chat/openai/#responses-api
 

--- a/tests/coded_tools/tools/test_video_describer.py
+++ b/tests/coded_tools/tools/test_video_describer.py
@@ -1,0 +1,100 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import os
+import sys
+from importlib.util import find_spec
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+# opencv is not a declared dependency of the studio (the tool itself disables import-error for
+# it), so CI has no cv2. Skipping the module there would leave the BYOK regression permanently
+# unexecuted in CI, so instead stand in a stub module when the real one is absent. The tests
+# patch cv2.VideoCapture explicitly, so the stub is never asked to decode anything.
+if find_spec("cv2") is None:
+    sys.modules["cv2"] = MagicMock(name="cv2")
+
+# The import must stay below the stub so environments without cv2 can load the tool.
+from coded_tools.tools.video_describer import VideoDescriber  # pylint: disable=wrong-import-position
+
+# Patch the names in the module under test.
+MODULE = "coded_tools.tools.video_describer"
+SLY_DATA: dict[str, Any] = {"llm_config": {"openai_api_key": "sly-key"}}
+
+
+class TestVideoDescriber(IsolatedAsyncioTestCase):
+    """
+    Unit tests for VideoDescriber.
+
+    cv2.VideoCapture and ChatOpenAI are replaced by stand-ins so no file is read and no network
+    is touched. The tests pin which api_key reaches ChatOpenAI under each BYOK scenario.
+    """
+
+    @staticmethod
+    def _chat_openai_mock(text: str) -> MagicMock:
+        """
+        Build a stand-in for the ChatOpenAI class whose instances answer ainvoke with the given text.
+
+        :param text: The description the fake model should return.
+        :return: A MagicMock usable as the patched ChatOpenAI class.
+        """
+        message = MagicMock(name="AIMessage")
+        message.text = text
+        llm = MagicMock(name="ChatOpenAI instance")
+        llm.ainvoke = AsyncMock(return_value=message)
+        return MagicMock(name="ChatOpenAI", return_value=llm)
+
+    @staticmethod
+    def _closed_capture() -> MagicMock:
+        """
+        Build a stand-in VideoCapture that reports no frames.
+
+        :return: A MagicMock whose isOpened() is False so the frame loop exits at once.
+        """
+        capture = MagicMock(name="VideoCapture instance")
+        capture.isOpened.return_value = False
+        return capture
+
+    async def test_sly_data_key_is_passed_to_chat_openai(self) -> None:
+        """
+        A BYOK key in sly_data reaches ChatOpenAI even when OPENAI_API_KEY is also set.
+        """
+        chat_cls: MagicMock = self._chat_openai_mock("A cat video.")
+        with (
+            patch(f"{MODULE}.cv2.VideoCapture", return_value=self._closed_capture()),
+            patch(f"{MODULE}.ChatOpenAI", chat_cls),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}),
+        ):
+            result: str = await VideoDescriber().async_invoke({"file_path": "/path/to/video.mp4"}, SLY_DATA)
+        self.assertEqual(result, "A cat video.")
+        self.assertEqual(chat_cls.call_args.kwargs["api_key"], "sly-key")
+        self.assertEqual(chat_cls.call_args.kwargs["model"], "gpt-4o")
+
+    async def test_env_key_used_without_sly_data(self) -> None:
+        """
+        Without sly_data the OPENAI_API_KEY environment variable is passed explicitly.
+        """
+        chat_cls: MagicMock = self._chat_openai_mock("A cat video.")
+        with (
+            patch(f"{MODULE}.cv2.VideoCapture", return_value=self._closed_capture()),
+            patch(f"{MODULE}.ChatOpenAI", chat_cls),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}),
+        ):
+            await VideoDescriber().async_invoke({"file_path": "/path/to/video.mp4", "openai_model": "gpt-5"}, {})
+        self.assertEqual(chat_cls.call_args.kwargs["api_key"], "env-key")
+        self.assertEqual(chat_cls.call_args.kwargs["model"], "gpt-5")

--- a/tests/neuro_san_studio/coded_tools/test_anthropic_code_execution.py
+++ b/tests/neuro_san_studio/coded_tools/test_anthropic_code_execution.py
@@ -1,0 +1,112 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import os
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from neuro_san_studio.coded_tools.anthropic_code_execution import CODE_EXECUTION_BETA
+from neuro_san_studio.coded_tools.anthropic_code_execution import CODE_EXECUTION_TOOL_TYPE
+from neuro_san_studio.coded_tools.anthropic_code_execution import AnthropicCodeExecution
+from neuro_san_studio.coded_tools.anthropic_tool import AnthropicTool
+
+# Patch the names in the module under test.
+MODULE = "neuro_san_studio.coded_tools.anthropic_code_execution"
+SLY_DATA: dict[str, Any] = {"llm_config": {"anthropic_api_key": "sly-key"}}
+TEXT_CONTENT: list[dict[str, Any]] = [{"type": "text", "text": "done"}]
+FILE_CONTENT: list[dict[str, Any]] = [
+    {"type": "code_execution_tool_result", "content": {"content": [{"file_id": "file_1"}]}},
+]
+
+
+class TestAnthropicCodeExecution(IsolatedAsyncioTestCase):
+    """
+    Unit tests for AnthropicCodeExecution.
+
+    AnthropicTool.arun and the raw Anthropic client are replaced by stand-ins so no network is
+    touched. The tests pin that sly_data is forwarded to the tool call and that the file download
+    authenticates with the same resolved key instead of silently reading the environment.
+    """
+
+    async def test_sly_data_is_forwarded_to_anthropic_tool(self) -> None:
+        """
+        async_invoke passes the caller's sly_data through to AnthropicTool.arun unchanged.
+        """
+        arun = AsyncMock(return_value=TEXT_CONTENT)
+        with patch.object(AnthropicTool, "arun", new=arun):
+            result: Any = await AnthropicCodeExecution().async_invoke({"query": "print(1)"}, SLY_DATA)
+        self.assertEqual(result, TEXT_CONTENT)
+        arun.assert_awaited_once_with(
+            query="print(1)",
+            tool_type=CODE_EXECUTION_TOOL_TYPE,
+            tool_name="code_execution",
+            anthropic_model=None,
+            betas=[CODE_EXECUTION_BETA],
+            sly_data=SLY_DATA,
+        )
+
+    async def test_save_file_receives_resolved_key(self) -> None:
+        """
+        When files were generated and save_file is requested, the BYOK key is handed to save_file.
+        """
+        arun = AsyncMock(return_value=FILE_CONTENT)
+        with (
+            patch.object(AnthropicTool, "arun", new=arun),
+            patch.object(AnthropicCodeExecution, "save_file") as save_file,
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "env-key"}),
+        ):
+            await AnthropicCodeExecution().async_invoke({"query": "plot", "save_file": True}, SLY_DATA)
+        # save_file is patched on the class, so the call is unbound: (file_ids, api_key).
+        save_file.assert_called_once_with(["file_1"], "sly-key")
+
+    async def test_save_file_receives_env_key_without_sly_data(self) -> None:
+        """
+        Without a BYOK key in sly_data, save_file is handed the ANTHROPIC_API_KEY environment value.
+        """
+        arun = AsyncMock(return_value=FILE_CONTENT)
+        with (
+            patch.object(AnthropicTool, "arun", new=arun),
+            patch.object(AnthropicCodeExecution, "save_file") as save_file,
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "env-key"}),
+        ):
+            await AnthropicCodeExecution().async_invoke({"query": "plot", "save_file": True}, {})
+        save_file.assert_called_once_with(["file_1"], "env-key")
+
+    async def test_save_file_not_called_without_flag(self) -> None:
+        """
+        Generated files are left in the container when save_file was not requested.
+        """
+        arun = AsyncMock(return_value=FILE_CONTENT)
+        with patch.object(AnthropicTool, "arun", new=arun), patch.object(AnthropicCodeExecution, "save_file") as save:
+            await AnthropicCodeExecution().async_invoke({"query": "plot"}, SLY_DATA)
+        save.assert_not_called()
+
+    def test_save_file_builds_client_with_key(self) -> None:
+        """
+        save_file constructs the Anthropic client with the resolved key and downloads each file.
+        """
+        anthropic_cls = MagicMock(name="Anthropic")
+        client: MagicMock = anthropic_cls.return_value
+        client.beta.files.retrieve_metadata.return_value.filename = "output.png"
+        with patch(f"{MODULE}.Anthropic", anthropic_cls), patch(f"{MODULE}.webbrowser.open") as browser_open:
+            AnthropicCodeExecution().save_file(["file_1"], "sly-key")
+        self.assertEqual(anthropic_cls.call_args.kwargs["api_key"], "sly-key")
+        client.beta.files.retrieve_metadata.assert_called_once_with("file_1")
+        client.beta.files.download.assert_called_once_with("file_1")
+        client.beta.files.download.return_value.write_to_file.assert_called_once_with("output.png")
+        browser_open.assert_called_once()

--- a/tests/neuro_san_studio/coded_tools/test_anthropic_web_search.py
+++ b/tests/neuro_san_studio/coded_tools/test_anthropic_web_search.py
@@ -1,0 +1,68 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from neuro_san_studio.coded_tools.anthropic_tool import AnthropicTool
+from neuro_san_studio.coded_tools.anthropic_web_search import WEB_SEARCH_TOOL_TYPE
+from neuro_san_studio.coded_tools.anthropic_web_search import AnthropicWebSearch
+
+SLY_DATA: dict[str, Any] = {"llm_config": {"anthropic_api_key": "sly-key"}}
+CONTENT: list[dict[str, Any]] = [{"type": "text", "text": "found"}]
+
+
+class TestAnthropicWebSearch(IsolatedAsyncioTestCase):
+    """
+    Unit tests for AnthropicWebSearch.
+
+    AnthropicTool.arun is replaced by a stand-in so no network is touched. The tests pin that
+    the caller's sly_data is forwarded (the BYOK regression) along with the existing arguments.
+    """
+
+    async def test_sly_data_is_forwarded_to_anthropic_tool(self) -> None:
+        """
+        async_invoke passes sly_data, the model and the tool kwargs through to AnthropicTool.arun.
+        """
+        arun = AsyncMock(return_value=CONTENT)
+        args: dict[str, Any] = {
+            "query": "news",
+            "anthropic_model": "claude-sonnet-4-5",
+            "additional_kwargs": {"max_uses": 3},
+        }
+        with patch.object(AnthropicTool, "arun", new=arun):
+            result: Any = await AnthropicWebSearch().async_invoke(args, SLY_DATA)
+        self.assertEqual(result, CONTENT)
+        arun.assert_awaited_once_with(
+            query="news",
+            tool_type=WEB_SEARCH_TOOL_TYPE,
+            tool_name="web_search",
+            anthropic_model="claude-sonnet-4-5",
+            betas=None,
+            sly_data=SLY_DATA,
+            max_uses=3,
+        )
+
+    async def test_missing_query_returns_error_without_calling_tool(self) -> None:
+        """
+        An empty query short-circuits with the documented error string.
+        """
+        arun = AsyncMock(return_value=CONTENT)
+        with patch.object(AnthropicTool, "arun", new=arun):
+            result: Any = await AnthropicWebSearch().async_invoke({}, SLY_DATA)
+        self.assertEqual(result, "Error: No query provided.")
+        arun.assert_not_awaited()

--- a/tests/neuro_san_studio/coded_tools/test_gemini_image_generation.py
+++ b/tests/neuro_san_studio/coded_tools/test_gemini_image_generation.py
@@ -1,0 +1,105 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import os
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from neuro_san_studio.coded_tools.gemini_image_generation import GeminiImageGeneration
+
+# Patch the name in the module under test, not "google.genai.Client".
+MODULE = "neuro_san_studio.coded_tools.gemini_image_generation"
+SLY_DATA: dict[str, Any] = {"llm_config": {"google_api_key": "sly-key"}}
+
+
+class TestGeminiImageGeneration(IsolatedAsyncioTestCase):
+    """
+    Unit tests for GeminiImageGeneration.
+
+    google.genai.Client is replaced by a stand-in so no network is touched. The tests pin which
+    api_key reaches the client constructor under each BYOK scenario and that the request
+    plumbing (model, prompt) and text extraction are unchanged.
+    """
+
+    @staticmethod
+    def _client_mock(parts: list[Any]) -> MagicMock:
+        """
+        Build a stand-in for the google.genai Client class whose generate_content returns the given parts.
+
+        :param parts: The response parts the fake generate_content call should return.
+        :return: A MagicMock usable as the patched Client class.
+        """
+        response = MagicMock(name="GenerateContentResponse")
+        response.parts = parts
+        client = MagicMock(name="Client instance")
+        client.aio.models.generate_content = AsyncMock(return_value=response)
+        return MagicMock(name="Client", return_value=client)
+
+    @staticmethod
+    def _text_part(text: str) -> MagicMock:
+        """
+        Build a text-only response part.
+
+        :param text: The text the part carries.
+        :return: A MagicMock part with no inline image data.
+        """
+        part = MagicMock(name="Part")
+        part.text = text
+        # Explicitly no image, otherwise the truthy MagicMock would be treated as a Blob.
+        part.inline_data = None
+        return part
+
+    async def test_sly_data_key_is_passed_to_client(self) -> None:
+        """
+        A BYOK key in sly_data reaches the Gemini client even when GOOGLE_API_KEY is also set.
+        """
+        client_cls: MagicMock = self._client_mock([])
+        with patch(f"{MODULE}.Client", client_cls), patch.dict(os.environ, {"GOOGLE_API_KEY": "env-key"}):
+            result: str = await GeminiImageGeneration().async_invoke({"query": "a cat"}, SLY_DATA)
+        self.assertEqual(result, "Image generation completed.")
+        self.assertEqual(client_cls.call_args.kwargs["api_key"], "sly-key")
+        generate: AsyncMock = client_cls.return_value.aio.models.generate_content
+        self.assertEqual(generate.call_args.kwargs["model"], "gemini-2.5-flash-image")
+        self.assertEqual(generate.call_args.kwargs["contents"], "a cat")
+
+    async def test_env_key_used_without_sly_data(self) -> None:
+        """
+        Without sly_data the GOOGLE_API_KEY environment variable is passed explicitly.
+        """
+        client_cls: MagicMock = self._client_mock([])
+        with patch(f"{MODULE}.Client", client_cls), patch.dict(os.environ, {"GOOGLE_API_KEY": "env-key"}):
+            await GeminiImageGeneration().async_invoke({"query": "a cat"}, {})
+        self.assertEqual(client_cls.call_args.kwargs["api_key"], "env-key")
+
+    async def test_none_key_when_no_source(self) -> None:
+        """
+        With neither source available, None is passed so google.genai runs its own env lookup.
+        """
+        client_cls: MagicMock = self._client_mock([])
+        with patch(f"{MODULE}.Client", client_cls), patch.dict(os.environ, {}, clear=True):
+            await GeminiImageGeneration().async_invoke({"query": "a cat"}, {})
+        self.assertIsNone(client_cls.call_args.kwargs["api_key"])
+
+    async def test_text_part_is_returned(self) -> None:
+        """
+        Text returned alongside (or instead of) an image is surfaced as the tool result.
+        """
+        client_cls: MagicMock = self._client_mock([self._text_part("Here is your cat.")])
+        with patch(f"{MODULE}.Client", client_cls), patch.dict(os.environ, {}, clear=True):
+            result: str = await GeminiImageGeneration().async_invoke({"query": "a cat"}, SLY_DATA)
+        self.assertEqual(result, "Here is your cat.")

--- a/tests/neuro_san_studio/coded_tools/test_openai_code_interpreter.py
+++ b/tests/neuro_san_studio/coded_tools/test_openai_code_interpreter.py
@@ -1,0 +1,73 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from neuro_san_studio.coded_tools.openai_code_interpreter import OpenAICodeInterpreter
+from neuro_san_studio.coded_tools.openai_tool import OpenAITool
+
+SLY_DATA: dict[str, Any] = {"llm_config": {"openai_api_key": "sly-key"}}
+CONTENT: list[dict[str, Any]] = [{"type": "text", "text": "42"}]
+
+
+class TestOpenAICodeInterpreter(IsolatedAsyncioTestCase):
+    """
+    Unit tests for OpenAICodeInterpreter.
+
+    OpenAITool.arun is replaced by a stand-in so no network is touched. The tests pin that
+    the caller's sly_data is forwarded (the BYOK regression) and that the container default
+    is still injected without mutating the caller's additional_kwargs.
+    """
+
+    async def test_sly_data_is_forwarded_with_default_container(self) -> None:
+        """
+        Without a container in additional_kwargs, an auto container is added and sly_data is forwarded.
+        """
+        arun = AsyncMock(return_value=CONTENT)
+        additional_kwargs: dict[str, Any] = {}
+        args: dict[str, Any] = {"query": "6 * 7", "additional_kwargs": additional_kwargs}
+        with patch.object(OpenAITool, "arun", new=arun):
+            result: Any = await OpenAICodeInterpreter().async_invoke(args, SLY_DATA)
+        self.assertEqual(result, CONTENT)
+        arun.assert_awaited_once_with("6 * 7", "code_interpreter", None, sly_data=SLY_DATA, container={"type": "auto"})
+        # The caller's dict must stay untouched; the default goes into a copy.
+        self.assertEqual(additional_kwargs, {})
+
+    async def test_explicit_container_is_kept(self) -> None:
+        """
+        A container supplied by the user is passed through unchanged.
+        """
+        arun = AsyncMock(return_value=CONTENT)
+        args: dict[str, Any] = {
+            "query": "6 * 7",
+            "openai_model": "gpt-5",
+            "additional_kwargs": {"container": "cntr_123"},
+        }
+        with patch.object(OpenAITool, "arun", new=arun):
+            await OpenAICodeInterpreter().async_invoke(args, SLY_DATA)
+        arun.assert_awaited_once_with("6 * 7", "code_interpreter", "gpt-5", sly_data=SLY_DATA, container="cntr_123")
+
+    async def test_missing_query_returns_error_without_calling_tool(self) -> None:
+        """
+        An empty query short-circuits with the documented error string.
+        """
+        arun = AsyncMock(return_value=CONTENT)
+        with patch.object(OpenAITool, "arun", new=arun):
+            result: Any = await OpenAICodeInterpreter().async_invoke({}, SLY_DATA)
+        self.assertEqual(result, "Error: No query provided.")
+        arun.assert_not_awaited()

--- a/tests/neuro_san_studio/coded_tools/test_openai_image_generation.py
+++ b/tests/neuro_san_studio/coded_tools/test_openai_image_generation.py
@@ -1,0 +1,68 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from neuro_san_studio.coded_tools.openai_image_generation import OpenAIImageGeneration
+from neuro_san_studio.coded_tools.openai_tool import OpenAITool
+
+SLY_DATA: dict[str, Any] = {"llm_config": {"openai_api_key": "sly-key"}}
+
+
+class TestOpenAIImageGeneration(IsolatedAsyncioTestCase):
+    """
+    Unit tests for OpenAIImageGeneration.
+
+    OpenAITool.arun is replaced by a stand-in so no network is touched and no image is
+    written or opened. The tests pin that the caller's sly_data is forwarded (the BYOK
+    regression) and that text and error results are surfaced as before.
+    """
+
+    async def test_sly_data_is_forwarded_and_text_returned(self) -> None:
+        """
+        async_invoke forwards sly_data and the tool kwargs, and returns the text block's text.
+        """
+        arun = AsyncMock(return_value=[{"type": "text", "text": "Here is your cat."}])
+        args: dict[str, Any] = {
+            "query": "a cat",
+            "openai_model": "gpt-5",
+            "additional_kwargs": {"quality": "medium"},
+        }
+        with patch.object(OpenAITool, "arun", new=arun):
+            result: str = await OpenAIImageGeneration().async_invoke(args, SLY_DATA)
+        self.assertEqual(result, "Here is your cat.")
+        arun.assert_awaited_once_with("a cat", "image_generation", "gpt-5", sly_data=SLY_DATA, quality="medium")
+
+    async def test_error_string_is_passed_through(self) -> None:
+        """
+        An error string from OpenAITool (e.g. missing credentials) is returned to the agent verbatim.
+        """
+        arun = AsyncMock(return_value="OpenAI Error: Missing credentials")
+        with patch.object(OpenAITool, "arun", new=arun):
+            result: str = await OpenAIImageGeneration().async_invoke({"query": "a cat"}, SLY_DATA)
+        self.assertEqual(result, "OpenAI Error: Missing credentials")
+
+    async def test_missing_query_returns_error_without_calling_tool(self) -> None:
+        """
+        An empty query short-circuits with the documented error string.
+        """
+        arun = AsyncMock(return_value=[])
+        with patch.object(OpenAITool, "arun", new=arun):
+            result: str = await OpenAIImageGeneration().async_invoke({}, SLY_DATA)
+        self.assertEqual(result, "Error: No query provided.")
+        arun.assert_not_awaited()

--- a/tests/neuro_san_studio/coded_tools/test_openai_video_generation.py
+++ b/tests/neuro_san_studio/coded_tools/test_openai_video_generation.py
@@ -1,0 +1,130 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import os
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from neuro_san_studio.coded_tools.openai_video_generation import OpenAIVideoGeneration
+
+SLY_DATA: dict[str, Any] = {"llm_config": {"openai_api_key": "sly-key"}}
+SLY_HEADERS: dict[str, str] = {"Authorization": "Bearer sly-key", "Content-Type": "application/json"}
+ENV_HEADERS: dict[str, str] = {"Authorization": "Bearer env-key", "Content-Type": "application/json"}
+# What the pre-fix module-level constant produced when OPENAI_API_KEY was unset; the API rejects it.
+NONE_HEADERS: dict[str, str] = {"Authorization": "Bearer None", "Content-Type": "application/json"}
+# Prefix is in .lycheeignore so the link checker never tries to open it.
+VIDEO_URI = "file:///path/to/vid_1.mp4"
+
+
+class TestOpenAIVideoGeneration(IsolatedAsyncioTestCase):
+    """
+    Unit tests for OpenAIVideoGeneration.
+
+    The HTTP helpers are replaced by stand-ins so no network is touched. The tests pin that the
+    bearer token is built per call from the BYOK key (or the environment) and that the same
+    headers reach every request of the create/remix, poll and download sequence.
+    """
+
+    def test_build_headers_uses_bearer_token(self) -> None:
+        """
+        build_headers wraps the key as a bearer token with a JSON content type.
+        """
+        self.assertEqual(
+            OpenAIVideoGeneration.build_headers("abc"),
+            {
+                "Authorization": "Bearer abc",
+                "Content-Type": "application/json",
+            },
+        )
+
+    async def test_sly_data_key_reaches_every_request(self) -> None:
+        """
+        A BYOK key in sly_data is used for create, poll and download even when OPENAI_API_KEY is set.
+        """
+        with (
+            patch.object(OpenAIVideoGeneration, "_create_video", new=AsyncMock(return_value="vid_1")) as create,
+            patch.object(
+                OpenAIVideoGeneration, "_poll_status", new=AsyncMock(return_value={"status": "completed"})
+            ) as poll,
+            patch.object(OpenAIVideoGeneration, "_display_video", new=AsyncMock(return_value=VIDEO_URI)) as display,
+            patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}),
+        ):
+            result: str = await OpenAIVideoGeneration().async_invoke({"query": "a cat"}, SLY_DATA)
+        self.assertEqual(result, f"Video generation completed with id vid_1. Saved to: {VIDEO_URI}")
+        # The helpers are patched on the class, so the calls are unbound: (session, headers, ...).
+        self.assertEqual(create.call_args.args[1], SLY_HEADERS)
+        self.assertEqual(create.call_args.args[2:], ("a cat", "sora-2", "720x1280", "4"))
+        self.assertEqual(poll.call_args.args[1:], (SLY_HEADERS, "vid_1"))
+        self.assertEqual(display.call_args.args[1:], (SLY_HEADERS, "vid_1", False, False))
+
+    async def test_env_key_used_without_sly_data(self) -> None:
+        """
+        Without sly_data the bearer token comes from OPENAI_API_KEY, resolved at call time.
+        """
+        with (
+            patch.object(OpenAIVideoGeneration, "_create_video", new=AsyncMock(return_value="vid_1")) as create,
+            patch.object(OpenAIVideoGeneration, "_poll_status", new=AsyncMock(return_value={"status": "completed"})),
+            patch.object(OpenAIVideoGeneration, "_display_video", new=AsyncMock(return_value=VIDEO_URI)),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}),
+        ):
+            await OpenAIVideoGeneration().async_invoke({"query": "a cat"}, {})
+        self.assertEqual(create.call_args.args[1], ENV_HEADERS)
+
+    async def test_remix_path_uses_same_headers(self) -> None:
+        """
+        The remix request carries the same per-call headers as a fresh generation.
+        """
+        with (
+            patch.object(OpenAIVideoGeneration, "_remix_video", new=AsyncMock(return_value="vid_2")) as remix,
+            patch.object(OpenAIVideoGeneration, "_poll_status", new=AsyncMock(return_value={"status": "completed"})),
+            patch.object(OpenAIVideoGeneration, "_display_video", new=AsyncMock(return_value=VIDEO_URI)),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}),
+        ):
+            await OpenAIVideoGeneration().async_invoke({"query": "make it night", "video_id": "vid_1"}, SLY_DATA)
+        self.assertEqual(remix.call_args.args[1:], (SLY_HEADERS, "vid_1", "make it night"))
+
+    async def test_none_key_when_no_source(self) -> None:
+        """
+        With neither source available the token is literally "Bearer None", matching the pre-fix behavior
+        when OPENAI_API_KEY was unset, so the API rejects the request exactly as it always did.
+        """
+        with (
+            patch.object(OpenAIVideoGeneration, "_create_video", new=AsyncMock(return_value="vid_1")) as create,
+            patch.object(OpenAIVideoGeneration, "_poll_status", new=AsyncMock(return_value={"status": "completed"})),
+            patch.object(OpenAIVideoGeneration, "_display_video", new=AsyncMock(return_value=VIDEO_URI)),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            await OpenAIVideoGeneration().async_invoke({"query": "a cat"}, {})
+        self.assertEqual(create.call_args.args[1], NONE_HEADERS)
+        self.assertEqual(OpenAIVideoGeneration.build_headers(None), NONE_HEADERS)
+
+    async def test_status_request_receives_headers(self) -> None:
+        """
+        The per-request headers reach the status request inside the polling loop, not only the loop's entry point.
+        """
+        with (
+            patch.object(OpenAIVideoGeneration, "_create_video", new=AsyncMock(return_value="vid_1")),
+            patch.object(
+                OpenAIVideoGeneration, "_get_status", new=AsyncMock(return_value={"status": "completed"})
+            ) as get_status,
+            patch.object(OpenAIVideoGeneration, "_display_video", new=AsyncMock(return_value=VIDEO_URI)),
+            patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"}),
+        ):
+            await OpenAIVideoGeneration().async_invoke({"query": "a cat"}, SLY_DATA)
+        # "completed" on the first poll returns before any sleep, so exactly one status call is made.
+        get_status.assert_awaited_once()
+        self.assertEqual(get_status.call_args.args[1:], (SLY_HEADERS, "vid_1"))

--- a/tests/neuro_san_studio/coded_tools/test_openai_web_search.py
+++ b/tests/neuro_san_studio/coded_tools/test_openai_web_search.py
@@ -1,0 +1,61 @@
+# Copyright © 2025-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from neuro_san_studio.coded_tools.openai_tool import OpenAITool
+from neuro_san_studio.coded_tools.openai_web_search import OpenAIWebSearch
+
+SLY_DATA: dict[str, Any] = {"llm_config": {"openai_api_key": "sly-key"}}
+CONTENT: list[dict[str, Any]] = [{"type": "text", "text": "found"}]
+
+
+class TestOpenAIWebSearch(IsolatedAsyncioTestCase):
+    """
+    Unit tests for OpenAIWebSearch.
+
+    OpenAITool.arun is replaced by a stand-in so no network is touched. The tests pin that
+    the caller's sly_data is forwarded (the BYOK regression) along with the existing arguments.
+    """
+
+    async def test_sly_data_is_forwarded_to_openai_tool(self) -> None:
+        """
+        async_invoke passes sly_data, the model and the tool kwargs through to OpenAITool.arun.
+        """
+        arun = AsyncMock(return_value=CONTENT)
+        args: dict[str, Any] = {
+            "query": "news",
+            "openai_model": "gpt-5",
+            "additional_kwargs": {"search_context_size": "low"},
+        }
+        with patch.object(OpenAITool, "arun", new=arun):
+            result: Any = await OpenAIWebSearch().async_invoke(args, SLY_DATA)
+        self.assertEqual(result, CONTENT)
+        arun.assert_awaited_once_with(
+            "news", "web_search_preview", "gpt-5", sly_data=SLY_DATA, search_context_size="low"
+        )
+
+    async def test_missing_query_returns_error_without_calling_tool(self) -> None:
+        """
+        An empty query short-circuits with the documented error string.
+        """
+        arun = AsyncMock(return_value=CONTENT)
+        with patch.object(OpenAITool, "arun", new=arun):
+            result: Any = await OpenAIWebSearch().async_invoke({}, SLY_DATA)
+        self.assertEqual(result, "Error: No query provided.")
+        arun.assert_not_awaited()


### PR DESCRIPTION
## Description

Part 2 of 2 for #1399, stacked on #1407 (base branch `1399-tools-byok-keys`). Once #1407 merges this should retarget to `main`; if GitHub does not do that automatically when the part 1 branch is deleted, I'll do it by hand.

Wires every coded tool that talks to a provider directly to the resolver from part 1, so a client's `sly_data.llm_config` key (`openai_api_key`, `anthropic_api_key`, `google_api_key`) authenticates the call and the environment variable is only the fallback. This is the part that makes the issue's `openai_web_search` scenario work: on a BYOK deployment with no platform keys the front man succeeded on the user's key while `website_search` returned "Missing credentials".

Fixes #1399

### What changed

- **The five `OpenAITool` / `AnthropicTool` wrappers** (`openai_web_search`, `openai_code_interpreter`, `openai_image_generation`, `anthropic_web_search`, `anthropic_code_execution`) forward `sly_data` to `arun`.
- **`AnthropicCodeExecution.save_file`** takes the resolved key for the raw `Anthropic()` download client, which previously always read the env var.
- **`GeminiImageGeneration`** resolves `google_api_key` via `ByokApiKey` before building the client. Passing `None` still lets google.genai read `GEMINI_API_KEY`, so the documented alias keeps working.
- **`OpenAIVideoGeneration`**: the import-time `API_KEY` / `HEADERS` module constants are gone; headers are built per call (`build_headers`) and threaded through the four HTTP helpers.
- **`coded_tools/tools/video_describer.py`** uses `OpenAITool.get_api_key`.
- **Tests** (8 modules): every wrapper forwards `sly_data` and keeps its existing arguments; `save_file` gets the BYOK key or the env fallback; Gemini, video generation (headers reach create, poll, status and download, including the remix path and the no-key case) and the video describer. The video describer test stubs `cv2` when it is not installed so it runs in CI instead of skipping (opencv is not a declared dependency).
- **Default model references**: the wrapper docstrings, four tool docs and the HOCON `args` comments (including `registries/basic/coding_assistant.hocon`) now cite the part 1 defaults `gpt-5.2` / `claude-sonnet-5` instead of the old ones.
- **Docs**: BYOK note in the seven `docs/examples/tools/*.md` pages and the OpenAI/Anthropic sections of `docs/search_tools.md`; the HOCON "Requirement" comments in `registries/tools/*.hocon`, `registries/tools/manifest.hocon` and the toolbox descriptors mention the `sly_data` alternative (14 comment lines, no other HOCON change).

### Behavior notes

- Without a key in `sly_data` the tool falls back to the env var (documented; leave the variable unset on a BYOK-only server). On a developer box with platform env keys, a client that sends a key will now have tools bill that key, which is what the issue asks for.
- Passing `api_key=None` (neither source) is equivalent to today's behavior for all clients involved, verified against the pinned versions.

### Follow-ups (not in this PR)

- #1405: `BaseRag` / `agentic_rag` build `OpenAIEmbeddings` from the env only; reachable multi-user via `airline_policy_web_search`.
- #1406: persistent-memory `TopicSummarizer` builds `ChatOpenAI` from the env only.

## Impact

- BYOK deployments: the OpenAI/Anthropic/Gemini toolbox tools and video generation work with the user's key and bill the user, matching the agents.
- Non-BYOK deployments: unchanged; every tool falls back to the same env var as before.
- API surface: `AnthropicCodeExecution.save_file` and `GeminiImageGeneration.get_response` gain a required `api_key` parameter (internal callers updated). `coded_tools/tools/video_describer.py` now imports `neuro_san_studio.coded_tools.openai_tool` (three other top-level `coded_tools` modules already import `neuro_san_studio`).

## Screenshots / Logs / Examples (optional)

Verified in a neuro-san 0.7.0 parity env (the pins in `requirements.txt`), on this branch with part 1 included:

| Check | Result |
|---|---|
| New unit tests (8 modules) | 27 passed in 1.92s |
| `tests/neuro_san_studio/coded_tools` + `tests/coded_tools/tools` | 439 passed, 4 skipped, 27 subtests passed in 3.05s |
| `ruff format --check`, `ruff check`, `pylint` on the changed .py files | clean, 10.00/10 |
| pymarkdown on the 8 touched docs | same warning counts as `main` |
| The 7 edited registries load via `AgentNetworkRestorer` | ok |

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Dependency upgrade
- [ ] Refactoring / Improvement
- [x] Documentation
- [ ] New agent / tool

## Checklist

- [x] Tested locally
- [x] Added/updated tests
- [x] Updated relevant documentation
- [ ] Added dependencies to appropriate `requirements.txt` (no new dependencies)

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's [Apache 2.0 License](../LICENSE.txt).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
