### PR TITLE
PdfRag: sniff the %PDF- header before reading a local file in full

### DIFF
--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -31,6 +31,7 @@ from neuro_san.interfaces.coded_tool import CodedTool
 
 from neuro_san_studio.coded_tools.base_rag import BaseRag
 from neuro_san_studio.coded_tools.base_rag import PostgresConfig
+from neuro_san_studio.coded_tools.utils.pdf_utils import PDF_HEADER_WINDOW
 from neuro_san_studio.coded_tools.utils.pdf_utils import PdfUtils
 from neuro_san_studio.coded_tools.utils.safe_fetch import MAX_RESPONSE_BYTES
 from neuro_san_studio.coded_tools.utils.safe_fetch import SafeFetch
@@ -48,13 +49,16 @@ class PdfRag(CodedTool, BaseRag):
 
     Remote PDFs are downloaded through the shared SSRF-hardened fetch path
     (SafeFetch): private/loopback/reserved hosts are rejected, DNS records are
-    validated at connection time (anti DNS-rebinding), redirects are not followed,
-    and response sizes are capped. Local file paths (a documented input form for
-    this tool) are read directly from disk — SafeFetch governs network fetches
-    only — subject to the same byte cap as downloads. Items with any other URL
-    scheme (file://, s3://, ...) are skipped with a logged message. All PDFs are
-    parsed with pypdf via the shared PdfUtils helper, one Document per page so
-    page numbers survive into the vector store metadata.
+    validated at connection time (anti DNS-rebinding), redirects are subject to
+    SafeFetch's redirect policy, and response sizes are capped. Local file paths
+    (a documented input form for this tool) are read directly from disk — SafeFetch
+    governs network fetches only — subject to the same byte cap as downloads, and
+    are checked for a PDF header ("%PDF-" within the first PDF_HEADER_WINDOW bytes)
+    before being read in full, so a non-PDF that merely carries a .pdf name is
+    skipped early with a clear message. Items with any other URL scheme (file://,
+    s3://, ...) are skipped with a logged message. All PDFs are parsed with pypdf
+    via the shared PdfUtils helper, one Document per page so page numbers survive
+    into the vector store metadata.
     """
 
     async def async_invoke(self, args: dict[str, Any], sly_data: dict[str, Any]) -> str | list[dict[str, Any]]:
@@ -339,15 +343,31 @@ class PdfRag(CodedTool, BaseRag):
         :param path: The local filesystem path of the PDF.
         :return: The extracted text of each page, in page order.
         :raises OSError: When the file is missing or unreadable.
-        :raises ValueError: response_too_large when the file exceeds MAX_RESPONSE_BYTES.
+        :raises ValueError: not_a_pdf when no "%PDF-" header appears in the first
+            PDF_HEADER_WINDOW bytes; response_too_large when the file exceeds
+            MAX_RESPONSE_BYTES.
         """
-        # Apply the same byte cap the remote path enforces, as a bound on the read
-        # itself rather than an os.path.getsize() pre-check: a size probe is not a
-        # hard cap (special files such as /dev/zero report size 0, and a regular
-        # file can grow or be replaced between the probe and the read). Reading at
-        # most one byte past the cap is cheap and makes the limit unconditional.
         with open(path, "rb") as pdf_file:
-            data: bytes = pdf_file.read(MAX_RESPONSE_BYTES + 1)
+            # Sniff the header BEFORE reading the rest. Without this, a /dev/zero
+            # style special file, a large non-PDF, or an HTML error page saved as
+            # report.pdf is read in full (up to the 50 MB cap) only for pypdf to
+            # fail with "Stream has ended unexpectedly", which points nowhere near
+            # the real problem. Stopping after PDF_HEADER_WINDOW bytes costs one
+            # small read and produces an error that names the actual cause.
+            head: bytes = pdf_file.read(PDF_HEADER_WINDOW)
+            if not PdfUtils.has_pdf_header(head):
+                raise ValueError(f"not_a_pdf: '{path}' has no PDF header in its first {PDF_HEADER_WINDOW} bytes.")
+            # Apply the same byte cap the remote path enforces, as a bound on the
+            # read itself rather than an os.path.getsize() pre-check: a size probe
+            # is not a hard cap (special files such as /dev/zero report size 0, and
+            # a regular file can grow or be replaced between the probe and the
+            # read). Reading at most one byte past the cap is cheap and makes the
+            # limit unconditional. The head already consumed len(head) bytes of that
+            # budget, so the remainder read is shortened by the same amount; the
+            # max() guards against a negative length (which read() treats as "read
+            # everything") should the cap ever be set below the header window.
+            remaining: int = max(0, MAX_RESPONSE_BYTES + 1 - len(head))
+            data: bytes = head + pdf_file.read(remaining)
         if len(data) > MAX_RESPONSE_BYTES:
             raise ValueError(f"response_too_large: '{path}' exceeds the {MAX_RESPONSE_BYTES}-byte limit.")
         return PdfUtils.parse_pdf_bytes_per_page(data)

--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -342,35 +342,36 @@ class PdfRag(CodedTool, BaseRag):
 
         :param path: The local filesystem path of the PDF.
         :return: The extracted text of each page, in page order.
-        :raises OSError: When the file is missing or unreadable.
-        :raises ValueError: not_a_pdf when no "%PDF-" header appears in the first
-            PDF_HEADER_WINDOW bytes; response_too_large when the file exceeds
-            MAX_RESPONSE_BYTES.
+        :raises OSError: When the file is missing, unreadable, or not seekable (a FIFO, say).
+        :raises ValueError: not_a_pdf when no "%PDF-" header appears in the sniff
+            window (PDF_HEADER_WINDOW bytes, or MAX_RESPONSE_BYTES + 1 if smaller);
+            response_too_large when the file exceeds MAX_RESPONSE_BYTES.
         """
         with open(path, "rb") as pdf_file:
             # Sniff the header BEFORE reading the rest. Without this, a /dev/zero
             # style special file, a large non-PDF, or an HTML error page saved as
             # report.pdf is read in full (up to the 50 MB cap) only for pypdf to
             # fail with "Stream has ended unexpectedly", which points nowhere near
-            # the real problem. Stopping after PDF_HEADER_WINDOW bytes costs one
-            # small read and produces an error that names the actual cause. The
-            # sniff read is itself bounded by the byte budget applied below, so the
-            # cap holds even if it is ever set below the header window (the sniff
-            # then simply sees a shorter head).
-            head: bytes = pdf_file.read(min(PDF_HEADER_WINDOW, MAX_RESPONSE_BYTES + 1))
+            # the real problem. Stopping after the sniff window costs one small read
+            # and produces an error that names the actual cause. The window is
+            # bounded by the byte budget too, so the cap holds even if it is ever
+            # set below PDF_HEADER_WINDOW (the sniff then sees a shorter head, and
+            # the message reports the window that was actually inspected).
+            sniff_window: int = min(PDF_HEADER_WINDOW, MAX_RESPONSE_BYTES + 1)
+            head: bytes = pdf_file.read(sniff_window)
             if not PdfUtils.has_pdf_header(head):
-                raise ValueError(f"not_a_pdf: '{path}' has no PDF header in its first {PDF_HEADER_WINDOW} bytes.")
+                raise ValueError(f"not_a_pdf: '{path}' has no PDF header in its first {sniff_window} bytes.")
             # Apply the same byte cap the remote path enforces, as a bound on the
             # read itself rather than an os.path.getsize() pre-check: a size probe
             # is not a hard cap (special files such as /dev/zero report size 0, and
             # a regular file can grow or be replaced between the probe and the
             # read). Reading at most one byte past the cap is cheap and makes the
-            # limit unconditional. The head already consumed len(head) bytes of that
-            # budget, so the remainder read is shortened by the same amount; the
-            # head read was capped at the same budget, so this is never negative
-            # (a negative length would make read() read everything).
-            remaining: int = MAX_RESPONSE_BYTES + 1 - len(head)
-            data: bytes = head + pdf_file.read(remaining)
+            # limit unconditional. Rewinding and reading the whole file in one go,
+            # rather than concatenating the head with a remainder read, avoids
+            # holding the remainder twice (briefly up to 2 x the cap) during the
+            # concatenation; re-reading the sniffed kilobyte is negligible.
+            pdf_file.seek(0)
+            data: bytes = pdf_file.read(MAX_RESPONSE_BYTES + 1)
         if len(data) > MAX_RESPONSE_BYTES:
             raise ValueError(f"response_too_large: '{path}' exceeds the {MAX_RESPONSE_BYTES}-byte limit.")
         return PdfUtils.parse_pdf_bytes_per_page(data)

--- a/neuro_san_studio/coded_tools/pdf_rag.py
+++ b/neuro_san_studio/coded_tools/pdf_rag.py
@@ -353,8 +353,11 @@ class PdfRag(CodedTool, BaseRag):
             # report.pdf is read in full (up to the 50 MB cap) only for pypdf to
             # fail with "Stream has ended unexpectedly", which points nowhere near
             # the real problem. Stopping after PDF_HEADER_WINDOW bytes costs one
-            # small read and produces an error that names the actual cause.
-            head: bytes = pdf_file.read(PDF_HEADER_WINDOW)
+            # small read and produces an error that names the actual cause. The
+            # sniff read is itself bounded by the byte budget applied below, so the
+            # cap holds even if it is ever set below the header window (the sniff
+            # then simply sees a shorter head).
+            head: bytes = pdf_file.read(min(PDF_HEADER_WINDOW, MAX_RESPONSE_BYTES + 1))
             if not PdfUtils.has_pdf_header(head):
                 raise ValueError(f"not_a_pdf: '{path}' has no PDF header in its first {PDF_HEADER_WINDOW} bytes.")
             # Apply the same byte cap the remote path enforces, as a bound on the
@@ -364,9 +367,9 @@ class PdfRag(CodedTool, BaseRag):
             # read). Reading at most one byte past the cap is cheap and makes the
             # limit unconditional. The head already consumed len(head) bytes of that
             # budget, so the remainder read is shortened by the same amount; the
-            # max() guards against a negative length (which read() treats as "read
-            # everything") should the cap ever be set below the header window.
-            remaining: int = max(0, MAX_RESPONSE_BYTES + 1 - len(head))
+            # head read was capped at the same budget, so this is never negative
+            # (a negative length would make read() read everything).
+            remaining: int = MAX_RESPONSE_BYTES + 1 - len(head)
             data: bytes = head + pdf_file.read(remaining)
         if len(data) > MAX_RESPONSE_BYTES:
             raise ValueError(f"response_too_large: '{path}' exceeds the {MAX_RESPONSE_BYTES}-byte limit.")

--- a/neuro_san_studio/coded_tools/utils/pdf_utils.py
+++ b/neuro_san_studio/coded_tools/utils/pdf_utils.py
@@ -18,9 +18,33 @@ from io import BytesIO
 
 from pypdf import PdfReader
 
+# How many leading bytes has_pdf_header inspects for the "%PDF-" marker. Adobe's
+# PDF implementation notes allow the header to appear anywhere within the first
+# 1024 bytes of the file (not only at offset 0), and pypdf tolerates that leading
+# junk (it logs "invalid pdf header" and still parses the document). A strict
+# startswith(b"%PDF-") check would therefore reject files pypdf reads fine.
+PDF_HEADER_WINDOW: int = 1024
+
 
 class PdfUtils:
     """Shared helpers for extracting text from PDF documents."""
+
+    @staticmethod
+    def has_pdf_header(head: bytes) -> bool:
+        """
+        Report whether the leading bytes of a file carry a PDF header marker.
+
+        Cheap sanity check meant to run BEFORE a file is read in full or handed to
+        pypdf: it lets callers reject an HTML error page saved as report.pdf, a NUL
+        stream, or an empty file with a clear message instead of pypdf's
+        "Stream has ended unexpectedly". It is not proof of a valid PDF; pypdf
+        remains the authority on whether the bytes actually parse.
+
+        :param head: The leading bytes of the candidate file (at least
+            PDF_HEADER_WINDOW bytes when the file is that long; extra bytes are ignored).
+        :return: True when "%PDF-" occurs within the first PDF_HEADER_WINDOW bytes.
+        """
+        return b"%PDF-" in head[:PDF_HEADER_WINDOW]
 
     @staticmethod
     def parse_pdf_bytes(data: bytes) -> str:

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -29,14 +29,19 @@ from unittest.mock import patch
 from aiohttp import ClientError
 
 from neuro_san_studio.coded_tools.pdf_rag import PdfRag
+from neuro_san_studio.coded_tools.utils.pdf_utils import PDF_HEADER_WINDOW
 from neuro_san_studio.coded_tools.utils.pdf_utils import PdfUtils
 from neuro_san_studio.coded_tools.utils.safe_fetch import SafeFetch
 
 PDF_BYTES = b"%PDF-1.4 fake body"
+# A "PDF" longer than the header sniff window, so the local reader has to fetch it in
+# two pieces (head + remainder). Tests built on it pin the byte-budget arithmetic that
+# fixtures shorter than PDF_HEADER_WINDOW cannot observe.
+BIG_PDF_BYTES: bytes = PDF_BYTES + b"x" * (PDF_HEADER_WINDOW * 3)
 PAGE_TEXTS = ["Page one text", "Page two text"]
 
 
-class TestPdfRag(TestCase):
+class TestPdfRag(TestCase):  # pylint: disable=too-many-public-methods
     """Unit tests for PdfRag: SSRF-hardened remote loading, local paths, input guards."""
 
     def setUp(self):
@@ -65,6 +70,20 @@ class TestPdfRag(TestCase):
         session_cm.__aenter__ = AsyncMock(return_value=session)
         session_cm.__aexit__ = AsyncMock(return_value=False)
         return session_cm
+
+    @staticmethod
+    def _write_temp_pdf_file(content: bytes) -> str:
+        """
+        Write bytes to a fresh temp file carrying a .pdf suffix and return its path.
+
+        The caller is responsible for os.unlink() once the test is done with it.
+
+        :param content: The bytes to store in the file.
+        :return: The absolute path of the temp file.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as handle:
+            handle.write(content)
+            return handle.name
 
     @staticmethod
     async def _download_failing_bad_urls(url: str, _session: Any) -> bytes:
@@ -290,10 +309,12 @@ class TestPdfRag(TestCase):
         self.assertNotIn("unsupported URL scheme", "\n".join(logs.output))
 
     def test_oversized_local_file_is_skipped(self):
-        """A local file over the byte cap is skipped instead of being read into memory."""
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as handle:
-            handle.write(PDF_BYTES)
-            local_path = handle.name
+        """A local file over the byte cap is skipped instead of being read into memory.
+
+        The fixture starts with a real PDF header so the header sniff passes and the
+        size cap is the check that rejects it (the log must say response_too_large).
+        """
+        local_path: str = self._write_temp_pdf_file(PDF_BYTES)
         try:
             with (
                 patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
@@ -301,12 +322,155 @@ class TestPdfRag(TestCase):
                 patch("neuro_san_studio.coded_tools.pdf_rag.MAX_RESPONSE_BYTES", len(PDF_BYTES) - 1),
                 patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
             ):
-                docs = self._load([local_path])
+                with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="ERROR") as logs:
+                    docs = self._load([local_path])
         finally:
             os.unlink(local_path)
 
         self.assertEqual(docs, [])
         mock_parse.assert_not_called()
+        joined_logs: str = "\n".join(logs.output)
+        self.assertIn("response_too_large", joined_logs)
+        self.assertNotIn("not_a_pdf", joined_logs)
+
+    def test_non_pdf_local_file_is_skipped_before_parse(self) -> None:
+        """An HTML error page saved as *.pdf is skipped with a not_a_pdf message; pypdf never sees it.
+
+        Previously such a file was read in full and handed to pypdf, whose
+        "Stream has ended unexpectedly" pointed nowhere near the real problem.
+        """
+        local_path: str = self._write_temp_pdf_file(b"<html><body>404</body></html>")
+        try:
+            with (
+                patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
+                patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
+            ):
+                with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="ERROR") as logs:
+                    docs = self._load([local_path])
+        finally:
+            os.unlink(local_path)
+
+        self.assertEqual(docs, [])
+        mock_parse.assert_not_called()
+        joined_logs: str = "\n".join(logs.output)
+        self.assertIn("not_a_pdf", joined_logs)
+        self.assertIn(local_path, joined_logs)
+
+    def test_local_file_with_leading_junk_before_header_still_loads(self) -> None:
+        """Junk bytes ahead of the %PDF- marker (within the sniff window) do not cause a skip.
+
+        Adobe's implementation notes allow the header anywhere in the first 1024
+        bytes and pypdf parses such files, so the sniff must not be a strict prefix
+        check. The parser receives the FULL bytes, junk included; pypdf handles it.
+        """
+        junk_then_pdf: bytes = b"j" * 300 + PDF_BYTES
+        local_path: str = self._write_temp_pdf_file(junk_then_pdf)
+        try:
+            with (
+                patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
+                patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
+            ):
+                # A skip is reported via logger.error, so no ERROR record means no skip.
+                with self.assertNoLogs("neuro_san_studio.coded_tools.pdf_rag", level="ERROR"):
+                    docs = self._load([local_path])
+        finally:
+            os.unlink(local_path)
+
+        mock_parse.assert_called_once_with(junk_then_pdf)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].metadata["source"], local_path)
+
+    def test_header_check_runs_before_full_read(self) -> None:
+        """The header sniff rejects a non-PDF before the size cap is even reached.
+
+        With the cap shrunk below the file size, a size-check-first implementation
+        would report response_too_large; seeing not_a_pdf instead proves the sniff
+        runs before the size check. The fixture is longer than PDF_HEADER_WINDOW so
+        the head read alone cannot cover the file.
+        """
+        non_pdf: bytes = b"<html>" + b"x" * (PDF_HEADER_WINDOW * 2) + b"</html>"
+        local_path: str = self._write_temp_pdf_file(non_pdf)
+        try:
+            with (
+                patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
+                # Cap below THIS fixture's size: a full read would report response_too_large.
+                patch("neuro_san_studio.coded_tools.pdf_rag.MAX_RESPONSE_BYTES", len(non_pdf) - 1),
+                patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
+            ):
+                with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="ERROR") as logs:
+                    docs = self._load([local_path])
+        finally:
+            os.unlink(local_path)
+
+        self.assertEqual(docs, [])
+        mock_parse.assert_not_called()
+        joined_logs: str = "\n".join(logs.output)
+        self.assertIn("not_a_pdf", joined_logs)
+        self.assertNotIn("response_too_large", joined_logs)
+
+    def test_local_file_larger_than_header_window_reaches_parser_intact(self) -> None:
+        """A local PDF longer than the sniff window is handed to the parser whole, not truncated.
+
+        The reader fetches the head and the remainder separately; dropping or
+        mis-sizing the remainder read would silently truncate every real PDF to its
+        first PDF_HEADER_WINDOW bytes.
+        """
+        local_path: str = self._write_temp_pdf_file(BIG_PDF_BYTES)
+        try:
+            with (
+                patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
+                patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
+            ):
+                docs = self._load([local_path])
+        finally:
+            os.unlink(local_path)
+
+        mock_parse.assert_called_once_with(BIG_PDF_BYTES)
+        self.assertEqual(len(docs), 1)
+
+    def test_oversized_local_file_larger_than_header_window_is_skipped(self) -> None:
+        """A local PDF longer than the sniff window still trips the byte cap when it exceeds it.
+
+        The head already spent part of the byte budget, so the remainder read must be
+        shortened by exactly that amount for the cap to stay exact.
+        """
+        local_path: str = self._write_temp_pdf_file(BIG_PDF_BYTES)
+        try:
+            with (
+                patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
+                # One byte under the file size: exactly the smallest cap that must reject it.
+                patch("neuro_san_studio.coded_tools.pdf_rag.MAX_RESPONSE_BYTES", len(BIG_PDF_BYTES) - 1),
+                patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
+            ):
+                with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="ERROR") as logs:
+                    docs = self._load([local_path])
+        finally:
+            os.unlink(local_path)
+
+        self.assertEqual(docs, [])
+        mock_parse.assert_not_called()
+        self.assertIn("response_too_large", "\n".join(logs.output))
+
+    def test_local_file_exactly_at_cap_larger_than_header_window_loads(self) -> None:
+        """A local PDF whose size equals the cap is accepted whole (the limit is inclusive).
+
+        Together with the one-byte-over sibling this pins both sides of the boundary,
+        so an off-by-one in the remainder read cannot hide.
+        """
+        local_path: str = self._write_temp_pdf_file(BIG_PDF_BYTES)
+        try:
+            with (
+                patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
+                patch("neuro_san_studio.coded_tools.pdf_rag.MAX_RESPONSE_BYTES", len(BIG_PDF_BYTES)),
+                patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
+            ):
+                with self.assertNoLogs("neuro_san_studio.coded_tools.pdf_rag", level="ERROR"):
+                    docs = self._load([local_path])
+        finally:
+            os.unlink(local_path)
+
+        mock_parse.assert_called_once_with(BIG_PDF_BYTES)
+        self.assertEqual(len(docs), 1)
 
     def test_cancellation_closes_session_only_after_children_unwind(self):
         """Cancelling the load lets every in-flight item unwind before the session closes.

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -20,6 +20,7 @@ import asyncio
 import os
 import tempfile
 from functools import partial
+from io import BytesIO
 from typing import Any
 from unittest import TestCase
 from unittest.mock import AsyncMock
@@ -471,6 +472,54 @@ class TestPdfRag(TestCase):  # pylint: disable=too-many-public-methods
 
         mock_parse.assert_called_once_with(BIG_PDF_BYTES)
         self.assertEqual(len(docs), 1)
+
+    @staticmethod
+    def _read_recording_sizes(buffer: BytesIO, sizes: list[int], size: int) -> bytes:
+        """
+        Serve a read() from an in-memory buffer while recording how many bytes were requested.
+
+        Bound with functools.partial as the side_effect of a mocked file handle's read().
+
+        :param buffer: The in-memory file contents to read from.
+        :param sizes: The list that collects every requested read size, in call order.
+        :param size: The number of bytes the caller asked for.
+        :return: The bytes read from the buffer.
+        """
+        sizes.append(size)
+        return buffer.read(size)
+
+    def test_header_read_is_bounded_when_cap_is_below_header_window(self) -> None:
+        """With the cap below the sniff window the sniff read shrinks too: never more than cap + 1 bytes are read.
+
+        Reading PDF_HEADER_WINDOW bytes unconditionally would let a file consume up to
+        1024 bytes under a 100-byte cap before the size check ran. A mocked handle
+        records every requested size, and the buffer position shows what was consumed.
+        """
+        cap: int = 100
+        self.assertLess(cap, PDF_HEADER_WINDOW)
+        sizes: list[int] = []
+        buffer: BytesIO = BytesIO(BIG_PDF_BYTES)
+        handle: MagicMock = MagicMock()
+        handle.read.side_effect = partial(self._read_recording_sizes, buffer, sizes)
+        opener: MagicMock = MagicMock()
+        opener.return_value.__enter__.return_value = handle
+
+        with (
+            # pdf_rag.py calls the builtin open(); a module-level name shadows it for this test.
+            patch("neuro_san_studio.coded_tools.pdf_rag.open", opener, create=True),
+            patch("neuro_san_studio.coded_tools.pdf_rag.MAX_RESPONSE_BYTES", cap),
+            patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
+        ):
+            with self.assertRaises(ValueError) as raised:
+                PdfRag._read_local_pdf_pages("big.pdf")  # pylint: disable=protected-access
+
+        # The header sits inside the shortened head, so the size cap is what rejected the file...
+        self.assertIn("response_too_large", str(raised.exception))
+        self.assertEqual(sizes[0], cap + 1)
+        self.assertLessEqual(max(sizes), cap + 1)
+        # ...and exactly cap + 1 bytes were consumed: not the whole fixture, and not the full sniff window.
+        self.assertEqual(buffer.tell(), cap + 1)
+        mock_parse.assert_not_called()
 
     def test_cancellation_closes_session_only_after_children_unwind(self):
         """Cancelling the load lets every in-flight item unwind before the session closes.

--- a/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
+++ b/tests/neuro_san_studio/coded_tools/test_pdf_rag.py
@@ -35,9 +35,9 @@ from neuro_san_studio.coded_tools.utils.pdf_utils import PdfUtils
 from neuro_san_studio.coded_tools.utils.safe_fetch import SafeFetch
 
 PDF_BYTES = b"%PDF-1.4 fake body"
-# A "PDF" longer than the header sniff window, so the local reader has to fetch it in
-# two pieces (head + remainder). Tests built on it pin the byte-budget arithmetic that
-# fixtures shorter than PDF_HEADER_WINDOW cannot observe.
+# A "PDF" longer than the header sniff window, so the sniff alone cannot cover it and
+# the reader must rewind and re-read. Tests built on it pin that the parser gets the
+# whole file and that the cap stays exact, which shorter fixtures cannot observe.
 BIG_PDF_BYTES: bytes = PDF_BYTES + b"x" * (PDF_HEADER_WINDOW * 3)
 PAGE_TEXTS = ["Page one text", "Page two text"]
 
@@ -412,9 +412,8 @@ class TestPdfRag(TestCase):  # pylint: disable=too-many-public-methods
     def test_local_file_larger_than_header_window_reaches_parser_intact(self) -> None:
         """A local PDF longer than the sniff window is handed to the parser whole, not truncated.
 
-        The reader fetches the head and the remainder separately; dropping or
-        mis-sizing the remainder read would silently truncate every real PDF to its
-        first PDF_HEADER_WINDOW bytes.
+        The reader sniffs, rewinds, then reads in full; a forgotten rewind would hand
+        the parser a file missing its first PDF_HEADER_WINDOW bytes.
         """
         local_path: str = self._write_temp_pdf_file(BIG_PDF_BYTES)
         try:
@@ -432,8 +431,8 @@ class TestPdfRag(TestCase):  # pylint: disable=too-many-public-methods
     def test_oversized_local_file_larger_than_header_window_is_skipped(self) -> None:
         """A local PDF longer than the sniff window still trips the byte cap when it exceeds it.
 
-        The head already spent part of the byte budget, so the remainder read must be
-        shortened by exactly that amount for the cap to stay exact.
+        Without the rewind after the sniff, the bounded read would start past the
+        head and a file one byte over the cap would measure under it.
         """
         local_path: str = self._write_temp_pdf_file(BIG_PDF_BYTES)
         try:
@@ -456,7 +455,7 @@ class TestPdfRag(TestCase):  # pylint: disable=too-many-public-methods
         """A local PDF whose size equals the cap is accepted whole (the limit is inclusive).
 
         Together with the one-byte-over sibling this pins both sides of the boundary,
-        so an off-by-one in the remainder read cannot hide.
+        so an off-by-one in the bounded read cannot hide.
         """
         local_path: str = self._write_temp_pdf_file(BIG_PDF_BYTES)
         try:
@@ -489,7 +488,7 @@ class TestPdfRag(TestCase):  # pylint: disable=too-many-public-methods
         return buffer.read(size)
 
     def test_header_read_is_bounded_when_cap_is_below_header_window(self) -> None:
-        """With the cap below the sniff window the sniff read shrinks too: never more than cap + 1 bytes are read.
+        """With the cap below the sniff window the sniff read shrinks too: no read ever asks for more than cap + 1.
 
         Reading PDF_HEADER_WINDOW bytes unconditionally would let a file consume up to
         1024 bytes under a 100-byte cap before the size check ran. A mocked handle
@@ -501,6 +500,8 @@ class TestPdfRag(TestCase):  # pylint: disable=too-many-public-methods
         buffer: BytesIO = BytesIO(BIG_PDF_BYTES)
         handle: MagicMock = MagicMock()
         handle.read.side_effect = partial(self._read_recording_sizes, buffer, sizes)
+        # The reader rewinds after the sniff; route seek() to the buffer so the rewind is real.
+        handle.seek.side_effect = buffer.seek
         opener: MagicMock = MagicMock()
         opener.return_value.__enter__.return_value = handle
 
@@ -515,11 +516,37 @@ class TestPdfRag(TestCase):  # pylint: disable=too-many-public-methods
 
         # The header sits inside the shortened head, so the size cap is what rejected the file...
         self.assertIn("response_too_large", str(raised.exception))
-        self.assertEqual(sizes[0], cap + 1)
-        self.assertLessEqual(max(sizes), cap + 1)
-        # ...and exactly cap + 1 bytes were consumed: not the whole fixture, and not the full sniff window.
+        # ...both reads (the sniff, then the rewound full read) stayed within the budget...
+        self.assertEqual(sizes, [cap + 1, cap + 1])
+        # ...and only cap + 1 bytes were ever consumed: not the whole fixture, not the full sniff window.
         self.assertEqual(buffer.tell(), cap + 1)
         mock_parse.assert_not_called()
+
+    def test_not_a_pdf_message_names_the_window_actually_inspected(self) -> None:
+        """When the cap shortens the sniff window, the not_a_pdf message reports that shorter window, not 1024.
+
+        A marker past the shortened window but inside PDF_HEADER_WINDOW is (correctly)
+        not found; the message must not claim that all 1024 bytes were checked.
+        """
+        cap: int = 100
+        marker_past_window: bytes = b"j" * (cap + 1) + PDF_BYTES
+        local_path: str = self._write_temp_pdf_file(marker_past_window)
+        try:
+            with (
+                patch.object(SafeFetch, "open_session", return_value=self._make_session_cm()),
+                patch("neuro_san_studio.coded_tools.pdf_rag.MAX_RESPONSE_BYTES", cap),
+                patch.object(PdfUtils, "parse_pdf_bytes_per_page", return_value=["ok"]) as mock_parse,
+            ):
+                with self.assertLogs("neuro_san_studio.coded_tools.pdf_rag", level="ERROR") as logs:
+                    docs = self._load([local_path])
+        finally:
+            os.unlink(local_path)
+
+        self.assertEqual(docs, [])
+        mock_parse.assert_not_called()
+        joined_logs: str = "\n".join(logs.output)
+        self.assertIn(f"not_a_pdf: '{local_path}' has no PDF header in its first {cap + 1} bytes.", joined_logs)
+        self.assertNotIn(f"first {PDF_HEADER_WINDOW} bytes", joined_logs)
 
     def test_cancellation_closes_session_only_after_children_unwind(self):
         """Cancelling the load lets every in-flight item unwind before the session closes.

--- a/tests/neuro_san_studio/coded_tools/utils/test_pdf_utils.py
+++ b/tests/neuro_san_studio/coded_tools/utils/test_pdf_utils.py
@@ -14,15 +14,17 @@
 #
 # END COPYRIGHT
 
-"""Tests for PdfUtils.parse_pdf_bytes."""
+"""Tests for PdfUtils.parse_pdf_bytes and PdfUtils.has_pdf_header."""
 
 from io import BytesIO
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from pypdf import PdfWriter
 from pypdf.errors import PdfReadError
 
+from neuro_san_studio.coded_tools.utils.pdf_utils import PDF_HEADER_WINDOW
 from neuro_san_studio.coded_tools.utils.pdf_utils import PdfUtils
 
 # Patch the name in the module under test, not "pypdf.PdfReader".
@@ -63,6 +65,22 @@ class TestPdfUtils:
             c.drawString(72, 720, text)
             c.showPage()
         c.save()
+        return buf.getvalue()
+
+    @staticmethod
+    def _minimal_pdf() -> bytes:
+        """
+        Build the smallest well-formed PDF pypdf will open: one blank page, no fonts.
+
+        Unlike _build_pdf this needs no reportlab, so tests using it run in CI, where
+        reportlab is not installed; pypdf is already a hard dependency of the repo.
+
+        :return: The complete PDF file bytes.
+        """
+        writer = PdfWriter()
+        writer.add_blank_page(width=612, height=792)
+        buf = BytesIO()
+        writer.write(buf)
         return buf.getvalue()
 
     # --- mocked unit tests ------------------------------------------------ #
@@ -157,3 +175,48 @@ class TestPdfUtils:
 
         with pytest.raises((PdfReadError, Exception)):
             PdfUtils.parse_pdf_bytes(b"this is definitely not a pdf")
+
+    # --- has_pdf_header --------------------------------------------------- #
+    @pytest.mark.parametrize(
+        "head, expected",
+        [
+            # The common case: the file starts with the marker.
+            pytest.param(b"%PDF-1.7 fake body", True, id="header_at_offset_zero"),
+            # Junk before the marker is tolerated, as pypdf and Adobe's notes allow (first 1024 bytes).
+            pytest.param(b"j" * 500 + b"%PDF-1.4 body", True, id="leading_junk_within_window"),
+            # A marker first appearing at offset PDF_HEADER_WINDOW is outside the sniffed window.
+            pytest.param(b"j" * PDF_HEADER_WINDOW + b"%PDF-1.4 body", False, id="marker_at_window_boundary"),
+            pytest.param(b"j" * (PDF_HEADER_WINDOW + 300) + b"%PDF-1.4 body", False, id="marker_past_window"),
+            # The marker's last byte is the window's last byte: still fully inside, so True.
+            pytest.param(
+                b"j" * (PDF_HEADER_WINDOW - 5) + b"%PDF-1.4 body", True, id="marker_ends_exactly_at_window_end"
+            ),
+            # Only "%PD" falls inside the window, so the full marker is not present.
+            pytest.param(b"j" * (PDF_HEADER_WINDOW - 3) + b"%PDF-1.4 body", False, id="marker_straddles_boundary"),
+            pytest.param(b"", False, id="empty_bytes"),
+            # A /dev/zero-style NUL stream.
+            pytest.param(b"\x00" * PDF_HEADER_WINDOW, False, id="nul_bytes"),
+            # An HTML error page saved with a .pdf name.
+            pytest.param(b"<html><body><h1>404 Not Found</h1></body></html>", False, id="html_page"),
+        ],
+    )
+    def test_has_pdf_header(self, head: bytes, expected: bool) -> None:
+        """
+        The sniff accepts %PDF- anywhere in the first PDF_HEADER_WINDOW bytes and nothing else.
+
+        :param head: The leading bytes handed to the sniff.
+        :param expected: Whether the sniff must report a PDF header for those bytes.
+        """
+        assert PdfUtils.has_pdf_header(head) is expected
+
+    def test_has_pdf_header_true_for_real_pdf(self) -> None:
+        """A genuine PDF that real pypdf opens also passes the header sniff.
+
+        Uses the hand-built minimal PDF rather than reportlab so this runs in CI; the
+        pypdf parse first proves the fixture is a real PDF, not just header-shaped bytes.
+        """
+        data: bytes = self._minimal_pdf()
+        assert len(PdfUtils.parse_pdf_bytes_per_page(data)) == 1
+        assert PdfUtils.has_pdf_header(data) is True
+        # The sniff only needs the leading window, which is all the local reader hands it.
+        assert PdfUtils.has_pdf_header(data[:PDF_HEADER_WINDOW]) is True


### PR DESCRIPTION
## Description

Follow-up to #1400 (PdfRag on SafeFetch + pypdf). `PdfRag._read_local_pdf_pages` read a local file up to the 50 MB cap into memory before pypdf got to complain, so a wrong path such as `/dev/zero`, a large non-PDF, or an HTML error page saved as `report.pdf` was read in full only to fail with pypdf's `Stream has ended unexpectedly`, which points nowhere near the real problem. The reader now sniffs the first 1024 bytes for the `%PDF-` marker and skips the item with a `not_a_pdf` message naming the path before reading the rest.

Fixes #1403. The issue's optional item 3 (the remote-side sniff) is deferred, see below.

## What changed

- **`neuro_san_studio/coded_tools/utils/pdf_utils.py`**: new module constant `PDF_HEADER_WINDOW = 1024` and `PdfUtils.has_pdf_header(head: bytes) -> bool`, which is `b"%PDF-" in head[:1024]`. Deliberately not `startswith`: Adobe's implementation notes allow the header anywhere in the first 1024 bytes and pypdf parses such junk-prefixed files (it logs "invalid pdf header" and carries on), so a strict prefix check would reject files pypdf reads fine. The docstring says plainly that this is a cheap sanity check, not proof of a valid PDF; pypdf remains the authority.
- **`neuro_san_studio/coded_tools/pdf_rag.py`, `_read_local_pdf_pages`**: reads the sniff window, `min(PDF_HEADER_WINDOW, MAX_RESPONSE_BYTES + 1)` bytes, and raises `ValueError("not_a_pdf: ... in its first <window> bytes")` when the header is missing (the existing per-item skip-and-log path reports it, same as `response_too_large`). It then rewinds and reads the whole file in one read bounded at `MAX_RESPONSE_BYTES + 1`, so the byte cap is unchanged and still enforced on the read itself. Bounding the sniff by the same budget means the cap holds even if it is ever set below the header window (Copilot round 1); the message names the window actually inspected, and rewinding instead of concatenating head plus remainder avoids briefly holding the remainder twice (Copilot round 2).
- The class docstring describes the header check. It also now says redirects are "subject to SafeFetch's redirect policy" rather than "not followed", so it stays true whichever of this PR and #1369 (bounded redirect following) merges first.

## Behavior notes

- `/dev/zero` and `garbage.pdf` alike now stop after one 1 KB read and log `not_a_pdf: '<path>' has no PDF header in its first 1024 bytes.` instead of reading 50 MB and logging a pypdf stream error.
- A real PDF with junk ahead of the header (within 1024 bytes) still loads, and pypdf receives the full bytes, junk included.
- The header check runs before the size check, so a huge non-PDF reports `not_a_pdf`, not `response_too_large`.
- **Remote side deferred.** Sniffing in `download_pdf_bytes` / `fetch_pdf_text` touches `safe_fetch.py`, which #1369 is rewriting for redirect following. I left it out to avoid a conflict; it can be its own small ticket once #1369 lands.
- `endswith(".pdf")` on the local path was considered and rejected in the issue: it checks the name rather than the content.

## Validation

- `tests/neuro_san_studio/coded_tools/utils/test_pdf_utils.py`: parametrized `test_has_pdf_header` (marker at offset 0, junk within the window, marker at and past the window boundary, marker ending exactly on the last window byte, marker straddling the boundary, empty input, NUL stream, HTML page) plus `test_has_pdf_header_true_for_real_pdf`, which builds a one-page PDF with `pypdf.PdfWriter` (no reportlab, so it runs in CI) and proves pypdf parses it before checking the sniff.
- `tests/neuro_san_studio/coded_tools/test_pdf_rag.py`: HTML saved as `.pdf` is skipped with `not_a_pdf` and pypdf is never called; a junk-prefixed PDF loads with the full bytes passed to the parser; the header check runs before the size check (cap shrunk below the file size, yet `not_a_pdf` is what appears); and three tests on a fixture longer than the sniff window pin the rewind and the cap: it reaches the parser intact, one byte over the cap is skipped, exactly at the cap loads. The existing oversized-file test now also asserts it was the size cap, not the sniff, that rejected it.
- `python -m pytest tests/neuro_san_studio/coded_tools`: 382 passed, 3 skipped. `ruff format --check`, `ruff check`, `pylint` on the four files: clean, 10.00/10 (neuro-san 0.7.0 CI-parity venv).
- Copilot rounds 1 and 2: `test_header_read_is_bounded_when_cap_is_below_header_window` mocks the file handle under a 100-byte cap and checks that both reads (the sniff, then the rewound full read) ask for 101 bytes and only 101 are consumed; `test_not_a_pdf_message_names_the_window_actually_inspected` checks the message says `first 101 bytes` under that cap. Each fails on the commit before its fix.
- Manual check: `PdfRag._read_local_pdf_pages("/dev/zero")` raises `not_a_pdf: '/dev/zero' has no PDF header in its first 1024 bytes.` in 0.0001 s; on `main` the same call reads 50 MB first and reports `response_too_large`.
